### PR TITLE
docs: align files service with gRPC

### DIFF
--- a/architecture/agent/overview.md
+++ b/architecture/agent/overview.md
@@ -21,11 +21,13 @@ graph TB
     subgraph Platform
         Threads
         Notifications
+        Files
         Tracing
     end
 
     Impl -->|read messages| Threads
     Impl -->|post responses| Threads
+    Impl -->|resolve files| Files
     Impl -->|subscribe| Notifications
     Impl -.->|optional| Tracing
 ```
@@ -33,6 +35,7 @@ graph TB
 | Responsibility | Description |
 |---------------|-------------|
 | **Read messages** | Pull pending messages from the assigned thread via Threads API |
+| **Resolve file URLs** | Request pre-signed download URLs for file references via Files API |
 | **Process** | Run implementation-specific logic (LLM calls, tool use, etc.) |
 | **Post responses** | Write response messages back to the thread via Threads API |
 | **Subscribe to notifications** | Listen for new-message events to react without polling delay |
@@ -79,7 +82,7 @@ sequenceDiagram
 
 - **Notifications are signals, not data.** The notification tells the agent "something happened on your thread." The agent always reads the actual messages from the Threads API. This keeps the Threads API as the single source of truth.
 - **Pull at defined loop stages.** The `whenBusy` configuration controls when mid-run messages are picked up: between turns (`wait`) or between tool calls (`injectAfterTools`). The notification wakes the agent, but the actual message read happens at the next check point in the LLM loop.
-- **No inbound connections.** The agent connects outbound to Notifications (gRPC subscribe stream) and Threads (gRPC calls). No server, no open port, no service discovery per agent.
+- **No inbound connections.** The agent connects outbound to Notifications (gRPC subscribe stream), Threads (gRPC calls), and Files (gRPC calls). No server, no open port, no service discovery per agent.
 
 ## Tools
 

--- a/architecture/api-contracts.md
+++ b/architecture/api-contracts.md
@@ -22,6 +22,7 @@ Services **do not** commit generated schema code in their own repositories. They
 |---------|-----------|
 | Runner | `agynio/api/runner/v1/runner.proto` |
 | Notifications | `agynio/api/notifications/v1/notifications.proto` |
+| Files | `agynio/api/files/v1/files.proto` |
 | Agent State | `agynio/api/agent_state/v1/agent_state.proto` |
 
 ### Conventions

--- a/architecture/gateway.md
+++ b/architecture/gateway.md
@@ -8,6 +8,7 @@ The Gateway exposes platform methods for external usage. It is the single entry 
 
 - Route external API requests to internal services.
 - Translate between external (OpenAPI/REST) and internal protocols.
+- Stream multipart file uploads to FilesService.UploadFile (client-streaming gRPC).
 - Validate requests and responses against OpenAPI specs.
 - Handle authentication at the boundary.
 

--- a/architecture/media.md
+++ b/architecture/media.md
@@ -10,30 +10,30 @@ Users can attach files to messages in thread conversations. Media files are stor
 sequenceDiagram
     participant C as Client
     participant GW as Gateway
-    participant F as Files
+    participant F as Files (gRPC)
     participant OS as Object Storage
-    participant Th as Threads
+    participant Th as Threads (gRPC)
     participant Ag as Agent
     participant LLM as LLM Provider
 
-    C->>GW: Upload file (multipart)
-    GW->>F: Store file
+    C->>GW: Upload file (multipart REST)
+    GW->>F: UploadFile (client-streaming gRPC)
     F->>OS: PUT object
-    F-->>GW: File reference {id, filename, contentType, sizeBytes}
-    GW-->>C: File reference
+    F-->>GW: UploadFileResponse {id, filename, content_type, size_bytes}
+    GW-->>C: File reference (REST)
 
     C->>GW: SendMessage {text, files: [{id}]}
-    GW->>Th: Store message with file IDs
+    GW->>Th: SendMessage (gRPC)
     Th-->>GW: Message stored
 
     Note over Ag: Agent picks up message
-    Ag->>Th: GetMessages
+    Ag->>Th: GetMessages (gRPC)
     Th-->>Ag: Messages with file IDs
-    Ag->>F: Resolve file IDs → pre-signed URLs
+    Ag->>F: GetDownloadUrl (gRPC)
     F-->>Ag: Pre-signed download URLs
     Ag->>LLM: File URLs as part of conversation context
     LLM-->>Ag: Response
-    Ag->>Th: Post response
+    Ag->>Th: SendMessage (gRPC)
 ```
 
 ## Files Service
