### PR TITLE
Refactor Threads, add Chat service, add delivery open question

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Target architecture of the platform. Describes how the system should work.
 | [Control Plane & Data Plane](architecture/control-data-plane.md) | Boundary definitions, criteria, service classification |
 | [Resource Definitions](architecture/resource-definitions.md) | Canonical schemas for all team-managed resources |
 | [Agent](architecture/agent/) | Agent contract, our implementation, state persistence |
+| [Chat](architecture/chat.md) | Built-in web/mobile app chat on top of Threads |
 | [Channels](architecture/channels.md) | Bidirectional interface for 3rd-party and own apps |
 | [Threads](architecture/threads.md) | Messaging service interface and data model |
 | [Media](architecture/media.md) | File attachments in thread messages |

--- a/architecture/channels.md
+++ b/architecture/channels.md
@@ -2,7 +2,9 @@
 
 ## Overview
 
-Channels are the bidirectional interface connecting 3rd-party products and Agyn's own apps with the Threads service. Each channel translates between an external messaging protocol and the internal thread model.
+Channels are the bidirectional interface connecting 3rd-party products with the Threads service. Each channel translates between an external messaging protocol and the internal thread model.
+
+Channels create and manage their own threads based on the logic of the specific integration (e.g., one thread per Slack channel, one thread per Slack thread).
 
 ## Responsibilities
 
@@ -15,22 +17,19 @@ A channel has two concerns:
 
 ```mermaid
 sequenceDiagram
-    participant Ext as External App<br/>(Slack, Web, Mobile)
+    participant Ext as External App<br/>(Slack, etc.)
     participant Ch as Channel
     participant Th as Threads
-    participant N as Notifications
-    participant A as Agent
 
-    Note over Ext,A: Inbound
+    Note over Ext,Th: Inbound
     Ext->>Ch: User sends message
     Ch->>Th: Translate & forward to thread
-    Th->>A: Pending message triggers agent
 
-    Note over Ext,A: Outbound
-    A->>Th: Post response to thread
-    Th->>N: Emit new-message event
-    N->>Ch: Notification delivered
+    Note over Ext,Th: Outbound
+    Ch->>Th: Check for unacknowledged messages
+    Th-->>Ch: Messages
     Ch->>Ext: Translate & forward to external app
+    Ch->>Th: AckMessages
 ```
 
 ### Inbound
@@ -38,18 +37,16 @@ sequenceDiagram
 1. External event arrives (e.g., Slack message).
 2. Channel translates the event into a thread message.
 3. Channel sends the message to Threads.
-4. Pending message triggers the Agents orchestrator.
 
 ### Outbound
 
