### PR TITLE
docs: reflect docker-runner extraction

### DIFF
--- a/architecture/runner.md
+++ b/architecture/runner.md
@@ -8,7 +8,7 @@ Multiple implementations exist for different backends:
 
 | Implementation | Backend | Status |
 |----------------|---------|--------|
-| `docker-runner` | Docker Engine | Existing (`agynio/platform`) |
+| `docker-runner` | Docker Engine | Active (`agynio/docker-runner`) |
 | `k8s-runner` | Kubernetes | Planned |
 
 ## gRPC API

--- a/architecture/system-overview.md
+++ b/architecture/system-overview.md
@@ -106,7 +106,8 @@ graph TB
 | Repository | Contents | Language | Status |
 |------------|----------|----------|--------|
 | `agynio/api` | API schemas: protobuf (internal gRPC) and OpenAPI (external) | Proto, YAML | Active |
-| `agynio/platform` | Monolith: platform-server, docker-runner, LLM package, platform-ui | TypeScript | Active (being decomposed) |
+| `agynio/platform` | Monolith: platform-server, LLM package, platform-ui | TypeScript | Active (being decomposed) |
+| `agynio/docker-runner` | Docker Runner service | TypeScript | Active |
 | `agynio/notifications` | Notifications service | Go | Standalone service |
 | `agynio/gateway` | Gateway service | Go | Standalone service |
 | `agynio/agent-state` | Agent State (APSS) service | Go | Standalone service |

--- a/gaps/migration-roadmap.md
+++ b/gaps/migration-roadmap.md
@@ -47,7 +47,7 @@ These services are already extracted and running independently:
 | Gateway | `agynio/gateway` | Serves Team API, proxies remaining to monolith |
 | Agent State (APSS) | `agynio/agent-state` | gRPC service with PostgreSQL |
 | Notifications | `agynio/notifications` | gRPC + Socket.IO, Redis pub/sub |
-| Docker Runner | `agynio/platform` (separate deploy) | gRPC, HMAC auth, Helm chart |
+| Docker Runner | `agynio/docker-runner` | fully extracted |
 
 ## Phase 2 — Extract from Monolith
 


### PR DESCRIPTION
## Summary
- update repository map and runner status for docker-runner extraction
- mark migration roadmap Phase 1 docker-runner as fully extracted

## Testing
- npx --yes markdownlint-cli --disable MD013 MD032 MD060 -- /workspace/architecture/architecture/system-overview.md /workspace/architecture/gaps/migration-roadmap.md /workspace/architecture/architecture/runner.md
- Tests not run (no test suite found)

Ref #20