@@ -45,7 +45,7 @@ A dedicated service responsible for file upload, metadata storage, and download 
 | Responsibility | Description |
 |---------------|-------------|
 | **Upload** | Accept file content, store in object storage, persist metadata |
-| **Metadata** | Store and serve file metadata (filename, contentType, sizeBytes) |
+| **Metadata** | Store and serve file metadata (filename, content_type, size_bytes) |
 | **Download URLs** | Generate pre-signed URLs for file access on demand |
 
 ### File Record
@@ -54,8 +54,8 @@ A dedicated service responsible for file upload, metadata storage, and download 
 |-------|------|-------------|
 | `id` | string (UUID) | Unique file identifier |
 | `filename` | string | Original filename |
-| `contentType` | string | MIME type |
-| `sizeBytes` | integer | File size in bytes |
+| `content_type` | string | MIME type |
+| `size_bytes` | integer | File size in bytes |
 | `created_at` | timestamp | Upload time |
 
 ### Classification
@@ -98,61 +98,94 @@ Pre-signed URL expiration should be long enough for LLM provider processing (rec
 
 ## API
 
-### Upload
+### Proto Definition
 
-```
-POST /files
-Content-Type: multipart/form-data
-```
+```protobuf
+syntax = "proto3";
 
-| Field | Type | Description |
-|-------|------|-------------|
-| `file` | binary | File content (multipart) |
+package agynio.api.files.v1;
 
-**Response** (`201 Created`):
+import "google/protobuf/timestamp.proto";
 
-| Field | Type | Description |
-|-------|------|-------------|
-| `id` | string (UUID) | File identifier |
-| `filename` | string | Original filename |
-| `contentType` | string | MIME type |
-| `sizeBytes` | integer | File size in bytes |
+option go_package = "github.com/agynio/api/gen/agynio/api/files/v1;filesv1";
 
-### Get Download URL
-
-```
-GET /files/{fileId}/url
+service FilesService {
+  // Client-side streaming upload. First message = metadata, subsequent = chunks.
+  rpc UploadFile(stream UploadFileRequest) returns (UploadFileResponse);
+  rpc GetDownloadUrl(GetDownloadUrlRequest) returns (GetDownloadUrlResponse);
+  rpc GetFileMetadata(GetFileMetadataRequest) returns (GetFileMetadataResponse);
+}
 ```
 
-**Response** (`200 OK`):
+### Messages
 
-| Field | Type | Description |
-|-------|------|-------------|
-| `url` | string | Pre-signed download URL |
-| `expiresAt` | timestamp | URL expiration time |
+```protobuf
+message UploadFileRequest {
+  oneof payload {
+    UploadFileMetadata metadata = 1;  // MUST be first message
+    bytes chunk_data = 2;             // Subsequent messages
+  }
+}
 
-### Get File Metadata
+message UploadFileMetadata {
+  string filename = 1;
+  string content_type = 2;
+}
 
+message UploadFileResponse {
+  string id = 1;
+  string filename = 2;
+  string content_type = 3;
+  int64 size_bytes = 4;
+}
+
+message GetDownloadUrlRequest {
+  string file_id = 1;
+}
+
+message GetDownloadUrlResponse {
+  string url = 1;
+  google.protobuf.Timestamp expires_at = 2;
+}
+
+message GetFileMetadataRequest {
+  string file_id = 1;
+}
+
+message GetFileMetadataResponse {
+  string id = 1;
+  string filename = 2;
+  string content_type = 3;
+  int64 size_bytes = 4;
+  google.protobuf.Timestamp created_at = 5;
+}
 ```
-GET /files/{fileId}
-```
 
-**Response** (`200 OK`):
+### Upload Streaming Protocol
 
-| Field | Type | Description |
-|-------|------|-------------|
-| `id` | string (UUID) | File identifier |
-| `filename` | string | Original filename |
-| `contentType` | string | MIME type |
-| `sizeBytes` | integer | File size in bytes |
-| `created_at` | timestamp | Upload time |
+1. **Message 1 (metadata):** `UploadFileRequest.metadata` with `filename` and `content_type`.
+2. **Messages 2..N (chunks):** `UploadFileRequest.chunk_data` (recommended 64 KiB chunks).
+3. **Stream close:** Client closes send side. Server computes `size_bytes`, writes to object storage, persists metadata, returns `UploadFileResponse`.
 
-### Constraints
+**Error codes:**
 
-| Constraint | Value |
-|------------|-------|
-| Max file size | TBD (recommended: 20 MB) |
-| Allowed MIME types | TBD (at minimum: images, PDFs, text files, common documents) |
+| Condition | gRPC Status Code |
+|---|---|
+| First message missing metadata | `INVALID_ARGUMENT` |
+| Disallowed MIME type | `INVALID_ARGUMENT` |
+| File exceeds max size | `RESOURCE_EXHAUSTED` |
+| File not found (Get/Download RPCs) | `NOT_FOUND` |
+| Object storage write failure | `INTERNAL` |
+
+### Gateway Translation (External REST → Internal gRPC)
+
+The Gateway receives `POST /files` (multipart/form-data) from external clients and translates to the `UploadFile` client-streaming gRPC call:
+
+1. Parse multipart form, extract `filename`, `content_type`, body stream.
+2. Open `UploadFile` stream, send metadata message first.
+3. Read file body in 64 KiB chunks, stream as `chunk_data` messages (no full-file buffering).
+4. Close stream, await response, translate to HTTP 201 JSON response.
+5. Map gRPC errors → HTTP: `INVALID_ARGUMENT` → 400, `RESOURCE_EXHAUSTED` → 413, `INTERNAL` → 502.
 
 ## Threads Integration
 

--- a/architecture/threads.md
+++ b/architecture/threads.md
@@ -43,7 +43,7 @@ Threads is the messaging service for conversations between participants. A singl
 | `thread_id` | string (UUID) | Parent thread |
 | `sender_id` | string (UUID) | Participant who sent the message |
 | `body` | string | Text content |
-| `files` | list of string (UUID) | Referenced file IDs (may be empty). See [Media](media.md) |
+| `files` | list of string (UUID) | Referenced file IDs (may be empty). See [Media API](media.md#api) |
 | `tokens` | integer | Token count for this message. Computed once at creation via [Token Counting](token-counting.md) |
 | `read_status` | map | Per-participant read status |
 | `created_at` | timestamp | When the message was sent |

--- a/gaps/migration-roadmap.md
+++ b/gaps/migration-roadmap.md
@@ -24,6 +24,7 @@ graph LR
         S9[Agents orchestrator]
         S10[Tracing service]
         S11[k8s-runner]
+        S12[Files service]
     end
 
     S1 --> S5
@@ -33,6 +34,7 @@ graph LR
 
     S5 --> S6 --> S7
     S7 --> S8 --> S9
+    S7 --> S12
     S9 --> S10 & S11
 ```
 
@@ -98,6 +100,14 @@ New service replacing the removed tracing stack:
 
 - Extended OpenTelemetry protocol for real-time in-progress events.
 - Ingestion and query APIs.
+
+### Files Service
+
+New data plane service for file attachments:
+
+- gRPC API for upload, metadata, and download URLs.
+- Object storage integration with metadata persistence.
+- Gateway streams multipart uploads to the gRPC client-streaming API.
 
 ### k8s-runner
 


### PR DESCRIPTION
## Summary
- replace the Files API documentation with the gRPC proto, streaming protocol, errors, and updated lifecycle diagram
- add Files service references across API contracts, gateway, agent contract, threads, and migration roadmap
- document the gateway multipart upload translation to gRPC streaming

## Testing
- Not run (docs-only change; no tests/lint configured)

Refs #11