### PR TITLE
Decide: Reconciliation approach — custom loop + PostgreSQL

### DIFF
--- a/architecture/control-data-plane.md
+++ b/architecture/control-data-plane.md
@@ -55,11 +55,26 @@ graph LR
 
 ## Reconciliation
 
-The control plane should implement a reconciliation loop that continuously converges actual state toward desired state.
+The control plane implements reconciliation loops that continuously converge actual state toward desired state.
 
-Key resources to reconcile:
+**Approach:** Custom polling loops with PostgreSQL as the source of truth. No CRDs.
+
+**Pattern:**
+
+```mermaid
+graph LR
+    PG[(PostgreSQL<br/>desired state)] --> Loop[Reconciliation Loop<br/>compare & act]
+    Runner[Runner gRPC<br/>actual state] --> Loop
+    Loop -->|start/stop workloads| Runner
+    Lease[K8s Lease<br/>leader election] -.-> Loop
+```
+
+- Each control plane service runs a polling loop on a timer.
+- Reads desired state from PostgreSQL, compares with actual state via Runner gRPC, takes corrective action.
+- Leader election via Kubernetes Lease — deploy with 2+ replicas, only the leader runs the loop.
+- Optional: subscribe to Notifications events for faster reactivity; the polling loop serves as consistency fallback.
+
+**Resources to reconcile:**
 - **Agents** — Ensure agent workloads exist for threads with pending messages; remove idle agents.
 - **Channels** — Ensure channel connections match their configuration (reconnect on credential rotation).
 - **Workspaces** — Ensure workspace containers match desired image/config; enforce TTL.
-
-The reconciliation approach (CRDs + operators vs. custom loop) is an [open question](../open-questions.md#reconciliation-approach).

--- a/open-questions.md
+++ b/open-questions.md
@@ -4,24 +4,6 @@ Unresolved architectural decisions requiring discussion.
 
 ---
 
-## Reconciliation Approach
-
-**Context:** The platform is migrating to become k8s-native. A reconciliation loop is needed to converge actual state toward desired state for dynamic resources (agents, channels, workspaces).
-
-**Options:**
-
-1. **CRDs + Operators** — Resources as Kubernetes Custom Resource Definitions, reconciled by operators.
-   - *Pros:* Native k8s tooling (kubectl, RBAC, etcd, watch semantics). Ecosystem compatibility.
-   - *Cons:* Couples resource model to k8s API. CRD schema evolution complexity. Requires operator expertise. Harder outside k8s.
-
-2. **Custom reconciliation loop** — Application-level loop reading desired state from PostgreSQL/Redis.
-   - *Pros:* Portable (works outside k8s). Full control. Simpler to test.
-   - *Cons:* Must reimplement watch/notification, leader election, consistency guarantees.
-
-**Decision:** TBD — Needs dedicated discussion.
-
----
-
 ## Agent Protocol
 
 **Context:** Most 3rd-party agents are CLI-based. The platform needs a protocol to communicate with agent processes in containers — providing configuration, connecting MCP tools, and collecting output.


### PR DESCRIPTION
## Decision

**Custom reconciliation loops with PostgreSQL as source of truth. No CRDs.**

### Rationale

- Users interact via web UI and Gateway, not `kubectl` — CRDs would be invisible infrastructure with no user benefit
- PostgreSQL gives simpler schema evolution (SQL migrations vs CRD conversion webhooks), full SQL query capability, and trivial test setup
- Kubernetes Leases provide leader election without CRDs
- Notifications service provides reactivity without CRD watch semantics
- CRD projection can be added later as an additive feature if DevOps/GitOps demand arises

### Implementation Pattern

- Each control plane service runs a polling loop on a timer (~5s)
- Reads desired state from PostgreSQL, compares with actual state via Runner gRPC, takes corrective action
- Leader election via Kubernetes Lease — deploy with 2+ replicas, only the leader runs the loop
- Optional: subscribe to Notifications events for faster reactivity; polling loop as consistency fallback

## Changes

- **`open-questions.md`** — Moved Reconciliation Approach from open questions to a new **Decided** section at the bottom, with full rationale and implementation notes
- **`architecture/control-data-plane.md`** — Replaced open question reference with the decided approach; added Mermaid diagram showing the reconciliation pattern (PostgreSQL → loop → Runner, with K8s Lease for leader election)