### PR TITLE
fix: documentation inconsistencies in new-service.md

### DIFF
--- a/architecture/operations/new-service.md
+++ b/architecture/operations/new-service.md
@@ -83,7 +83,6 @@ agynio/<service>/
 ├── devspace.yaml          # DevSpace config: dev mode + E2E tests
 ├── Dockerfile
 ├── README.md
-├── Makefile
 └── go.mod
 ```
 
@@ -176,7 +175,7 @@ Add GitHub Actions workflows under `.github/workflows/` in the service repo. All
 | Workflow | Trigger | Artifacts |
 |----------|---------|-----------|
 | `ci.yml` | Pull requests | Lint, test, build |
-| `release.yml` | Push to `main` or `v*.*.*` tag | Container image + Helm chart to GHCR |
+| `release.yml` | `v*.*.*` tag | Container image + Helm chart to GHCR |
 
 ### Image Tags
 
@@ -195,7 +194,7 @@ On `v*.*.*` tag push:
 
 ## Bootstrap
 
-Register the service in `agynio/bootstrap_v2` so it is deployed in the local cluster. See [Local Development](local-development.md) for how bootstrap provisions the cluster.
+Register the service in `agynio/bootstrap` so it is deployed in the local cluster. See [Local Development](local-development.md) for how bootstrap provisions the cluster.
 
 ---
 


### PR DESCRIPTION
Fixes three documentation inconsistencies in `architecture/operations/new-service.md`:

1. **Remove `Makefile`** from repository structure tree — it was listed but never described anywhere in the docs.
2. **Fix release trigger** — changed from "Push to `main` or `v*.*.*` tag" to just "`v*.*.*` tag". Releases should only be triggered by versioned tags.
3. **Rename `bootstrap_v2` → `bootstrap`** — the repository was renamed.

Closes #28