### PR TITLE
Move token storage from Threads to Agent State

### DIFF
--- a/architecture/media.md
+++ b/architecture/media.md
@@ -221,7 +221,6 @@ The Message model gains an optional `files` field:
 | `sender_id` | string (UUID) | Participant who sent the message |
 | `body` | string | Text content |
 | `files` | list of string (UUID) | Referenced file IDs (may be empty) |
-| `tokens` | integer | Token count for this message. Computed once at creation via [Token Counting](token-counting.md) |
 | `read_status` | map | Per-participant read status |
 | `created_at` | timestamp | When the message was sent |
 
@@ -229,4 +228,4 @@ Consumers (Gateway, agent) resolve file IDs to metadata and download URLs by cal
 
 ## Context Size and Summarization
 
-Media files consume tokens that cannot be estimated from text length. The [Token Counting](token-counting.md) service provides accurate per-message token counts, including media content. Token counts are stored per message at creation time and used by the summarization reducer.
+Media files consume tokens that cannot be estimated from text length. The [Token Counting](token-counting.md) service provides accurate per-message token counts, including media content. Token counts are stored in the Agent State service and used by the summarization reducer.

--- a/architecture/threads.md
+++ b/architecture/threads.md
@@ -44,7 +44,6 @@ Threads is the messaging service for conversations between participants. A singl
 | `sender_id` | string (UUID) | Participant who sent the message |
 | `body` | string | Text content |
 | `files` | list of string (UUID) | Referenced file IDs (may be empty). See [Media API](media.md#api) |
-| `tokens` | integer | Token count for this message. Computed once at creation via [Token Counting](token-counting.md) |
 | `read_status` | map | Per-participant read status |
 | `created_at` | timestamp | When the message was sent |
 

--- a/architecture/token-counting.md
+++ b/architecture/token-counting.md
@@ -61,6 +61,4 @@ The response array has the same length as the input `messages` array. Each eleme
 
 ## Token Storage
 
-Tokens are counted **once** when a message is created and the count is stored in the message entity in the database. This avoids calling the Token Counting service repeatedly for the same messages.
-
-The summarization reducer reads the stored token count from each message rather than re-counting. It sums the per-message counts to decide whether to summarize (`maxTokens` threshold) and uses them for the head/tail split (`keepTokens` budget).
+The agent counts tokens once when it processes a message and persists the count in the Agent State service. The summarization reducer reads stored token counts from agent state rather than re-counting. It sums the per-message counts to decide whether to summarize (`maxTokens` threshold) and uses them for the head/tail split (`keepTokens` budget).


### PR DESCRIPTION
Threads is a generic messaging protocol — it carries messages between any participants (human-to-human, human-to-agent, agent-to-agent). Token counts are agent-specific and belong in Agent State.

## Changes

- **`threads.md`** — removed `tokens` field from Message data model
- **`media.md`** — removed `tokens` field from Message data model, updated Context Size section to reference Agent State
- **`token-counting.md`** — rewrote Token Storage section: tokens stored in Agent State, counted once when the agent processes a message