### PR TITLE
Decide: Agent protocol — pull + notifications

### DIFF
--- a/architecture/agent/overview.md
+++ b/architecture/agent/overview.md
@@ -20,22 +20,66 @@ graph TB
 
     subgraph Platform
         Threads
+        Notifications
         Tracing
     end
 
     Impl -->|read messages| Threads
     Impl -->|post responses| Threads
+    Impl -->|subscribe| Notifications
     Impl -.->|optional| Tracing
 ```
 
 | Responsibility | Description |
 |---------------|-------------|
-| **Read messages** | Consume pending messages from the assigned thread |
+| **Read messages** | Pull pending messages from the assigned thread via Threads API |
 | **Process** | Run implementation-specific logic (LLM calls, tool use, etc.) |
-| **Post responses** | Write response messages back to the thread |
+| **Post responses** | Write response messages back to the thread via Threads API |
+| **Subscribe to notifications** | Listen for new-message events to react without polling delay |
 | **Use tools via MCP** | Connect to MCP servers for tool access |
 | **Report tracing** | Optionally emit tracing data |
-| **Signal completion** | Indicate when processing is done (idle) |
+
+The agent is a **pure client** — it makes outbound connections to platform services. It does not expose any server or accept inbound connections.
+
+## Communication Protocol
+
+The agent uses a **pull strategy combined with notifications** to receive messages.
+
+### How It Works
+
+```mermaid
+sequenceDiagram
+    participant N as Notifications
+    participant A as Agent
+    participant T as Threads
+
+    Note over A: Startup
+    A->>N: Subscribe to thread room
+    A->>T: GetMessages (unread)
+    A->>A: Process messages
+
+    Note over A: Mid-run: new message arrives
+    N-->>A: message.created event
+    A->>T: GetMessages (unread)
+    A->>A: Process new messages
+
+    Note over A: Idle: no messages
+    A->>A: Wait for notification or poll interval
+    N-->>A: message.created event
+    A->>T: GetMessages (unread)
+    A->>A: Process messages
+```
+
+1. On startup, the agent subscribes to notifications for its thread and pulls pending messages from the Threads API.
+2. During processing, new messages may arrive. The Notifications service delivers a `message.created` event instantly, waking the agent to check for new messages at the appropriate point in its processing loop.
+3. When idle (current turn complete, no pending messages), the agent waits for either a notification or the poll interval to expire, then checks again.
+4. The polling loop is a **fallback** — it catches anything missed during notification gaps (reconnects, race conditions). The poll interval can be long (10s, 30s) since notifications handle the latency-sensitive path.
+
+### Design Principles
+
+- **Notifications are signals, not data.** The notification tells the agent "something happened on your thread." The agent always reads the actual messages from the Threads API. This keeps the Threads API as the single source of truth.
+- **Pull at defined loop stages.** The `whenBusy` configuration controls when mid-run messages are picked up: between turns (`wait`) or between tool calls (`injectAfterTools`). The notification wakes the agent, but the actual message read happens at the next check point in the LLM loop.
+- **No inbound connections.** The agent connects outbound to Notifications (gRPC subscribe stream) and Threads (gRPC calls). No server, no open port, no service discovery per agent.
 
 ## Tools
 
@@ -60,23 +104,31 @@ sequenceDiagram
     participant CLI as Agent CLI
     participant MCP as MCP Servers
     participant T as Threads
+    participant N as Notifications
 
+    W->>N: Subscribe to thread room
     W->>CLI: Start process with config
     W->>MCP: Start MCP servers
     W->>CLI: Connect MCP servers
+    W->>T: GetMessages (unread)
+    W->>CLI: Feed messages
     CLI->>MCP: Tool calls
     MCP-->>CLI: Tool results
     CLI-->>W: Output
     W->>T: Post response to thread
+    Note over W: Wait for notification or poll
+    N-->>W: message.created
+    W->>T: GetMessages (unread)
+    W->>CLI: Feed new messages
 ```
 
 The wrapper:
-1. Starts the agent CLI process.
-2. Provides configuration (model, system prompt, etc.).
+1. Subscribes to notifications for the assigned thread.
+2. Starts the agent CLI process with configuration.
 3. Connects MCP tool servers to the agent.
