### PR TITLE
docs: document dual api paths

### DIFF
--- a/architecture/gateway.md
+++ b/architecture/gateway.md
@@ -2,7 +2,16 @@
 
 ## Overview
 
-The Gateway exposes platform methods for external usage. It is the single entry point for external clients (web app, mobile app, integrators) to interact with the platform.
+The Gateway exposes platform methods for external usage. It is the entry point for external clients (web app, mobile app, integrators) to interact with new platform services.
+
+The gateway is accessible via two ingress paths:
+
+| Path | Host | Prefix stripped | Use case |
+|------|------|-----------------|----------|
+| Subdomain | `gateway.agyn.dev` | No | Direct access, service-to-service |
+| Path-based | `agyn.dev/apiv2/` | Yes (`/apiv2/` → `/`) | UI consumption (same origin as the web app) |
+
+The path-based route allows the web app (platform-ui) to call new gateway-backed APIs without cross-origin requests. Legacy monolith APIs remain at `/api` on the same domain.
 
 ## Responsibilities
 
@@ -23,3 +32,12 @@ The gateway (`agynio/gateway`, Go) currently:
 - Uses `oapi-codegen` for server stub generation from the OpenAPI spec.
 - Proxies remaining routes (`/api/*`, `/health`) to the upstream platform-server.
 - Applies CORS, request ID, and recovery middleware.
+
+### Ingress Routing
+
+The gateway receives traffic through two Istio VirtualService routes (defined in `agynio/bootstrap_v2`, `stacks/platform/main.tf`):
+
+1. **Subdomain route** (`virtualservice_gateway`): `gateway.agyn.dev/*` → `gateway-gateway:8080`. No URI rewrite.
+2. **Path-based route** (`virtualservice_platform_ui`): `agyn.dev/apiv2/*` → `gateway-gateway:8080` with URI rewrite (`/apiv2/` → `/`). This route is defined on the same VirtualService as the platform-ui and platform-server routes.
+
+The UI uses the path-based route (`/apiv2/`) so that both the legacy monolith API (`/api`) and the new gateway API (`/apiv2/`) are served from the same origin, avoiding CORS overhead.

--- a/architecture/system-overview.md
+++ b/architecture/system-overview.md
@@ -38,7 +38,12 @@ graph TB
         MCP2[MCP Server]
     end
 
-    WebApp & MobileApp --> Gateway
+    subgraph Monolith
+        PS[platform-server]
+    end
+
+    WebApp & MobileApp -- "/apiv2/" --> Gateway
+    WebApp & MobileApp -- "/api" --> PS
     ThirdParty <--> Channels
     WebApp & MobileApp --> Channels
 
@@ -82,7 +87,7 @@ graph TB
 | **Tracing** | Ingestion and query of tracing data. Extended OpenTelemetry protocol for real-time in-progress events |
 | **Teams** | Management of team resources: agents, workspaces, MCP servers, etc. |
 | **Runner** | Executes workloads. Implementations: docker-runner, k8s-runner |
-| **Gateway** | Exposes platform methods for external usage |
+| **Gateway** | Exposes platform methods for external usage. Accessible at `gateway.agyn.dev` (subdomain) and `agyn.dev/apiv2/` (path-based, prefix stripped) |
 
 ## Data Stores
 

--- a/gaps/current-state.md
+++ b/gaps/current-state.md
@@ -41,6 +41,7 @@ graph TB
 | Language | Go |
 | API | REST (OpenAPI 3.0.3), proxy to platform-server |
 | Current scope | Team Management API (`/team/v1/`) with request/response validation. Proxies `/api/*` and `/health` to upstream platform-server |
+| Ingress | `gateway.agyn.dev` (subdomain) and `agyn.dev/apiv2/` (path-based, prefix stripped). The UI uses the path-based route |
 | Helm chart | `charts/gateway/` |
 | Dependencies | Platform-server (upstream proxy target) |
 | Gap | Currently proxies most routes to monolith. Needs to route to individual services as they are extracted |
@@ -90,6 +91,17 @@ These components exist inside `agynio/platform` (`packages/platform-server`) and
 | Channels (Slack trigger) | `packages/platform-server/src/nodes/` (trigger nodes) | Standalone Channels service |
 | Agents orchestrator | `packages/platform-server/src/agents/` | Standalone control plane service |
 | Tracing | Removed (issue #760). Historical references remain | New standalone Tracing service |
+
+### Platform UI — API Consumption
+
+The web app (platform-ui) consumes two API base paths on the same origin (`agyn.dev`):
+
+| Base Path | Backend | Content |
+|-----------|---------|---------|
+| `/api` | platform-server (monolith) | Legacy REST API — all current platform functionality |
+| `/apiv2/` | gateway (new services) | New REST API — Team Management, future extracted services |
+
+As services are extracted from the monolith and exposed through the gateway, endpoints migrate from `/api` to `/apiv2/`. The `/api` path will be removed when the monolith is fully decomposed.
 
 ## Monolith Components
 


### PR DESCRIPTION
## Summary
- update system overview diagram and gateway summary with `/api` and `/apiv2/`
- document gateway ingress paths and routing details
- add gateway ingress and UI API consumption notes to current state

## Testing
- Not run (no tests configured)

Fixes #13