### PR TITLE
Docs: remove edge tags, rename bootstrap_v2, add DevSpace commands

### DIFF
--- a/architecture/authz.md
+++ b/architecture/authz.md
@@ -82,7 +82,7 @@ The authorization model is managed as infrastructure-as-code in a dedicated repo
 | Terraform module | Creates the OpenFGA store, writes the model version |
 | Model tests | `fga model test` — validates expected check results against sample tuples |
 
-The repository is versioned via git tags. The platform's infrastructure repo (`agynio/bootstrap_v2`) references a specific version:
+The repository is versioned via git tags. The platform's infrastructure repo (`agynio/bootstrap`) references a specific version:
 
 ```hcl
 module "openfga_authz" {
@@ -104,7 +104,7 @@ Terraform outputs (`store_id`, `model_id`) feed into the Authorization service's
 1. Change the authorization model DSL in `agynio/openfga-model`.
 2. Run `fga model test` to validate.
 3. Merge, tag a new version.
-4. Update the module version in `agynio/bootstrap_v2`.
+4. Update the module version in `agynio/bootstrap`.
 5. `terraform apply` writes the new model version to OpenFGA.
 6. Authorization service picks up the new `model_id` on next deploy (or uses latest if not pinned).
 

--- a/architecture/gateway.md
+++ b/architecture/gateway.md
@@ -35,7 +35,7 @@ The gateway (`agynio/gateway`, Go) currently:
 
 ### Ingress Routing
 
-The gateway receives traffic through two Istio VirtualService routes (defined in `agynio/bootstrap_v2`, `stacks/platform/main.tf`):
+The gateway receives traffic through two Istio VirtualService routes (defined in `agynio/bootstrap`, `stacks/platform/main.tf`):
 
 1. **Subdomain route** (`virtualservice_gateway`): `gateway.agyn.dev/*` → `gateway-gateway:8080`. No URI rewrite.
 2. **Path-based route** (`virtualservice_platform_ui`): `agyn.dev/apiv2/*` → `gateway-gateway:8080` with URI rewrite (`/apiv2/` → `/`). This route is defined on the same VirtualService as the platform-ui and platform-server routes.

--- a/architecture/media.md
+++ b/architecture/media.md
@@ -71,7 +71,7 @@ A new S3-compatible object storage backend is required. In production, this can 
 | Aspect | Details |
 |--------|---------|
 | Protocol | S3-compatible API |
-| Local | MinIO deployed via bootstrap_v2 |
+| Local | MinIO deployed via bootstrap |
 | Production | Any S3-compatible provider |
 
 ### Object Key

--- a/architecture/operations/ci-cd.md
+++ b/architecture/operations/ci-cd.md
@@ -6,7 +6,7 @@ Every service follows the same CI/CD pattern: GitHub Actions publish a container
 
 | Artifact | Registry | Tag pattern |
 |----------|----------|-------------|
-| Container image | `ghcr.io/agynio/<service>` | `sha-<short>`, `main`, `<semver>`, `latest` |
+| Container image | `ghcr.io/agynio/<service>` | `sha-<short>`, `<semver>`, `latest` |
 | Helm chart | `oci://ghcr.io/agynio/charts/<service>` | `<semver>` (from tag `v*.*.*`) |
 
 ## Workflows
@@ -15,15 +15,14 @@ Each service repository contains GitHub Actions workflows under `.github/workflo
 
 ### Image Build (`docker-ghcr.yml` or combined `release.yml`)
 
-**Trigger:** Push to `main` branch or push of a `v*.*.*` tag.
+**Trigger:** Push of a `v*.*.*` tag.
 
 **Steps:**
 1. Checkout repository.
 2. Set up Docker Buildx (multi-platform: `linux/amd64`, `linux/arm64`).
 3. Log in to GHCR using `GITHUB_TOKEN`.
 4. Build and push image with metadata-driven tags:
-   - `sha-<short>` — every push.
-   - `main` — pushes to main branch.
+   - `sha-<short>` — every release.
    - `<major>.<minor>.<patch>`, `<major>.<minor>`, `<major>` — semver tags.
    - `latest` — stable semver tags (no pre-release suffix).
 5. Layer caching via GitHub Actions cache (`type=gha`).

--- a/architecture/operations/e2e-testing.md
+++ b/architecture/operations/e2e-testing.md
@@ -4,7 +4,7 @@ E2E tests run inside the cluster in a dedicated test pod, separate from the serv
 
 ## How It Works
 
-DevSpace deploys a dedicated test pod using its built-in `component-chart`. This pod runs a dev container image with `sleep infinity`, giving DevSpace a target to sync source code into and exec test commands against. The service deployments managed by ArgoCD are untouched — they keep running their pinned release images.
+DevSpace deploys a dedicated test pod using [`component-chart`](https://devspace.sh/component-chart/docs/introduction) — a generic Helm chart provided by DevSpace for deploying containers without writing custom chart templates. This pod runs a dev container image with `sleep infinity`, giving DevSpace a target to sync source code into and exec test commands against. The service deployments managed by ArgoCD are untouched — they keep running their pinned release images.
 
 ```mermaid
 graph LR

--- a/architecture/operations/local-development.md
+++ b/architecture/operations/local-development.md
@@ -4,11 +4,11 @@
 
 The single source of truth for running the full Agyn cluster locally is:
 
-**Repository:** [`agynio/bootstrap_v2`](https://github.com/agynio/bootstrap_v2)
+**Repository:** [`agynio/bootstrap`](https://github.com/agynio/bootstrap)
 
 No other custom docker-compose files or local setups should exist. All services are configured and deployed from this repo.
 
-Bootstrap uses **Terraform** to provision a local Kubernetes cluster (k3d) and deploy all services via **Argo CD**. Setup instructions, stack descriptions, and local endpoints are documented in the [bootstrap_v2 repository](https://github.com/agynio/bootstrap_v2).
+Bootstrap uses **Terraform** to provision a local Kubernetes cluster (k3d) and deploy all services via **Argo CD**. Setup instructions, stack descriptions, and local endpoints are documented in the [bootstrap repository](https://github.com/agynio/bootstrap).
 
 ## Service Development with DevSpace
 

--- a/architecture/operations/new-service.md
+++ b/architecture/operations/new-service.md
@@ -15,7 +15,7 @@ flowchart LR
 | Step | Outcome |
 |------|---------|
 | [API Schema](#api-schema) | Proto and/or OpenAPI definitions merged in `agynio/api` |
-| [Implementation](#implementation) | Service repo with application code, Dockerfile, Helm chart |
+| [Implementation](#implementation) | Service repo with application code, Dockerfile, Helm chart, DevSpace config |
 | [CI/CD](#cicd) | GitHub Actions publish image and chart to GHCR on every release |
 | [Bootstrap](#bootstrap) | Service deployed in the local cluster via Argo CD |
 | [E2E Tests](#e2e-tests) | Automated tests verify the service in a real cluster |
@@ -80,10 +80,57 @@ agynio/<service>/
 ├── test/
 │   └── e2e/               # E2E tests
 ├── buf.gen.yaml           # Proto code generation config
+├── devspace.yaml          # DevSpace config: dev mode + E2E tests
 ├── Dockerfile
+├── README.md
 ├── Makefile
 └── go.mod
 ```
+
+### README
+
+Each service README follows a standard structure:
+
+~~~markdown
+# <Service Name>
+
+Short description of what the service does.
+
+Architecture: [<Service Name>](https://github.com/agynio/architecture/blob/main/architecture/<service>.md)
+
+## Local Development
+
+Full setup: [Local Development](https://github.com/agynio/architecture/blob/main/architecture/operations/local-development.md)
+
+### Prepare environment
+
+```bash
+git clone https://github.com/agynio/bootstrap.git
+cd bootstrap
+chmod +x apply.sh
+./apply.sh -y
+```
+
+See [bootstrap](https://github.com/agynio/bootstrap) for details.
+
+### Run from sources
+
+```bash
+# Deploy once (exit when healthy)
+devspace dev
+
+# Watch mode (streams logs, re-syncs on changes)
+devspace dev -w
+```
+
+### Run tests
+
+```bash
+devspace run test:e2e
+```
+
+See [E2E Testing](https://github.com/agynio/architecture/blob/main/architecture/operations/e2e-testing.md).
+~~~
 
 ### Proto Code Generation
 
@@ -103,6 +150,21 @@ dependencies:
 
 The base chart (`agynio/base-chart`) provides templates for Deployment, Service, ServiceAccount, HPA, and Ingress. Service charts override values.
 
+
+### DevSpace
+
+Each service provides a `devspace.yaml` with three commands:
+
+| Command | Purpose |
+|---------|---------|
+| `devspace dev` | Deploy once: patch the service pod with a dev container, sync source, start the service, exit when healthy. Used by CI and scripts. |
+| `devspace dev -w` | Watch mode: same as `devspace dev` but keeps running, streams logs, and re-syncs on file changes. Used during local development. |
+| `devspace run test:e2e` | Run E2E tests in a separate test pod inside the cluster. Self-contained: deploys test pod → syncs source → runs tests → cleans up. |
+
+`devspace dev` and `devspace dev -w` patch the existing service deployment with a dev container image, replacing the released image with source-based hot-reload. The `-w` flag is implemented via a pipeline flag (see gateway's `devspace.yaml` for the pattern).
+
+`devspace run test:e2e` does not touch the service pod. It deploys a separate test pod, syncs test code into it, and executes the tests. See [E2E Testing](e2e-testing.md).
+
 ---
 
 ## CI/CD
@@ -120,7 +182,6 @@ Add GitHub Actions workflows under `.github/workflows/` in the service repo. All
 
 | Condition | Tags |
 |-----------|------|
-| Push to `main` | `edge` |
 | Push `v*.*.*` tag | `<semver>`, `latest`, `sha-<commit>` |
 
 ### Helm Chart Publishing


### PR DESCRIPTION
## Changes

### Remove edge image tags
- `new-service.md`: removed `edge` tag row — only release tags (`<semver>`, `latest`, `sha-<commit>`)
- `ci-cd.md`: removed `main` from tag pattern, trigger, and tag bullets

### Rename bootstrap_v2 → bootstrap
Updated all references across `authz.md`, `gateway.md`, `media.md`, `local-development.md`, `new-service.md`.

### Add DevSpace commands requirement
`new-service.md` now specifies three required DevSpace commands:

| Command | Purpose |
|---------|---------|
| `devspace dev` | Deploy once — exit when healthy |
| `devspace dev -w` | Watch mode — streams logs, re-syncs |
| `devspace run test:e2e` | E2E tests in a separate test pod |

### Explain component-chart
`e2e-testing.md`: inline explanation + link.

### Standardize README
`new-service.md` now includes a README template that every service must follow:
- Short description
- Link to architecture page
- Local Development section:
  - Prepare env (clone bootstrap, `./apply.sh -y`)
  - Run from sources (`devspace dev` / `devspace dev -w`)
  - Run tests (`devspace run test:e2e`)

## Files Changed

| File | Change |
|------|--------|
| `architecture/operations/new-service.md` | Edge tags, DevSpace section, README template, repo structure |
| `architecture/operations/ci-cd.md` | Edge/main tags removed |
| `architecture/operations/e2e-testing.md` | component-chart explanation |
| `architecture/authz.md` | bootstrap_v2 → bootstrap |
| `architecture/gateway.md` | bootstrap_v2 → bootstrap |
| `architecture/media.md` | bootstrap_v2 → bootstrap |
| `architecture/operations/local-development.md` | bootstrap_v2 → bootstrap |