-4. Collects output and routes it back to the thread.
-
-The communication protocol between the wrapper and the agent process is [to be defined](../../open-questions.md#agent-protocol).
+4. Pulls messages from Threads and feeds them to the CLI.
+5. Collects CLI output and posts responses to the thread.
+6. Waits for notifications or poll fallback for new messages.
 
 ## Lifecycle
 
@@ -87,20 +139,30 @@ sequenceDiagram
     participant R as Runner
     participant A as Agent Container
 
-    T->>O: Pending message detected
-    O->>R: Start agent workload
+    T->>O: Pending message (reconciliation loop)
+    O->>R: StartWorkload
     R->>A: Create container
-    A->>A: Process messages
+    A->>A: Subscribe, pull, process
     A->>T: Post response
-    A->>O: Idle
-    O->>R: Stop workload
+
+    Note over A,O: Agent idle, waiting for messages
+    O->>O: Activity check (reconciliation loop)
+    Note over O: Idle timeout exceeded
+    O->>R: StopWorkload
 ```
 
-1. Threads service has pending (unread-by-agent) messages.
-2. Agents orchestrator detects this and requests Runner to start an agent workload.
+1. The orchestrator's reconciliation loop detects threads with pending messages.
+2. Orchestrator requests Runner to start an agent workload with thread ID and agent config.
 3. Runner creates a container with the agent image, MCP sidecars, and configuration.
-4. Agent processes messages, posts responses back to the thread.
-5. Agent signals idle. Orchestrator requests Runner to stop the workload.
+4. Agent subscribes to notifications, pulls messages, processes, posts responses.
+5. Agent waits for new messages (notification or poll fallback).
+6. The orchestrator monitors agent activity. When idle timeout is exceeded, it stops the workload via Runner.
+
+### Idle Timeout
+
+The **orchestrator** owns idle timeout enforcement. During each reconciliation pass, it checks running agent workloads against their last activity (last message on the thread). Agents that have been idle beyond the configured timeout are stopped via `Runner.StopWorkload`.
+
+The agent container does not implement idle detection. It may exit naturally (process completion, crash), but the orchestrator is the authority for lifecycle management.
 
 ### Scaling
 

--- a/gaps/migration-roadmap.md
+++ b/gaps/migration-roadmap.md
@@ -56,7 +56,7 @@ Extract the agent from `platform-server` into a standalone container:
 - **Move**: `packages/llm/` (Loop, Reducer, Router, FunctionTool, messages) and agent node logic from `packages/platform-server/src/nodes/agent/`.
 - **Connect**: Agent State service (remote gRPC) for state persistence.
 - **Connect**: MCP servers for tools.
-- **Define**: Agent container interface and wrapper for 3rd-party CLI agents. See [open question](../open-questions.md#agent-protocol).
+- **Implement**: Pull + notifications communication protocol and CLI wrapper. See [agent overview](../architecture/agent/overview.md#communication-protocol).
 
 ### Threads Extraction
 

--- a/open-questions.md
+++ b/open-questions.md
@@ -4,24 +4,6 @@ Unresolved architectural decisions requiring discussion.
 
 ---
 
-## Agent Protocol
-
-**Context:** Most 3rd-party agents are CLI-based. The platform needs a protocol to communicate with agent processes in containers — providing configuration, connecting MCP tools, and collecting output.
-
-**Options:**
-
-1. **Push (gRPC)** — Platform pushes messages/config to the agent. Agent exposes a gRPC server.
-   - *Pros:* Immediate delivery. Platform controls flow.
-   - *Cons:* Agent must implement a gRPC server. Harder for simple CLI wrappers.
-
-2. **Pull** — Agent pulls pending work from the platform. No exposed methods on agent side.
-   - *Pros:* Simpler agent implementation. Agent controls pace.
-   - *Cons:* Latency (polling). Platform needs a queue/inbox per agent.
-
-**Decision:** TBD
-
----
-
 ## Agent Batching Protocol
 
 **Context:** Simple case is one container per agent invocation. For specific agents, a single instance processing multiple threads may be more efficient.


### PR DESCRIPTION
## Decision

**Pull strategy combined with notifications. Agent is a pure client.**

### Communication Protocol

1. On startup, the agent subscribes to Notifications for its thread and pulls pending messages from the Threads API.
2. During processing, `message.created` notifications wake the agent to check for new messages at the next check point in the LLM loop (`whenBusy` controls timing).
3. When idle, the agent waits for a notification or poll interval — whichever comes first.
4. Polling loop is a fallback (long interval, 10-30s). Notifications handle the latency-sensitive path.

### Design Principles

- **Notifications are signals, not data.** Agent always reads actual messages from Threads API.
- **Pull at defined loop stages.** `whenBusy` config controls when mid-run messages are picked up.
- **No inbound connections.** Agent connects outbound to Notifications (gRPC stream) and Threads (gRPC calls). No server, no service discovery per agent.

### Idle Timeout

Owned by the **orchestrator**, not the agent. Reconciliation loop checks running workloads against last thread activity. Agents exceeding idle timeout are stopped via `Runner.StopWorkload`. Agent container does not implement idle detection.

## Changes

- **`architecture/agent/overview.md`** — Added Communication Protocol section with sequence diagram. Updated agent contract (added Notifications). Updated wrapper model to show pull + notifications flow. Updated lifecycle with orchestrator-owned idle timeout. Removed "Signal completion" from contract (orchestrator handles this).
- **`open-questions.md`** — Removed Agent Protocol question (6 remaining).
- **`gaps/migration-roadmap.md`** — Updated agent extraction step to reference the decided protocol.