### PR TITLE
Remove filesystem store migration open question

### DIFF
--- a/open-questions.md
+++ b/open-questions.md
@@ -38,16 +38,6 @@ Unresolved architectural decisions requiring discussion.
 
 ---
 
-## Filesystem Store Migration
-
-**Context:** Graph definitions use a filesystem-based dataset. Other services use PostgreSQL and Redis.
-
-**Questions:**
-- Will the filesystem store be migrated to PostgreSQL or another store?
-- If not, how is it backed up and replicated in k8s (PVCs, object storage)?
-
----
-
 ## Scheduler Service
 
 **Context:** Currently the Runner is purely data plane (executes workloads). A separate **Scheduler** service may be needed in the control plane to decide *what* and *when* to run.


### PR DESCRIPTION
Teams service already uses PostgreSQL — the filesystem store migration question is resolved. Removed from open-questions.md.

Remaining open questions (5):
1. Agent Batching Protocol
2. Threads Service Data Store
3. Channel Interface Definition
4. Scheduler Service
5. Summarization Packaging