-1. Agent posts a response to the thread.
-2. Notifications service emits a new-message event.
-3. Channel receives the notification (subscribed to relevant rooms).
-4. Channel translates and sends the message to the 3rd-party API.
+1. Channel detects unacknowledged messages on its threads (via delivery mechanism — see [open question](../open-questions.md#message-delivery-unification)).
+2. Channel translates and sends the messages to the 3rd-party API.
+3. Channel acknowledges the messages via `AckMessages`.
 
 ## Channel Interface
 
-Every channel implementation (Slack, web app, mobile app, etc.) must implement the same channel interface. Agyn's own web and mobile apps are also channel implementations.
+Every channel implementation (Slack, etc.) must implement the same channel interface. The platform's own web and mobile apps are **not** channels — they are served by the [Chat](chat.md) service.
 
 ## Channel Configuration
 

--- a/architecture/chat.md
+++ b/architecture/chat.md
@@ -1,0 +1,30 @@
+# Chat
+
+## Overview
+
+The Chat service implements the built-in web and mobile app chat experience on top of [Threads](threads.md). It manages thread creation, participant management, and unread counts for the platform's own UI.
+
+Threads is a generic messaging service. Chat adds the application-level logic specific to the platform's own clients.
+
+## Responsibilities
+
+| Responsibility | Description |
+|---------------|-------------|
+| **Thread lifecycle** | Create threads, add participants, archive threads for the built-in app |
+| **Unread counts** | Track and serve per-user unread message counts based on Threads acknowledgment state |
+| **Message delivery** | Receive messages from the UI via Gateway, forward to Threads |
+
+## Relationship to Threads
+
+Chat is a consumer of the Threads API. It does not duplicate messaging logic — it calls Threads for all message storage and retrieval.
+
+```mermaid
+graph LR
+    UI[Web / Mobile App] --> GW[Gateway]
+    GW --> Chat
+    Chat --> Threads
+```
+
+## Classification
+
+The Chat service is a **data plane** service.

--- a/architecture/chat.md
+++ b/architecture/chat.md
@@ -6,13 +6,15 @@ The Chat service implements the built-in web and mobile app chat experience on t
 
 Threads is a generic messaging service. Chat adds the application-level logic specific to the platform's own clients.
 
-## Responsibilities
+## Interface
 
-| Responsibility | Description |
-|---------------|-------------|
-| **Thread lifecycle** | Create threads, add participants, archive threads for the built-in app |
-| **Unread counts** | Track and serve per-user unread message counts based on Threads acknowledgment state |
-| **Message delivery** | Receive messages from the UI via Gateway, forward to Threads |
+| Method | Description |
+|--------|-------------|
+| **CreateChat** | Create a new chat thread between users (and optionally agents) |
+| **GetChats** | List chats for a user with pagination |
+| **GetMessages** | List messages in a chat with pagination and unread count |
+| **SendMessage** | Send a message in a chat |
+| **MarkAsRead** | Mark messages as read for a user (calls Threads AckMessages) |
 
 ## Relationship to Threads
 

--- a/architecture/control-data-plane.md
+++ b/architecture/control-data-plane.md
@@ -36,6 +36,7 @@ graph LR
         Files
         TokenCounting[Token Counting]
         LLM
+        Chat
         Secrets
     end
 
@@ -59,6 +60,7 @@ graph LR
 | **Token Counting** | Data | Counts tokens per message on the hot path during agent execution |
 | **LLM** | Data | Proxies LLM API calls from agents to providers on the hot path during agent execution |
 | **Secrets** | Data | Resolves secret values from external providers at runtime |
+| **Chat** | Data | Built-in app chat experience on top of Threads |
 | **Runner** | Data | Executes workloads (containers/pods), provides exec and log streaming |
 
 ## Reconciliation

--- a/architecture/media.md
+++ b/architecture/media.md
@@ -221,6 +221,7 @@ The Message model gains an optional `files` field:
 | `sender_id` | string (UUID) | Participant who sent the message |
 | `body` | string | Text content |
 | `files` | list of string (UUID) | Referenced file IDs (may be empty) |
+| `ack_status` | map | Per-participant acknowledgment status |
 | `created_at` | timestamp | When the message was sent |
 
 Consumers (Gateway, agent) resolve file IDs to metadata and download URLs by calling the Files service.

--- a/architecture/media.md
+++ b/architecture/media.md
@@ -221,7 +221,6 @@ The Message model gains an optional `files` field:
 | `sender_id` | string (UUID) | Participant who sent the message |
 | `body` | string | Text content |
 | `files` | list of string (UUID) | Referenced file IDs (may be empty) |
-| `read_status` | map | Per-participant read status |
 | `created_at` | timestamp | When the message was sent |
 
 Consumers (Gateway, agent) resolve file IDs to metadata and download URLs by calling the Files service.

--- a/architecture/system-overview.md
+++ b/architecture/system-overview.md
@@ -19,6 +19,7 @@ graph TB
 
     subgraph Data Plane
         Gateway[Gateway]
+        Chat[Chat]
         Channels[Channels]
         Threads[Threads]
         Files[Files]
@@ -45,23 +46,22 @@ graph TB
     WebApp & MobileApp -- "/apiv2/" --> Gateway
     WebApp & MobileApp -- "/api" --> PS
     ThirdParty <--> Channels
-    WebApp & MobileApp --> Channels
 
-    Gateway --> Threads
+    Gateway --> Chat
     Gateway --> Files
     Gateway --> Notifications
     Gateway --> LLM
     Gateway --> Secrets
-    Channels <--> Threads
-    Channels --> Notifications
+    Chat --> Threads
+    Channels --> Threads
 
-    Threads --> Notifications
     AgentsOrch --> Runner
     AgentsOrch --> Threads
 
     Runner --> Agent1 & Agent2
     Agent1 --> MCP1
     Agent2 --> MCP2
+    Agent1 & Agent2 --> Threads
     Agent1 & Agent2 --> AgentState
     Agent1 & Agent2 --> Files
     Agent1 & Agent2 --> TokenCounting
@@ -75,10 +75,11 @@ graph TB
 
 | Component | Responsibility |
 |-----------|---------------|
-| **Channels** | Bidirectional interface connecting 3rd-party products (Slack, etc.) and own apps (web, mobile) with Threads |
-| **Threads** | Conversation messaging between multiple participants (humans and agents) |
+| **Chat** | Built-in web/mobile app chat experience. Thread lifecycle, unread counts. Built on top of Threads |
+| **Channels** | Bidirectional interface connecting 3rd-party products (Slack, etc.) with Threads. Each channel creates and manages its own threads |
+| **Threads** | Generic messaging between participants. Stores messages, tracks participants by ID, provides message acknowledgment. Participant-type-agnostic |
 | **Files** | File upload, metadata storage, and pre-signed download URL generation. Backed by S3-compatible object storage |
-| **Token Counting** | Per-message token counting for LLM messages. Replaces text-length heuristic for summarization decisions |
+| **Token Counting** | Per-message token counting for LLM messages |
 | **LLM** | Manages LLM providers and models. Proxies LLM API calls from agents to providers with injected credentials |
 | **Secrets** | Manages secret providers and secrets. Resolves secret values from external providers at runtime |
 | **Notifications** | Real-time event fanout via persistent connections (socket). Delivers events to relevant clients |

--- a/architecture/threads.md
+++ b/architecture/threads.md
@@ -2,7 +2,9 @@
 
 ## Overview
 
-Threads is the messaging service for conversations between participants. A single thread can include multiple participants — both humans and agents.
+Threads is the messaging service for conversations between participants. It stores messages, tracks participants, and provides message acknowledgment. Threads is participant-type-agnostic — it identifies participants by ID and applies the same behavior regardless of whether the participant is a user, an agent, or a channel.
+
+Business logic (chat UX, agent processing, channel integration) is implemented by services built on top of Threads.
 
 ## Interface
 
@@ -10,10 +12,11 @@ Threads is the messaging service for conversations between participants. A singl
 |--------|-------------|
 | **CreateThread** | Create a new thread with initial participants |
 | **ArchiveThread** | Archive a thread (soft-delete) |
-| **AddParticipant** | Add a participant (human or agent) to an existing thread |
+| **AddParticipant** | Add a participant to an existing thread |
 | **SendMessage** | Send a message to a thread (text and/or file references) |
 | **GetThreads** | List threads with pagination |
 | **GetMessages** | List messages in a thread with pagination |
+| **AckMessages** | Acknowledge messages as processed by a participant |
 
 ## Data Model
 
@@ -32,7 +35,6 @@ Threads is the messaging service for conversations between participants. A singl
 | Field | Type | Description |
 |-------|------|-------------|
 | `id` | string (UUID) | Participant identifier |
-| `type` | enum | `human`, `agent` |
 | `joined_at` | timestamp | When the participant joined |
 
 ### Message
@@ -44,11 +46,15 @@ Threads is the messaging service for conversations between participants. A singl
 | `sender_id` | string (UUID) | Participant who sent the message |
 | `body` | string | Text content |
 | `files` | list of string (UUID) | Referenced file IDs (may be empty). See [Media API](media.md#api) |
-| `read_status` | map | Per-participant read status |
 | `created_at` | timestamp | When the message was sent |
 
-## Read Status
+## Message Acknowledgment
 
-Messages include read status tracked per participant. This enables:
-- Unread message counts in the UI.
-- The Agents orchestrator detecting pending (unread-by-agent) messages.
+`GetMessages` is a read-only operation — it does not change message state. `AckMessages` is a separate call where a participant explicitly marks messages as processed.
+
+This separation handles crash recovery: a consumer can read messages, process them, and only acknowledge after successful processing. If the consumer crashes before acknowledging, the messages remain unacknowledged and can be re-read.
+
+Unacknowledged messages per participant enable:
+- Unread message counts in the UI (via [Chat](chat.md) service).
+- The Agents orchestrator detecting threads with pending work.
+- Channels detecting outbound messages to deliver to external apps.

--- a/architecture/threads.md
+++ b/architecture/threads.md
@@ -46,6 +46,7 @@ Business logic (chat UX, agent processing, channel integration) is implemented b
 | `sender_id` | string (UUID) | Participant who sent the message |
 | `body` | string | Text content |
 | `files` | list of string (UUID) | Referenced file IDs (may be empty). See [Media API](media.md#api) |
+| `ack_status` | map | Per-participant acknowledgment status |
 | `created_at` | timestamp | When the message was sent |
 
 ## Message Acknowledgment

--- a/open-questions.md
+++ b/open-questions.md
@@ -22,14 +22,12 @@ Unresolved architectural decisions requiring discussion.
 
 **Questions:**
 - Dedicated PostgreSQL schema or separate database?
-- How does Threads interact with Agents orchestrator? (Notifications-based? Direct callback? Polling?)
-- Does Threads own read-status tracking, or is that a consumer concern?
 
 ---
 
 ## Channel Interface Definition
 
-**Context:** Channels need a formal interface that all implementations (Slack, web app, mobile app) must satisfy.
+**Context:** Channels need a formal interface that all implementations (Slack, etc.) must satisfy.
 
 **Questions:**
 - Is the channel interface a gRPC service contract, a container contract, or an SDK/library interface?
@@ -38,13 +36,22 @@ Unresolved architectural decisions requiring discussion.
 
 ---
 
-## Filesystem Store Migration
+## Message Delivery Unification
 
-**Context:** Graph definitions use a filesystem-based dataset. Other services use PostgreSQL and Redis.
+**Context:** Three distinct delivery patterns exist for consuming messages from Threads:
 
-**Questions:**
-- Will the filesystem store be migrated to PostgreSQL or another store?
-- If not, how is it backed up and replicated in k8s (PVCs, object storage)?
+1. **Notifications service** — fire-and-forget socket-based events for real-time web UI. No delivery guarantee.
+2. **Agent pull** — agents read unacknowledged messages when ready, acknowledge after processing. Queue-like semantics.
+3. **Channel push** — channels need guaranteed delivery of outbound messages to external apps.
+
+These patterns need alignment.
+
+**Options:**
+
+1. **Message broker** — Threads publishes messages to a broker (e.g., NATS, Kafka). Consumers subscribe with their own delivery semantics (at-least-once for agents/channels, best-effort for UI).
+2. **Fire-and-forget notifications + pull fallback** — Notifications service delivers real-time signals. All consumers pull unacknowledged messages from Threads as the reliable path. Notifications only reduce latency.
+
+**Decision:** TBD
 
 ---
 


### PR DESCRIPTION
## Threads refactored

- **Participant-type-agnostic** — removed `type` enum from Participant. Threads identifies participants by ID only, same behavior for all.
- **AckMessages** — explicit acknowledgment method, separate from `GetMessages`. Handles crash recovery: messages remain unacknowledged until consumer confirms processing.
- Removed `read_status` from Message model (acknowledgment tracked separately).
- Business logic (chat UX, agent processing, channel integration) lives in services built on top of Threads.

## Chat service (new — `architecture/chat.md`)

Built-in web/mobile app chat experience on top of Threads:
- Thread lifecycle (create, add participants, archive)
- Unread counts based on Threads acknowledgment state
- Message delivery from UI via Gateway → Chat → Threads

## Channels updated

- Channels create and manage their own threads per integration logic
- Own apps (web, mobile) are **not** channels — served by Chat service
- Outbound flow uses pull + `AckMessages`

## Open questions updated

- **Added**: Message Delivery Unification — three patterns (notifications fire-and-forget, agent pull, channel push) need alignment. Options: message broker vs. notifications + pull fallback.
- **Removed**: Filesystem store migration (resolved — Teams uses PostgreSQL).
- **Trimmed**: Threads Data Store — removed resolved sub-questions (orchestrator interaction, read-status ownership).

## Other updates

- `system-overview.md` — Chat added to diagram and component table; Gateway routes to Chat instead of Threads directly
- `control-data-plane.md` — Chat added as data plane service
- `media.md` — removed `read_status` from Message model
- `README.md` — Chat added to index