### PR TITLE
Rewrite Orchestrator as general workload orchestrator with MCP adapter

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Target architecture of the platform. Describes how the system should work.
 | [Control Plane & Data Plane](architecture/control-data-plane.md) | Boundary definitions, criteria, service classification |
 | [Resource Definitions](architecture/resource-definitions.md) | Canonical schemas for all team-managed resources |
 | [Agent](architecture/agent/) | Agent contract, our implementation, state persistence |
+| [Agents Orchestrator](architecture/orchestrator.md) | Agent workload lifecycle — reconciliation, demand/supply, idle timeout |
 | [Chat](architecture/chat.md) | Built-in web/mobile app chat on top of Threads |
 | [Channels](architecture/channels.md) | Bidirectional interface for 3rd-party and own apps |
 | [Threads](architecture/threads.md) | Messaging service interface and data model |

--- a/README.md
+++ b/README.md
@@ -17,7 +17,8 @@ Target architecture of the platform. Describes how the system should work.
 | [Control Plane & Data Plane](architecture/control-data-plane.md) | Boundary definitions, criteria, service classification |
 | [Resource Definitions](architecture/resource-definitions.md) | Canonical schemas for all team-managed resources |
 | [Agent](architecture/agent/) | Agent contract, our implementation, state persistence |
-| [Agents Orchestrator](architecture/orchestrator.md) | Agent workload lifecycle — reconciliation, demand/supply, idle timeout |
+| [Orchestrator](architecture/orchestrator.md) | Workload lifecycle — reconciles agents, MCP servers, and discovery signals |
+| [MCP Adapter](architecture/mcp-adapter.md) | Standalone binary wrapping any MCP server — bridges stdio/HTTP to gRPC |
 | [Chat](architecture/chat.md) | Built-in web/mobile app chat on top of Threads |
 | [Channels](architecture/channels.md) | Bidirectional interface for 3rd-party and own apps |
 | [Threads](architecture/threads.md) | Messaging service interface and data model |

--- a/README.md
+++ b/README.md
@@ -17,8 +17,8 @@ Target architecture of the platform. Describes how the system should work.
 | [Control Plane & Data Plane](architecture/control-data-plane.md) | Boundary definitions, criteria, service classification |
 | [Resource Definitions](architecture/resource-definitions.md) | Canonical schemas for all team-managed resources |
 | [Agent](architecture/agent/) | Agent contract, our implementation, state persistence |
-| [Orchestrator](architecture/orchestrator.md) | Workload lifecycle — reconciles agents, MCP servers, and discovery signals |
-| [MCP Adapter](architecture/mcp-adapter.md) | Standalone binary wrapping any MCP server — bridges stdio/HTTP to gRPC |
+| [Agents Orchestrator](architecture/orchestrator.md) | Agent workload lifecycle — reconciles agent pods |
+| [MCP Adapter](architecture/mcp-adapter.md) | Wraps any MCP server — bridges stdio/HTTP to gRPC |
 | [Chat](architecture/chat.md) | Built-in web/mobile app chat on top of Threads |
 | [Channels](architecture/channels.md) | Bidirectional interface for 3rd-party and own apps |
 | [Threads](architecture/threads.md) | Messaging service interface and data model |

--- a/architecture/agent/overview.md
+++ b/architecture/agent/overview.md
@@ -12,10 +12,14 @@ Every agent, regardless of implementation, must satisfy the same contract:
 
 ```mermaid
 graph TB
-    subgraph "Agent Container"
+    subgraph "Agent Workload"
         Impl[Agent Implementation<br/>our own / 3rd-party CLI / custom]
-        MCP[MCP Tool Servers]
-        Impl --> MCP
+        Ziti[OpenZiti Tunnel]
+    end
+
+    subgraph "MCP Workloads (separate)"
+        MCP1[MCP Server 1<br/>adapter + server]
+        MCP2[MCP Server 2<br/>adapter + server]
     end
 
     subgraph Platform
@@ -25,6 +29,8 @@ graph TB
         Tracing
     end
 
+    Impl -->|gRPC over OpenZiti| MCP1
+    Impl -->|gRPC over OpenZiti| MCP2
     Impl -->|read/ack messages| Threads
     Impl -->|post responses| Threads
     Impl -->|resolve files| Files
@@ -40,10 +46,10 @@ graph TB
 | **Process** | Run implementation-specific logic (LLM calls, tool use, etc.) |
 | **Post responses** | Write response messages back to the thread via Threads API |
 | **Subscribe to notifications** | Listen for `message.created` events on `thread_participant:{agentId}` room |
-| **Use tools via MCP** | Connect to MCP servers for tool access |
+| **Use tools via MCP** | Call MCP servers over gRPC via [MCP Adapter](../mcp-adapter.md) |
 | **Report tracing** | Optionally emit tracing data |
 
-The agent is a **pure client** — it makes outbound connections to platform services. It does not expose any server or accept inbound connections.
+The agent is a **pure client** — it makes outbound connections to platform services and MCP servers. It does not expose any server or accept inbound connections.
 
 ## Communication Protocol
 
@@ -86,20 +92,22 @@ sequenceDiagram
 ### Design Principles
 
 - **Pull at defined loop stages.** The `whenBusy` configuration controls when mid-run messages are picked up: between turns (`wait`) or between tool calls (`injectAfterTools`). The notification wakes the agent, but the actual message read happens at the next check point in the LLM loop.
-- **No inbound connections.** The agent connects outbound to Notifications (gRPC subscribe stream), Threads (gRPC calls), and Files (gRPC calls). No server, no open port, no service discovery per agent.
+- **No inbound connections.** The agent connects outbound to Notifications (gRPC subscribe stream), Threads (gRPC calls), Files (gRPC calls), and MCP servers (gRPC via OpenZiti). No server, no open port, no service discovery per agent.
 
 ## Tools
 
-All tools are provided via **MCP protocol** (Model Context Protocol). The goal is to eliminate built-in tools entirely, making tools reusable across any agent implementation.
+All tools are provided via **MCP protocol** (Model Context Protocol) through the [MCP Adapter](../mcp-adapter.md). The goal is to eliminate built-in tools entirely, making tools reusable across any agent implementation.
+
+Each MCP server runs as a **separate workload** with its own OpenZiti identity. The agent connects to MCP servers over gRPC via OpenZiti — the same network layer used for platform services.
 
 | Aspect | Details |
 |--------|---------|
-| Transport | stdio (newline-delimited JSON-RPC 2.0) |
-| Server location | Inside the workspace container (sidecar) |
+| Agent-side transport | gRPC over OpenZiti |
+| MCP server-side transport | [MCP Adapter](../mcp-adapter.md) bridges gRPC ↔ stdio or Streamable HTTP |
 | Namespacing | `<namespace>:<toolName>` to prevent collisions |
-| Resilience | Heartbeat + restart with configurable backoff |
+| Server lifecycle | Managed by the [Orchestrator](../orchestrator.md), not the agent |
 
-MCP servers are defined as team resources (see [Teams](../teams.md)) and mounted into the agent container as sidecars by the Runner.
+MCP servers are defined as team resources (see [Teams](../teams.md)) and attached to agents via [attachments](../resource-definitions.md#attachment). The [Orchestrator](../orchestrator.md) starts MCP server workloads before the agent workload and passes MCP server gRPC endpoints to the agent as configuration.
 
 ## Wrapper Model
 
@@ -109,17 +117,17 @@ Most 3rd-party agents are implemented as CLIs. The platform provides a **wrapper
 sequenceDiagram
     participant W as Wrapper
     participant CLI as Agent CLI
-    participant MCP as MCP Servers
+    participant MCP as MCP Servers (gRPC)
     participant T as Threads
     participant N as Notifications
 
     W->>N: Subscribe to thread_participant:{agentId} room
     W->>CLI: Start process with config
-    W->>MCP: Start MCP servers
+    W->>MCP: Connect to MCP servers via gRPC
     W->>CLI: Connect MCP servers
     W->>T: GetUnackedMessages(agentId)
     W->>CLI: Feed messages
-    CLI->>MCP: Tool calls
+    CLI->>MCP: Tool calls (gRPC)
     MCP-->>CLI: Tool results
     CLI-->>W: Output
     W->>T: Post response to thread
@@ -133,7 +141,7 @@ sequenceDiagram
 The wrapper:
 1. Subscribes to notifications for the agent's participant room.
 2. Starts the agent CLI process with configuration.
-3. Connects MCP tool servers to the agent.
+3. Connects to MCP servers via gRPC (endpoints provided by the Orchestrator).
 4. Pulls unacknowledged messages from Threads and feeds them to the CLI.
 5. Collects CLI output and posts responses to the thread.
 6. Acknowledges processed messages via `AckMessages`.
@@ -141,39 +149,46 @@ The wrapper:
 
 ## Lifecycle
 
-The [Agents Orchestrator](../orchestrator.md) manages the full agent workload lifecycle — starting containers when demand exists, stopping them when idle. This section summarizes the lifecycle from the agent's perspective.
+The [Orchestrator](../orchestrator.md) manages the full agent workload lifecycle — starting containers when demand exists, stopping them when idle. This section summarizes the lifecycle from the agent's perspective.
 
 ```mermaid
 sequenceDiagram
     participant T as Threads
-    participant O as Agents Orchestrator
+    participant O as Orchestrator
     participant R as Runner
-    participant A as Agent Container
+    participant M as MCP Server Workloads
+    participant A as Agent Workload
 
     T->>O: Unacknowledged messages (reconciliation loop)
-    O->>R: StartWorkload
-    R->>A: Create container
+    O->>R: Start MCP server workloads
+    R->>M: Create MCP containers
+    Note over M: MCP servers ready
+    O->>R: StartWorkload (agent)
+    R->>A: Create agent container
+    A->>M: Connect to MCP servers (gRPC)
     A->>A: Subscribe, pull, process, ack
     A->>T: Post response
 
     Note over A,O: Agent idle, waiting for messages
     O->>O: Activity check (reconciliation loop)
     Note over O: Idle timeout exceeded
-    O->>R: StopWorkload
+    O->>R: StopWorkload (agent)
+    Note over O: No agents reference MCP servers
+    O->>R: StopWorkload (MCP servers)
 ```
 
-1. The orchestrator's reconciliation loop detects threads with unacknowledged messages for agent participants.
-2. Orchestrator requests Runner to start an agent workload with thread ID and agent config.
-3. Runner creates a container with the agent image, MCP sidecars, and configuration.
-4. Agent subscribes to notifications, pulls unacknowledged messages, processes, posts responses, acknowledges.
+1. The Orchestrator's reconciliation loop detects threads with unacknowledged messages for agent participants.
+2. Orchestrator ensures the agent's MCP server dependencies are running.
+3. Orchestrator requests Runner to start an agent workload with thread ID, agent config, and MCP server endpoints.
+4. Agent connects to MCP servers over gRPC, subscribes to notifications, pulls messages, processes, responds, acknowledges.
 5. Agent waits for new messages (notification or poll fallback).
-6. The orchestrator monitors agent activity. When idle timeout is exceeded, it stops the workload via Runner.
+6. The Orchestrator monitors agent activity. When idle timeout is exceeded, it stops the agent workload. MCP server workloads are stopped when no agents reference them.
 
 ### Idle Timeout
 
-The **orchestrator** owns idle timeout enforcement. During each reconciliation pass, it checks running agent workloads against their last activity (last message on the thread). Agents that have been idle beyond the configured timeout are stopped via `Runner.StopWorkload`.
+The **Orchestrator** owns idle timeout enforcement. During each reconciliation pass, it checks running agent workloads against their last activity (last message on the thread). Agents that have been idle beyond the configured timeout are stopped via `Runner.StopWorkload`.
 
-The agent container does not implement idle detection. It may exit naturally (process completion, crash), but the orchestrator is the authority for lifecycle management.
+The agent container does not implement idle detection. It may exit naturally (process completion, crash), but the Orchestrator is the authority for lifecycle management.
 
 ### Scaling
 

--- a/architecture/agent/overview.md
+++ b/architecture/agent/overview.md
@@ -8,18 +8,17 @@ This document describes the agent contract: what an agent is, how it connects to
 
 ## Agent Contract
 
-Every agent, regardless of implementation, must satisfy the same contract:
+Every agent, regardless of implementation, must satisfy the same contract. The agent workload structure is defined in [Orchestrator — Agent Workload](../orchestrator.md#agent-workload).
 
 ```mermaid
 graph TB
-    subgraph "Agent Workload"
-        Impl[Agent Implementation<br/>our own / 3rd-party CLI / custom]
+    subgraph "Agent Workload (pod)"
+        Impl[Agent Implementation]
+        MCP1[MCP Sidecar 1]
+        MCP2[MCP Sidecar 2]
         Ziti[OpenZiti Tunnel]
-    end
-
-    subgraph "MCP Workloads (separate)"
-        MCP1[MCP Server 1<br/>adapter + server]
-        MCP2[MCP Server 2<br/>adapter + server]
+        Impl -->|gRPC| MCP1
+        Impl -->|gRPC| MCP2
     end
 
     subgraph Platform
@@ -29,8 +28,6 @@ graph TB
         Tracing
     end
 
-    Impl -->|gRPC over OpenZiti| MCP1
-    Impl -->|gRPC over OpenZiti| MCP2
     Impl -->|read/ack messages| Threads
     Impl -->|post responses| Threads
     Impl -->|resolve files| Files
@@ -46,10 +43,10 @@ graph TB
 | **Process** | Run implementation-specific logic (LLM calls, tool use, etc.) |
 | **Post responses** | Write response messages back to the thread via Threads API |
 | **Subscribe to notifications** | Listen for `message.created` events on `thread_participant:{agentId}` room |
-| **Use tools via MCP** | Call MCP servers over gRPC via [MCP Adapter](../mcp-adapter.md) |
+| **Use tools via MCP** | Call [MCP sidecars](../mcp-adapter.md) via gRPC |
 | **Report tracing** | Optionally emit tracing data |
 
-The agent is a **pure client** — it makes outbound connections to platform services and MCP servers. It does not expose any server or accept inbound connections.
+The agent is a **pure client** — it makes outbound connections to platform services. It does not expose any server or accept inbound connections.
 
 ## Communication Protocol
 
@@ -92,22 +89,20 @@ sequenceDiagram
 ### Design Principles
 
 - **Pull at defined loop stages.** The `whenBusy` configuration controls when mid-run messages are picked up: between turns (`wait`) or between tool calls (`injectAfterTools`). The notification wakes the agent, but the actual message read happens at the next check point in the LLM loop.
-- **No inbound connections.** The agent connects outbound to Notifications (gRPC subscribe stream), Threads (gRPC calls), Files (gRPC calls), and MCP servers (gRPC via OpenZiti). No server, no open port, no service discovery per agent.
+- **No inbound connections.** The agent connects outbound to Notifications (gRPC subscribe stream), Threads (gRPC calls), and Files (gRPC calls). No server, no open port, no service discovery per agent.
 
 ## Tools
 
-All tools are provided via **MCP protocol** (Model Context Protocol) through the [MCP Adapter](../mcp-adapter.md). The goal is to eliminate built-in tools entirely, making tools reusable across any agent implementation.
-
-Each MCP server runs as a **separate workload** with its own OpenZiti identity. The agent connects to MCP servers over gRPC via OpenZiti — the same network layer used for platform services.
+All tools are provided via **MCP protocol** (Model Context Protocol) through [MCP Adapter](../mcp-adapter.md) sidecars. The goal is to eliminate built-in tools entirely, making tools reusable across any agent implementation.
 
 | Aspect | Details |
 |--------|---------|
-| Agent-side transport | gRPC over OpenZiti |
-| MCP server-side transport | [MCP Adapter](../mcp-adapter.md) bridges gRPC ↔ stdio or Streamable HTTP |
+| Transport | gRPC (agent → adapter sidecar) |
+| Protocol bridge | [MCP Adapter](../mcp-adapter.md) bridges gRPC ↔ stdio or Streamable HTTP |
 | Namespacing | `<namespace>:<toolName>` to prevent collisions |
-| Server lifecycle | Managed by the [Orchestrator](../orchestrator.md), not the agent |
+| Resilience | Adapter handles heartbeat + restart with configurable backoff |
 
-MCP servers are defined as team resources (see [Teams](../teams.md)) and attached to agents via [attachments](../resource-definitions.md#attachment). The [Orchestrator](../orchestrator.md) starts MCP server workloads before the agent workload and passes MCP server gRPC endpoints to the agent as configuration.
+MCP servers are defined as team resources (see [Teams](../teams.md)) and attached to agents via [attachments](../resource-definitions.md#attachment). The [Agents Orchestrator](../orchestrator.md) includes them as sidecars when assembling the workload.
 
 ## Wrapper Model
 
@@ -117,17 +112,17 @@ Most 3rd-party agents are implemented as CLIs. The platform provides a **wrapper
 sequenceDiagram
     participant W as Wrapper
     participant CLI as Agent CLI
-    participant MCP as MCP Servers (gRPC)
+    participant MCP as MCP Sidecars
     participant T as Threads
     participant N as Notifications
 
     W->>N: Subscribe to thread_participant:{agentId} room
     W->>CLI: Start process with config
-    W->>MCP: Connect to MCP servers via gRPC
+    W->>MCP: Connect via gRPC
     W->>CLI: Connect MCP servers
     W->>T: GetUnackedMessages(agentId)
     W->>CLI: Feed messages
-    CLI->>MCP: Tool calls (gRPC)
+    CLI->>MCP: Tool calls
     MCP-->>CLI: Tool results
     CLI-->>W: Output
     W->>T: Post response to thread
@@ -141,7 +136,7 @@ sequenceDiagram
 The wrapper:
 1. Subscribes to notifications for the agent's participant room.
 2. Starts the agent CLI process with configuration.
-3. Connects to MCP servers via gRPC (endpoints provided by the Orchestrator).
+3. Connects to MCP sidecars via gRPC.
 4. Pulls unacknowledged messages from Threads and feeds them to the CLI.
 5. Collects CLI output and posts responses to the thread.
 6. Acknowledges processed messages via `AckMessages`.
@@ -149,46 +144,33 @@ The wrapper:
 
 ## Lifecycle
 
-The [Orchestrator](../orchestrator.md) manages the full agent workload lifecycle — starting containers when demand exists, stopping them when idle. This section summarizes the lifecycle from the agent's perspective.
+The [Agents Orchestrator](../orchestrator.md) manages the full workload lifecycle — starting pods when demand exists, stopping them when idle.
 
 ```mermaid
 sequenceDiagram
     participant T as Threads
-    participant O as Orchestrator
+    participant O as Agents Orchestrator
     participant R as Runner
-    participant M as MCP Server Workloads
     participant A as Agent Workload
 
     T->>O: Unacknowledged messages (reconciliation loop)
-    O->>R: Start MCP server workloads
-    R->>M: Create MCP containers
-    Note over M: MCP servers ready
-    O->>R: StartWorkload (agent)
-    R->>A: Create agent container
-    A->>M: Connect to MCP servers (gRPC)
+    O->>R: StartWorkload
+    R->>A: Create pod
+    Note over A: Sidecars start, agent starts
     A->>A: Subscribe, pull, process, ack
     A->>T: Post response
 
     Note over A,O: Agent idle, waiting for messages
     O->>O: Activity check (reconciliation loop)
     Note over O: Idle timeout exceeded
-    O->>R: StopWorkload (agent)
-    Note over O: No agents reference MCP servers
-    O->>R: StopWorkload (MCP servers)
+    O->>R: StopWorkload
 ```
-
-1. The Orchestrator's reconciliation loop detects threads with unacknowledged messages for agent participants.
-2. Orchestrator ensures the agent's MCP server dependencies are running.
-3. Orchestrator requests Runner to start an agent workload with thread ID, agent config, and MCP server endpoints.
-4. Agent connects to MCP servers over gRPC, subscribes to notifications, pulls messages, processes, responds, acknowledges.
-5. Agent waits for new messages (notification or poll fallback).
-6. The Orchestrator monitors agent activity. When idle timeout is exceeded, it stops the agent workload. MCP server workloads are stopped when no agents reference them.
 
 ### Idle Timeout
 
-The **Orchestrator** owns idle timeout enforcement. During each reconciliation pass, it checks running agent workloads against their last activity (last message on the thread). Agents that have been idle beyond the configured timeout are stopped via `Runner.StopWorkload`.
+The **orchestrator** owns idle timeout enforcement. During each reconciliation pass, it checks running agent workloads against their last activity (last message on the thread). Agents that have been idle beyond the configured timeout are stopped via `Runner.StopWorkload`.
 
-The agent container does not implement idle detection. It may exit naturally (process completion, crash), but the Orchestrator is the authority for lifecycle management.
+The agent container does not implement idle detection. It may exit naturally (process completion, crash), but the orchestrator is the authority for lifecycle management.
 
 ### Scaling
 

--- a/architecture/agent/overview.md
+++ b/architecture/agent/overview.md
@@ -141,6 +141,8 @@ The wrapper:
 
 ## Lifecycle
 
+The [Agents Orchestrator](../orchestrator.md) manages the full agent workload lifecycle — starting containers when demand exists, stopping them when idle. This section summarizes the lifecycle from the agent's perspective.
+
 ```mermaid
 sequenceDiagram
     participant T as Threads

--- a/architecture/authn.md
+++ b/architecture/authn.md
@@ -60,7 +60,7 @@ The OIDC provider is configured system-wide (not per-tenant):
 
 ## Network Identity (OpenZiti)
 
-Agents, Channels, Runners, and the Agents Orchestrator authenticate via **OpenZiti** network-level identity. Each receives a unique x509 certificate from the OpenZiti Controller. All API communication uses mTLS over the OpenZiti overlay — the identity is in the certificate, not in application-level tokens.
+Agents, MCP servers, Channels, and Runners authenticate via **OpenZiti** network-level identity. Each receives a unique x509 certificate from the OpenZiti Controller. All API communication uses mTLS over the OpenZiti overlay — the identity is in the certificate, not in application-level tokens.
 
 ### Enrollment
 
@@ -93,7 +93,7 @@ Agent containers are short-lived. Their OpenZiti identities are created and dest
 
 ```mermaid
 sequenceDiagram
-    participant O as Agents Orchestrator
+    participant O as Orchestrator
     participant R as Runner
     participant ZC as OpenZiti Controller
     participant A as Agent Container
@@ -120,7 +120,7 @@ sequenceDiagram
 
 | Identity | Lifecycle | Calls via OpenZiti |
 |----------|-----------|--------------------|
-| Agents Orchestrator | Persistent (enrolled once) | Runner |
+| Orchestrator | Persistent (enrolled once) | Runner |
 | Runner | Persistent (enrolled via service token) | OpenZiti Controller (identity management) |
 | Agent container | Ephemeral (per container) | Gateway |
 | Channel | Persistent (enrolled via service token) | Gateway |
@@ -149,7 +149,7 @@ graph TB
         end
 
         subgraph Istio + OpenZiti
-            Orch[Agents Orchestrator]
+            Orch[Orchestrator]
             IntRunner[Internal Runner]
         end
 

--- a/architecture/authn.md
+++ b/architecture/authn.md
@@ -60,7 +60,7 @@ The OIDC provider is configured system-wide (not per-tenant):
 
 ## Network Identity (OpenZiti)
 
-Agents, MCP servers, Channels, and Runners authenticate via **OpenZiti** network-level identity. Each receives a unique x509 certificate from the OpenZiti Controller. All API communication uses mTLS over the OpenZiti overlay — the identity is in the certificate, not in application-level tokens.
+Agents, Channels, and Runners authenticate via **OpenZiti** network-level identity. Each receives a unique x509 certificate from the OpenZiti Controller. All API communication uses mTLS over the OpenZiti overlay — the identity is in the certificate, not in application-level tokens.
 
 ### Enrollment
 
@@ -89,31 +89,32 @@ sequenceDiagram
 
 ### Agent Identity Lifecycle
 
-Agent containers are short-lived. Their OpenZiti identities are created and destroyed with the container.
+Agent workloads are short-lived. Each receives an OpenZiti identity scoped to `agentId + threadId`. MCP server sidecars share this identity.
 
 ```mermaid
 sequenceDiagram
-    participant O as Orchestrator
+    participant O as Agents Orchestrator
     participant R as Runner
     participant ZC as OpenZiti Controller
-    participant A as Agent Container
+    participant A as Agent Workload (agent + MCP sidecars)
 
     O->>R: StartWorkload (via OpenZiti)
-    R->>ZC: Create identity for agent
+    R->>ZC: Create identity (agentId + threadId)
     ZC->>R: Enrollment JWT
-    R->>A: Start container with enrollment JWT
+    R->>A: Start pod with enrollment JWT
     A->>ZC: Enroll (exchange JWT for x509 cert)
-    A->>A: Call platform APIs via OpenZiti mTLS
+    A->>A: Agent calls platform APIs via OpenZiti mTLS
+    A->>A: Agent calls MCP sidecars via gRPC
 
     Note over O: Idle timeout exceeded
     O->>R: StopWorkload (via OpenZiti)
-    R->>A: Stop container
+    R->>A: Stop pod
     R->>ZC: Delete agent identity
 ```
 
-1. Runner requests an OpenZiti identity for the agent before starting the container.
+1. Runner requests an OpenZiti identity for the agent workload.
 2. Agent container enrolls on startup, receiving an x509 certificate.
-3. All API calls from the agent use mTLS. The Gateway extracts identity from the client certificate.
+3. All API calls from the agent use mTLS via the OpenZiti sidecar. The Gateway extracts identity from the client certificate.
 4. When Runner stops the workload, it deletes the OpenZiti identity. The certificate becomes invalid.
 
 ### OpenZiti Identities
@@ -122,7 +123,7 @@ sequenceDiagram
 |----------|-----------|--------------------|
 | Orchestrator | Persistent (enrolled once) | Runner |
 | Runner | Persistent (enrolled via service token) | OpenZiti Controller (identity management) |
-| Agent container | Ephemeral (per container) | Gateway |
+| Agent workload | Ephemeral (per agentId + threadId) | Gateway |
 | Channel | Persistent (enrolled via service token) | Gateway |
 
 ## Two Network Layers

--- a/architecture/control-data-plane.md
+++ b/architecture/control-data-plane.md
@@ -49,7 +49,7 @@ graph LR
 | Service | Plane | Rationale |
 |---------|-------|-----------|
 | **Teams** | Control | Manages desired state of team resources (agent definitions, MCP server configs, workspace configs) |
-| **Agents orchestrator** | Control | Decides which agent workloads should exist; reconciles agent lifecycle |
+| **[Agents Orchestrator](orchestrator.md)** | Control | Reconciles agent workloads: starts containers for threads with unacknowledged agent messages, stops idle agents |
 | **Channels** (configuration) | Control | Defines channel desired state (credentials, target IDs, routing rules) |
 | **Channels** (connection) | Data | Maintains live connections to 3rd-party APIs, translates messages |
 | **Threads** | Data | Carries conversation messages between participants |

--- a/architecture/control-data-plane.md
+++ b/architecture/control-data-plane.md
@@ -22,7 +22,7 @@
 graph LR
     subgraph Control Plane
         Teams
-        AgentsOrch[Agents Orchestrator]
+        Orch[Orchestrator]
     end
 
     subgraph Data Plane
@@ -41,15 +41,15 @@ graph LR
         Authorization
     end
 
-    Teams -->|desired state| AgentsOrch
-    AgentsOrch -->|schedule workloads| Runner
-    AgentsOrch -->|read pending messages| Threads
+    Teams -->|desired state| Orch
+    Orch -->|schedule workloads| Runner
+    Orch -->|read pending messages| Threads
 ```
 
 | Service | Plane | Rationale |
 |---------|-------|-----------|
 | **Teams** | Control | Manages desired state of team resources (agent definitions, MCP server configs, workspace configs) |
-| **[Agents Orchestrator](orchestrator.md)** | Control | Reconciles agent workloads: starts containers for threads with unacknowledged agent messages, stops idle agents |
+| **[Orchestrator](orchestrator.md)** | Control | Reconciles all workloads: agents, MCP servers, and discovery signals. Starts MCP server dependencies before agents, stops idle workloads |
 | **Channels** (configuration) | Control | Defines channel desired state (credentials, target IDs, routing rules) |
 | **Channels** (connection) | Data | Maintains live connections to 3rd-party APIs, translates messages |
 | **Threads** | Data | Carries conversation messages between participants |
@@ -88,5 +88,5 @@ graph LR
 
 **Resources to reconcile:**
 - **Agents** — Ensure agent workloads exist for threads with pending messages; remove idle agents.
+- **MCP Servers** — Ensure MCP server workloads are running for agents that need them; manage discovery signals with TTL.
 - **Channels** — Ensure channel connections match their configuration (reconnect on credential rotation).
-- **Workspaces** — Ensure workspace containers match desired image/config; enforce TTL.

--- a/architecture/control-data-plane.md
+++ b/architecture/control-data-plane.md
@@ -22,7 +22,7 @@
 graph LR
     subgraph Control Plane
         Teams
-        Orch[Orchestrator]
+        Orch[Agents Orchestrator]
     end
 
     subgraph Data Plane
@@ -42,14 +42,14 @@ graph LR
     end
 
     Teams -->|desired state| Orch
-    Orch -->|schedule workloads| Runner
+    Orch -->|schedule agent workloads| Runner
     Orch -->|read pending messages| Threads
 ```
 
 | Service | Plane | Rationale |
 |---------|-------|-----------|
 | **Teams** | Control | Manages desired state of team resources (agent definitions, MCP server configs, workspace configs) |
-| **[Orchestrator](orchestrator.md)** | Control | Reconciles all workloads: agents, MCP servers, and discovery signals. Starts MCP server dependencies before agents, stops idle workloads |
+| **[Agents Orchestrator](orchestrator.md)** | Control | Reconciles [agent workloads](orchestrator.md#agent-workload). Starts pods when threads have unacked agent messages, stops idle agents |
 | **Channels** (configuration) | Control | Defines channel desired state (credentials, target IDs, routing rules) |
 | **Channels** (connection) | Data | Maintains live connections to 3rd-party APIs, translates messages |
 | **Threads** | Data | Carries conversation messages between participants |
@@ -87,6 +87,5 @@ graph LR
 - Optional: subscribe to Notifications events for faster reactivity; the polling loop serves as consistency fallback.
 
 **Resources to reconcile:**
-- **Agents** — Ensure agent workloads exist for threads with pending messages; remove idle agents.
-- **MCP Servers** — Ensure MCP server workloads are running for agents that need them; manage discovery signals with TTL.
+- **Agents** — Ensure [agent workloads](orchestrator.md#agent-workload) exist for threads with pending messages; remove idle agents.
 - **Channels** — Ensure channel connections match their configuration (reconnect on credential rotation).

--- a/architecture/mcp-adapter.md
+++ b/architecture/mcp-adapter.md
@@ -1,0 +1,88 @@
+# MCP Adapter
+
+## Overview
+
+The MCP Adapter is a standalone binary that wraps any MCP server and exposes a uniform gRPC interface. It is the entrypoint of every MCP server workload.
+
+The adapter handles the protocol translation between the MCP server's native transport (stdio or Streamable HTTP) and the gRPC interface that agents consume over [OpenZiti](authn.md). Agents never interact with MCP servers directly — they always talk gRPC to the adapter.
+
+## Architecture
+
+```
+MCP Workload
+├── Main container
+│   ├── MCP Adapter binary (entrypoint)
+│   │   ├── gRPC server (external, over OpenZiti)
+│   │   └── MCP client (local, stdio or HTTP)
+│   └── MCP server process (launched by adapter)
+└── Sidecar: OpenZiti tunnel
+```
+
+The adapter is added to any MCP server image and used as the container entrypoint. The MCP server image provides the runtime and dependencies (Node.js, Python, etc.). The adapter binary is a static executable with no runtime dependencies.
+
+## Transport Modes
+
+The adapter supports two modes, matching the two standard MCP transports.
+
+### stdio Mode
+
+The adapter launches the MCP server as a subprocess and communicates via stdin/stdout (newline-delimited JSON-RPC 2.0).
+
+```
+adapter --mode stdio --command "npx best-mcp-server" --grpc-port 50051
+```
+
+This supports the majority of existing MCP servers, which are distributed via package managers (`npx`, `uvx`, `pip`, etc.) and implement only the stdio transport.
+
+### HTTP Mode
+
+The adapter launches the MCP server as a subprocess and connects to it via Streamable HTTP (HTTP POST/GET + optional SSE) on a local port.
+
+```
+adapter --mode http --command "uvx some-mcp --port 8080" --http-port 8080 --grpc-port 50051
+```
+
+The adapter waits for the MCP server to become ready on the specified port before accepting gRPC connections.
+
+## Lifecycle
+
+The adapter owns the MCP server process lifecycle:
+
+1. **Start** — launch the MCP server subprocess with the configured command.
+2. **Initialize** — perform the MCP `initialize` handshake (capability exchange).
+3. **Ready** — begin accepting gRPC connections from agents.
+4. **Health check** — periodic heartbeat to detect MCP server failures.
+5. **Restart** — if the MCP server process dies, restart it with configurable backoff.
+6. **Shutdown** — on SIGTERM, gracefully stop the MCP server process and drain gRPC connections.
+
+## gRPC Interface
+
+The adapter exposes a gRPC service that mirrors the MCP protocol operations. Agents call these RPCs over OpenZiti.
+
+The gRPC proto is defined in `agynio/api`. Key operations:
+
+| RPC | MCP Method | Description |
+|-----|-----------|-------------|
+| `ListTools` | `tools/list` | List available tools |
+| `CallTool` | `tools/call` | Execute a tool and return the result |
+| `ListResources` | `resources/list` | List available resources |
+| `ReadResource` | `resources/read` | Read a resource |
+| `ListPrompts` | `prompts/list` | List available prompts |
+| `GetPrompt` | `prompts/get` | Get a prompt |
+
+The adapter translates between gRPC request/response types and MCP JSON-RPC messages. Streaming tool results are supported via server-streaming RPCs.
+
+## Configuration
+
+The adapter is configured entirely via command-line flags and environment variables. No config files.
+
+| Flag | Env | Required | Description |
+|------|-----|----------|-------------|
+| `--mode` | `MCP_ADAPTER_MODE` | Yes | `stdio` or `http` |
+| `--command` | `MCP_ADAPTER_COMMAND` | Yes | Shell command to launch the MCP server |
+| `--grpc-port` | `MCP_ADAPTER_GRPC_PORT` | Yes | Port for the gRPC server |
+| `--http-port` | `MCP_ADAPTER_HTTP_PORT` | No (http mode) | Port the MCP server listens on (http mode only) |
+| `--startup-timeout` | `MCP_ADAPTER_STARTUP_TIMEOUT` | No | Max time to wait for MCP server readiness |
+| `--restart-max-attempts` | `MCP_ADAPTER_RESTART_MAX_ATTEMPTS` | No | Max restart attempts on failure |
+| `--restart-backoff` | `MCP_ADAPTER_RESTART_BACKOFF` | No | Base backoff between restarts |
+| `--heartbeat-interval` | `MCP_ADAPTER_HEARTBEAT_INTERVAL` | No | Heartbeat interval for health checks |

--- a/architecture/mcp-adapter.md
+++ b/architecture/mcp-adapter.md
@@ -2,20 +2,18 @@
 
 ## Overview
 
-The MCP Adapter is a standalone binary that wraps any MCP server and exposes a uniform gRPC interface. It is the entrypoint of every MCP server workload.
+The MCP Adapter is a standalone binary that wraps any MCP server and exposes a uniform gRPC interface. It runs as the entrypoint of each MCP server sidecar within an [agent workload](orchestrator.md#agent-workload).
 
-The adapter handles the protocol translation between the MCP server's native transport (stdio or Streamable HTTP) and the gRPC interface that agents consume over [OpenZiti](authn.md). Agents never interact with MCP servers directly — they always talk gRPC to the adapter.
+The adapter translates between the MCP server's native transport (stdio or Streamable HTTP) and gRPC.
 
 ## Architecture
 
 ```
-MCP Workload
-├── Main container
-│   ├── MCP Adapter binary (entrypoint)
-│   │   ├── gRPC server (external, over OpenZiti)
-│   │   └── MCP client (local, stdio or HTTP)
-│   └── MCP server process (launched by adapter)
-└── Sidecar: OpenZiti tunnel
+MCP Server Sidecar (one per MCP server in the pod)
+├── MCP Adapter binary (entrypoint)
+│   ├── gRPC server (port N)
+│   └── MCP client (stdio or HTTP to subprocess)
+└── MCP server process (launched by adapter)
 ```
 
 The adapter is added to any MCP server image and used as the container entrypoint. The MCP server image provides the runtime and dependencies (Node.js, Python, etc.). The adapter binary is a static executable with no runtime dependencies.
@@ -50,14 +48,12 @@ The adapter owns the MCP server process lifecycle:
 
 1. **Start** — launch the MCP server subprocess with the configured command.
 2. **Initialize** — perform the MCP `initialize` handshake (capability exchange).
-3. **Ready** — begin accepting gRPC connections from agents.
+3. **Ready** — begin accepting gRPC connections.
 4. **Health check** — periodic heartbeat to detect MCP server failures.
 5. **Restart** — if the MCP server process dies, restart it with configurable backoff.
 6. **Shutdown** — on SIGTERM, gracefully stop the MCP server process and drain gRPC connections.
 
 ## gRPC Interface
-
-The adapter exposes a gRPC service that mirrors the MCP protocol operations. Agents call these RPCs over OpenZiti.
 
 The gRPC proto is defined in `agynio/api`. Key operations:
 
@@ -70,7 +66,7 @@ The gRPC proto is defined in `agynio/api`. Key operations:
 | `ListPrompts` | `prompts/list` | List available prompts |
 | `GetPrompt` | `prompts/get` | Get a prompt |
 
-The adapter translates between gRPC request/response types and MCP JSON-RPC messages. Streaming tool results are supported via server-streaming RPCs.
+Streaming tool results are supported via server-streaming RPCs.
 
 ## Configuration
 

--- a/architecture/notifications.md
+++ b/architecture/notifications.md
@@ -83,6 +83,8 @@ Rooms are scoped by resource type and ID:
 | `thread_participant:{id}` | `thread_participant:550e8400-...` | Threads → message recipients (agents, channels, users) |
 | `workload:{id}` | `workload:7c9e6679-...` | Runner → workload status changes, log events |
 | `agent:{id}` | `agent:f47ac10b-...` | Teams → agent resource updates |
+| `threads:messages:new` | `threads:messages:new` | Threads → broadcast on every new message. Consumed by Orchestrator |
+| `runner:workloads:status` | `runner:workloads:status` | Runner → broadcast on workload state transitions. Consumed by Orchestrator |
 
 Consumers subscribe to rooms matching their identity or the resources they observe. A channel subscribes to `thread_participant:{channelId}`. A UI client displaying agent logs subscribes to `workload:{workloadId}`.
 

--- a/architecture/orchestrator.md
+++ b/architecture/orchestrator.md
@@ -1,0 +1,161 @@
+# Agents Orchestrator
+
+## Overview
+
+The Agents Orchestrator decides which agent workloads should be running and reconciles actual state toward that goal. It is the **only service** that starts and stops agent containers.
+
+The orchestrator is a **control plane** service. It does not touch messages, proxy traffic, or hold user-facing connections. It observes demand (threads with unacknowledged messages for agent participants) and supply (running workloads), computes the diff, and acts through the [Runner](runner.md).
+
+## Reconciliation
+
+The orchestrator runs a periodic reconciliation loop backed by PostgreSQL (see [Reconciliation Approach](control-data-plane.md#reconciliation-approach)).
+
+Each pass computes a diff between demand and supply, then acts on the result:
+
+| Outcome | Condition | Action |
+|---------|-----------|--------|
+| **Start** | Thread has unacked messages for an agent participant, no workload running | `StartWorkload` via Runner |
+| **Keep** | Thread has unacked messages, workload running | No action |
+| **Stop** | No unacked messages, workload idle beyond timeout | `StopWorkload` via Runner |
+| **Restart** | Demand exists, workload in failed/stopped state | `StartWorkload` via Runner |
+
+```mermaid
+graph LR
+    subgraph Inputs
+        Demand[Demand<br/>Threads with unacked agent messages]
+        Supply[Supply<br/>Running workloads]
+    end
+
+    Orch[Reconciliation Loop]
+    Runner[Runner]
+
+    Demand --> Orch
+    Supply --> Orch
+    Orch -->|StartWorkload / StopWorkload| Runner
+```
+
+### Demand: Threads with Unacked Agent Messages
+
+The orchestrator needs to know which threads have unacknowledged messages for agent participants.
+
+[Threads](threads.md) is participant-type-agnostic — it does not distinguish agents from users. The orchestrator maintains the set of agent identity IDs (received from the identity lifecycle — see [Workload Assembly](#workload-assembly)). It queries Threads for unacked messages scoped to those IDs.
+
+**Interface:** `GetParticipantsWithUnackedMessages(participant_ids: []UUID) → []{participant_id, thread_id}`. Returns the set of (participant, thread) pairs that have at least one unacknowledged message. This is a bulk query — the orchestrator passes all known agent identity IDs and gets back the full demand set in one call.
+
+**Sync mechanism:** Pull + Notifications ([Consumer Sync Protocol](notifications.md#consumer-sync-protocol)).
+
+- **Pull:** Each reconciliation pass calls `GetParticipantsWithUnackedMessages` as the source of truth.
+- **Notifications:** The orchestrator subscribes to the `threads:messages:new` room. Threads publishes to this room on every `SendMessage`. The notification wakes the orchestrator to run a reconciliation pass sooner rather than waiting for the next timer tick.
+
+The notification reduces the latency between a user sending a message and the orchestrator starting an agent workload. The pull ensures correctness — notifications are fire-and-forget and may be lost.
+
+### Supply: Running Workloads
+
+The orchestrator maintains a synchronized view of workloads managed by the Runner.
+
+**Sync mechanism:** Pull + Notifications ([Consumer Sync Protocol](notifications.md#consumer-sync-protocol)).
+
+- **Pull:** The orchestrator queries the Runner for all workloads matching orchestrator-managed labels (e.g., `managed-by=orchestrator`). This returns the full supply set.
+- **Notifications:** The orchestrator subscribes to the `runner:workloads:status` room. Runner publishes to this room on workload state transitions (started, stopped, failed). The notification triggers an immediate reconciliation pass.
+
+The orchestrator maintains an in-memory supply map updated by both pull results and notification events. The periodic pull re-syncs the full state and corrects any drift.
+
+## State
+
+The orchestrator tracks workload assignments in PostgreSQL:
+
+| Column | Type | Description |
+|--------|------|-------------|
+| `id` | UUID | Primary key |
+| `agent_identity_id` | UUID | The agent's platform identity |
+| `thread_id` | UUID | Thread being served |
+| `runner_workload_id` | string | Workload ID returned by Runner (null while pending) |
+| `status` | enum | `pending`, `starting`, `running`, `stopping`, `stopped`, `failed` |
+| `last_activity_at` | timestamp | Last message timestamp on the thread |
+| `created_at` | timestamp | When assignment was created |
+| `updated_at` | timestamp | Last status change |
+| `tenant_id` | UUID | Tenant scope |
+
+This table makes the reconciliation loop idempotent. If the orchestrator crashes mid-loop, it restarts and diffs again — assignments in `pending` or `starting` states are reconciled against actual Runner state.
+
+### Status Transitions
+
+```mermaid
+stateDiagram-v2
+    [*] --> pending: Demand detected
+    pending --> starting: StartWorkload issued
+    starting --> running: Runner confirms workload running
+    starting --> failed: StartWorkload error
+    running --> stopping: Idle timeout exceeded
+    running --> failed: Workload crashed (Runner notification)
+    stopping --> stopped: Runner confirms workload stopped
+    failed --> starting: Demand still exists (retry)
+    stopped --> [*]
+```
+
+## Workload Assembly
+
+When starting an agent workload, the orchestrator assembles the full `StartWorkloadRequest` for the Runner:
+
+1. **Resolve agent config** from [Teams](teams.md) — image, model, system prompt, behavior settings, attached MCP servers, workspace configuration.
+2. **Build container specs** — main agent container + MCP server sidecars + workspace volumes.
+3. **Provision identity** — request an [OpenZiti identity](authn.md) for the agent container. The identity is created before the container starts and deleted when the container stops.
+4. **Inject configuration** — thread ID, agent identity, platform service endpoints, OpenZiti enrollment token — passed as environment variables or mounted config.
+
+The orchestrator does not fetch the full agent config on every reconciliation pass. Config is fetched when starting a new workload. For running workloads, config changes are not hot-reloaded — the agent runs with the config it was started with.
+
+## Idle Timeout
+
+The orchestrator owns idle timeout enforcement. During each reconciliation pass, it checks `last_activity_at` for running workloads against the configured timeout. If the timeout is exceeded and no unacknowledged messages remain for the agent participant, the orchestrator stops the workload via `Runner.StopWorkload`.
+
+`last_activity_at` is derived from the demand query — if a thread has unacked messages, the agent is not idle. The absence of the agent's identity from the demand result, combined with elapsed time since the last demand was observed, determines idleness.
+
+The agent container does not implement idle detection. It may exit naturally (process completion, crash), but the orchestrator is the authority for lifecycle management.
+
+## Failure Handling
+
+| Failure | Behavior |
+|---------|----------|
+| `StartWorkload` fails | Assignment marked `failed`. Retried on next reconciliation pass if demand still exists |
+| Agent container crashes | Runner publishes workload status change. Orchestrator detects demand without supply on next pass → restarts |
+| Runner unreachable | Orchestrator cannot confirm supply. Logs error, retries next pass. Running agents continue independently (they communicate with Threads/Notifications directly) |
+| Orchestrator crashes | Restarts, loads assignments from PostgreSQL, queries Runner for actual state, reconciles the diff |
+
+## Notification Rooms
+
+The orchestrator introduces two source-oriented notification rooms:
+
+| Room | Publisher | Event | Subscriber |
+|------|-----------|-------|------------|
+| `threads:messages:new` | Threads | New message sent | Orchestrator (+ any future consumer needing message-level events) |
+| `runner:workloads:status` | Runner | Workload state transition | Orchestrator (+ any future consumer needing workload lifecycle events) |
+
+These rooms are **broadcast topics** — any consumer interested in the event type can subscribe. They complement the existing per-recipient rooms (`thread_participant:{id}`, `workload:{id}`) which serve individual consumers.
+
+## Interactions
+
+```mermaid
+graph TB
+    subgraph Control Plane
+        Orch[Agents Orchestrator]
+        Teams[Teams]
+    end
+
+    subgraph Data Plane
+        Threads[Threads]
+        Runner[Runner]
+        Notif[Notifications]
+    end
+
+    DB[(PostgreSQL<br/>workload_assignments)]
+
+    Teams -->|agent config| Orch
+    Threads -->|unacked agent messages| Orch
+    Runner -->|workload state| Orch
+    Notif -->|threads:messages:new| Orch
+    Notif -->|runner:workloads:status| Orch
+    Orch -->|StartWorkload / StopWorkload| Runner
+    Orch --> DB
+```
+
+The orchestrator reads from Threads, Teams, and Runner. It writes only to Runner (start/stop) and its own PostgreSQL database. It does not write messages, manage configs, or hold any user-facing connections.

--- a/architecture/orchestrator.md
+++ b/architecture/orchestrator.md
@@ -1,161 +1,96 @@
-# Orchestrator
+# Agents Orchestrator
 
 ## Overview
 
-The Orchestrator decides which workloads should be running and reconciles actual state toward that goal. It is the **only service** that starts and stops workloads through the [Runner](runner.md).
+The Agents Orchestrator decides which agent workloads should be running and reconciles actual state toward that goal. It is the **only service** that starts and stops agent containers.
 
-The Orchestrator is a **control plane** service. It does not touch messages, proxy traffic, or hold user-facing connections. It observes demand, compares it against running supply, computes the diff, and acts.
+The orchestrator is a **control plane** service. It does not touch messages, proxy traffic, or hold user-facing connections. It observes demand (threads with unacknowledged messages for agent participants) and supply (running workloads), computes the diff, and acts through the [Runner](runner.md).
 
-## Workload Types
+## Agent Workload
 
-The Orchestrator manages multiple workload types. Each type has its own demand source, but all share the same reconciliation pattern and Runner interface.
-
-| Workload Type | Demand Source | Lifetime | Identity |
-|---------------|--------------|----------|----------|
-| **Agent** | Threads with unacked messages for agent participants | Until idle timeout or thread completes | Own [OpenZiti identity](authn.md) |
-| **MCP Server** | Agent config references MCP server; or discovery signal | While referencing agents are running; or until discovery TTL expires | Own [OpenZiti identity](authn.md) |
-
-Each workload is a separate Runner unit with its own OpenZiti network identity. Agents and MCP servers are **never co-located in the same workload** — they communicate over the network via gRPC (see [MCP Adapter](mcp-adapter.md)).
-
-### Agent Workloads
-
-An agent workload runs the agent process. Its demand comes from [Threads](threads.md) — specifically, threads with unacknowledged messages for agent participants.
+An agent workload is a single pod. All containers share the network namespace and filesystem volumes.
 
 ```
-Agent Workload
+Agent Workload (pod)
 ├── Main container: agent image (our implementation or wrapped 3rd-party CLI)
-└── Sidecar: OpenZiti tunnel (network identity)
+├── Sidecar: MCP server A (adapter + server process, port 50051)
+├── Sidecar: MCP server B (adapter + server process, port 50052)
+└── Sidecar: OpenZiti tunnel
 ```
 
-### MCP Server Workloads
-
-An MCP server workload runs an MCP server behind the [MCP Adapter](mcp-adapter.md). The adapter is the container entrypoint — it launches the MCP server process, bridges its native transport (stdio or HTTP) to gRPC, and exposes a uniform gRPC interface over OpenZiti.
-
-```
-MCP Workload
-├── Main container: MCP server image + adapter binary (entrypoint)
-│   adapter --mode stdio --command "npx best-mcp-server" --grpc-port 50051
-│   adapter --mode http  --command "uvx some-mcp --port 8080" --http-port 8080 --grpc-port 50051
-└── Sidecar: OpenZiti tunnel (network identity)
-```
-
-MCP servers are separate workloads (not sidecars of the agent) because:
-- Each workload has its own OpenZiti identity with independently scoped network access.
-- An MCP server may be shared across multiple agents (singleton pattern).
-- An MCP server may require different resources than the agent (e.g., GPU).
+The workload [identity](authn.md#agent-identity-lifecycle) is scoped to `agentId + threadId`. Each [MCP sidecar](mcp-adapter.md) launches its MCP server process and exposes gRPC.
 
 ## Reconciliation
 
-The Orchestrator runs a periodic reconciliation loop backed by PostgreSQL (see [Reconciliation Approach](control-data-plane.md#reconciliation)).
+The orchestrator runs a periodic reconciliation loop backed by PostgreSQL (see [Reconciliation Approach](control-data-plane.md#reconciliation)).
 
-Each pass computes a diff between demand and supply per workload type, then acts on the result:
+Each pass computes a diff between demand and supply, then acts on the result:
 
 | Outcome | Condition | Action |
 |---------|-----------|--------|
-| **Start** | Demand exists, no workload running | `StartWorkload` via Runner |
-| **Keep** | Demand exists, workload running | No action |
-| **Stop** | No demand, workload idle beyond timeout | `StopWorkload` via Runner |
+| **Start** | Thread has unacked messages for an agent participant, no workload running | `StartWorkload` via Runner |
+| **Keep** | Thread has unacked messages, workload running | No action |
+| **Stop** | No unacked messages, workload idle beyond timeout | `StopWorkload` via Runner |
 | **Restart** | Demand exists, workload in failed/stopped state | `StartWorkload` via Runner |
-
-### Dependency Ordering
-
-When an agent references MCP servers, the Orchestrator starts MCP server workloads first and waits for them to become ready before starting the agent workload. On shutdown, the agent workload is stopped first; MCP server workloads are stopped when no agents reference them.
 
 ```mermaid
 graph LR
-    subgraph Demand
-        TD[Thread demand<br/>unacked agent messages]
-        AC[Agent config<br/>MCP references]
-        DS[Discovery signals<br/>short TTL]
+    subgraph Inputs
+        Demand[Demand<br/>Threads with unacked agent messages]
+        Supply[Supply<br/>Running workloads]
     end
 
     Orch[Reconciliation Loop]
-
-    subgraph Supply
-        RA[Agent workloads]
-        RM[MCP workloads]
-    end
-
     Runner[Runner]
 
-    TD --> Orch
-    AC --> Orch
-    DS --> Orch
-    Orch --> RA & RM
-    RA & RM -->|actual state| Orch
+    Demand --> Orch
+    Supply --> Orch
     Orch -->|StartWorkload / StopWorkload| Runner
 ```
 
-### Agent Demand
+### Demand: Threads with Unacked Agent Messages
 
-The Orchestrator needs to know which threads have unacknowledged messages for agent participants.
+The orchestrator needs to know which threads have unacknowledged messages for agent participants.
 
-[Threads](threads.md) is participant-type-agnostic — it does not distinguish agents from users. The Orchestrator maintains the set of agent identity IDs (from agent workload lifecycle). It queries Threads for unacked messages scoped to those IDs.
+[Threads](threads.md) is participant-type-agnostic — it does not distinguish agents from users. The orchestrator maintains the set of agent identity IDs (received from the identity lifecycle — see [Workload Assembly](#workload-assembly)). It queries Threads for unacked messages scoped to those IDs.
 
-**Interface:** `GetParticipantsWithUnackedMessages(participant_ids: []UUID) → []{participant_id, thread_id}`. Returns (participant, thread) pairs that have at least one unacknowledged message. Bulk query — the Orchestrator passes all known agent identity IDs and gets back the full demand set in one call.
+**Interface:** `GetParticipantsWithUnackedMessages(participant_ids: []UUID) → []{participant_id, thread_id}`. Returns the set of (participant, thread) pairs that have at least one unacknowledged message. This is a bulk query — the orchestrator passes all known agent identity IDs and gets back the full demand set in one call.
 
 **Sync mechanism:** Pull + Notifications ([Consumer Sync Protocol](notifications.md#consumer-sync-protocol)).
 
 - **Pull:** Each reconciliation pass calls `GetParticipantsWithUnackedMessages` as the source of truth.
-- **Notifications:** The Orchestrator subscribes to the `threads:messages:new` room. Threads publishes to this room on every `SendMessage`. The notification wakes the Orchestrator to run a reconciliation pass immediately rather than waiting for the next timer tick.
+- **Notifications:** The orchestrator subscribes to the `threads:messages:new` room. Threads publishes to this room on every `SendMessage`. The notification wakes the orchestrator to run a reconciliation pass sooner rather than waiting for the next timer tick.
 
-The notification reduces latency between a user sending a message and the Orchestrator starting an agent workload. The pull ensures correctness — notifications are fire-and-forget and may be lost.
-
-### MCP Server Demand
-
-MCP server demand has two sources:
-
-1. **Agent dependency.** The agent config (from [Teams](teams.md)) references MCP servers via [attachments](resource-definitions.md#attachment). When the Orchestrator determines that an agent workload should be running, it resolves the agent's attached MCP servers and ensures those workloads are running first.
-
-2. **Discovery signal.** The UI can request MCP tool discovery by creating a short-TTL signal. The Orchestrator starts the MCP server workload, the UI queries it for tool listings through a dedicated platform service (the UI does not connect to the MCP workload directly), and the workload is automatically stopped when the TTL expires. See [Tool Discovery](#tool-discovery).
+The notification reduces the latency between a user sending a message and the orchestrator starting an agent workload. The pull ensures correctness — notifications are fire-and-forget and may be lost.
 
 ### Supply: Running Workloads
 
-The Orchestrator maintains a synchronized view of all workloads it manages via the Runner.
+The orchestrator maintains a synchronized view of workloads managed by the Runner.
 
 **Sync mechanism:** Pull + Notifications ([Consumer Sync Protocol](notifications.md#consumer-sync-protocol)).
 
-- **Pull:** The Orchestrator queries the Runner for all workloads matching orchestrator-managed labels (e.g., `managed-by=orchestrator`). This returns the full supply set.
-- **Notifications:** The Orchestrator subscribes to the `runner:workloads:status` room. Runner publishes to this room on workload state transitions (started, stopped, failed). The notification triggers an immediate reconciliation pass.
+- **Pull:** The orchestrator queries the Runner for all workloads matching orchestrator-managed labels (e.g., `managed-by=orchestrator`). This returns the full supply set.
+- **Notifications:** The orchestrator subscribes to the `runner:workloads:status` room. Runner publishes to this room on workload state transitions (started, stopped, failed). The notification triggers an immediate reconciliation pass.
 
-The Orchestrator maintains an in-memory supply map updated by both pull results and notification events. The periodic pull re-syncs the full state and corrects any drift.
+The orchestrator maintains an in-memory supply map updated by both pull results and notification events. The periodic pull re-syncs the full state and corrects any drift.
 
 ## State
 
-The Orchestrator tracks workload assignments in PostgreSQL:
-
-### workload_assignments
+The orchestrator tracks workload assignments in PostgreSQL:
 
 | Column | Type | Description |
 |--------|------|-------------|
 | `id` | UUID | Primary key |
-| `workload_type` | enum | `agent`, `mcp_server` |
-| `identity_id` | UUID | OpenZiti identity for this workload |
+| `agent_identity_id` | UUID | The agent's platform identity |
+| `thread_id` | UUID | Thread being served |
 | `runner_workload_id` | string | Workload ID returned by Runner (null while pending) |
 | `status` | enum | `pending`, `starting`, `running`, `stopping`, `stopped`, `failed` |
-| `last_activity_at` | timestamp | Last demand observed |
+| `last_activity_at` | timestamp | Last message timestamp on the thread |
 | `created_at` | timestamp | When assignment was created |
 | `updated_at` | timestamp | Last status change |
 | `tenant_id` | UUID | Tenant scope |
 
-### agent_assignments
-
-| Column | Type | Description |
-|--------|------|-------------|
-| `workload_assignment_id` | UUID | FK to `workload_assignments` |
-| `agent_identity_id` | UUID | The agent's platform identity |
-| `thread_id` | UUID | Thread being served |
-
-### mcp_assignments
-
-| Column | Type | Description |
-|--------|------|-------------|
-| `workload_assignment_id` | UUID | FK to `workload_assignments` |
-| `mcp_server_id` | UUID | Teams MCP server resource ID |
-| `discovery` | boolean | `true` if started for tool discovery |
-| `ttl_expires_at` | timestamp (nullable) | Discovery TTL expiration (null for agent-demand MCP) |
-
-This structure makes the reconciliation loop idempotent. If the Orchestrator crashes mid-loop, it restarts and diffs again — assignments in `pending` or `starting` states are reconciled against actual Runner state.
+This table makes the reconciliation loop idempotent. If the orchestrator crashes mid-loop, it restarts and diffs again — assignments in `pending` or `starting` states are reconciled against actual Runner state.
 
 ### Status Transitions
 
@@ -165,8 +100,8 @@ stateDiagram-v2
     pending --> starting: StartWorkload issued
     starting --> running: Runner confirms workload running
     starting --> failed: StartWorkload error
-    running --> stopping: Idle timeout / no demand / TTL expired
-    running --> failed: Workload crashed
+    running --> stopping: Idle timeout exceeded
+    running --> failed: Workload crashed (Runner notification)
     stopping --> stopped: Runner confirms workload stopped
     failed --> starting: Demand still exists (retry)
     stopped --> [*]
@@ -174,63 +109,40 @@ stateDiagram-v2
 
 ## Workload Assembly
 
-When starting a workload, the Orchestrator assembles the `StartWorkloadRequest` for the Runner.
+When starting an agent workload, the orchestrator assembles the full `StartWorkloadRequest` for the Runner:
 
-### Agent Workload Assembly
+1. **Resolve agent config** from [Teams](teams.md) — image, model, system prompt, behavior settings, attached MCP servers, workspace configuration.
+2. **Build container specs** — main agent container + [MCP sidecars](mcp-adapter.md) + OpenZiti sidecar + workspace volumes.
+3. **Provision [identity](authn.md#agent-identity-lifecycle)** — created before the workload starts, deleted when it stops.
+4. **Inject configuration** — thread ID, agent identity, platform service endpoints, MCP server ports — passed as environment variables or mounted config.
 
-1. **Resolve agent config** from [Teams](teams.md) — image, model, system prompt, behavior settings, workspace configuration.
-2. **Resolve MCP server dependencies** — ensure all referenced MCP server workloads are running and ready.
-3. **Provision identity** — create an [OpenZiti identity](authn.md) for the agent. The identity is created before the workload starts and deleted when it stops.
-4. **Build container spec** — agent image, environment variables (thread ID, agent identity, platform service endpoints, MCP server gRPC endpoints, OpenZiti enrollment token).
-
-### MCP Server Workload Assembly
-
-1. **Resolve MCP server config** from [Teams](teams.md) — image, command, transport mode, workspace configuration.
-2. **Provision identity** — create an [OpenZiti identity](authn.md) scoped to the network access this MCP server requires.
-3. **Build container spec** — MCP server image with the [MCP Adapter](mcp-adapter.md) binary as entrypoint. Environment variables include the MCP server command, transport mode, gRPC port, and OpenZiti enrollment token.
-
-The Orchestrator does not fetch configs on every reconciliation pass. Config is fetched when starting a new workload. Running workloads are not hot-reloaded.
+The orchestrator does not fetch the full agent config on every reconciliation pass. Config is fetched when starting a new workload. For running workloads, config changes are not hot-reloaded — the agent runs with the config it was started with.
 
 ## Idle Timeout
 
-The Orchestrator owns idle timeout enforcement for agent workloads. During each reconciliation pass, it checks `last_activity_at` for running agent workloads against the configured timeout. If the timeout is exceeded and no unacknowledged messages remain for the agent participant, the Orchestrator stops the workload.
+The orchestrator owns idle timeout enforcement. During each reconciliation pass, it checks `last_activity_at` for running workloads against the configured timeout. If the timeout is exceeded and no unacknowledged messages remain for the agent participant, the orchestrator stops the workload via `Runner.StopWorkload`.
 
 `last_activity_at` is derived from the demand query — if a thread has unacked messages, the agent is not idle. The absence of the agent's identity from the demand result, combined with elapsed time since the last demand was observed, determines idleness.
 
-MCP server workloads are stopped when no agent workloads reference them (no remaining demand). Discovery MCP workloads are stopped when their TTL expires.
-
-The agent container does not implement idle detection. It may exit naturally (process completion, crash), but the Orchestrator is the authority for lifecycle management.
-
-## Tool Discovery
-
-The UI can discover available tools from an MCP server without a running agent. The flow:
-
-1. UI creates a **discovery signal** — a short-TTL request specifying the MCP server resource ID.
-2. The Orchestrator's reconciliation loop picks up the signal and starts the MCP server workload with the `discovery` flag and a TTL.
-3. The MCP server starts and the adapter exposes gRPC.
-4. The UI queries the MCP server's tool listing through a dedicated platform service (the UI does not connect to the MCP workload directly).
-5. When the TTL expires, the Orchestrator stops the MCP server workload.
-
-This reuses the same reconciliation loop — no special synchronous path. The discovery signal is just another demand source for MCP server workloads.
+The agent container does not implement idle detection. It may exit naturally (process completion, crash), but the orchestrator is the authority for lifecycle management.
 
 ## Failure Handling
 
 | Failure | Behavior |
 |---------|----------|
 | `StartWorkload` fails | Assignment marked `failed`. Retried on next reconciliation pass if demand still exists |
-| Workload crashes | Runner publishes workload status change. Orchestrator detects demand without supply on next pass → restarts |
-| Runner unreachable | Orchestrator cannot confirm supply. Logs error, retries next pass. Running workloads continue independently |
+| Agent container crashes | Runner publishes workload status change. Orchestrator detects demand without supply on next pass → restarts |
+| Runner unreachable | Orchestrator cannot confirm supply. Logs error, retries next pass. Running agents continue independently |
 | Orchestrator crashes | Restarts, loads assignments from PostgreSQL, queries Runner for actual state, reconciles the diff |
-| MCP server fails to start | Agent workload start is deferred. MCP server restart is retried. Agent only starts when all dependencies are ready |
 
 ## Notification Rooms
 
-The Orchestrator uses two source-oriented notification rooms:
+The orchestrator uses two source-oriented notification rooms:
 
 | Room | Publisher | Event | Subscriber |
 |------|-----------|-------|------------|
-| `threads:messages:new` | Threads | New message sent | Orchestrator |
-| `runner:workloads:status` | Runner | Workload state transition | Orchestrator |
+| `threads:messages:new` | Threads | New message sent | Orchestrator (+ any future consumer needing message-level events) |
+| `runner:workloads:status` | Runner | Workload state transition | Orchestrator (+ any future consumer needing workload lifecycle events) |
 
 These rooms are **broadcast topics** — any consumer interested in the event type can subscribe. They complement the existing per-recipient rooms (`thread_participant:{id}`, `workload:{id}`) which serve individual consumers.
 
@@ -239,7 +151,7 @@ These rooms are **broadcast topics** — any consumer interested in the event ty
 ```mermaid
 graph TB
     subgraph Control Plane
-        Orch[Orchestrator]
+        Orch[Agents Orchestrator]
         Teams[Teams]
     end
 
@@ -251,12 +163,13 @@ graph TB
 
     DB[(PostgreSQL<br/>workload_assignments)]
 
-    Teams -->|agent + MCP config| Orch
+    Teams -->|agent config| Orch
     Threads -->|unacked agent messages| Orch
     Runner -->|workload state| Orch
-    Notif -->|threads:messages:new<br/>runner:workloads:status| Orch
+    Notif -->|threads:messages:new| Orch
+    Notif -->|runner:workloads:status| Orch
     Orch -->|StartWorkload / StopWorkload| Runner
     Orch --> DB
 ```
 
-The Orchestrator reads from Threads, Teams, and Runner. It writes only to Runner (start/stop) and its own PostgreSQL database. It does not write messages, manage configs, or hold any user-facing connections.
+The orchestrator reads from Threads, Teams, and Runner. It writes only to Runner (start/stop) and its own PostgreSQL database. It does not write messages, manage configs, or hold any user-facing connections.

--- a/architecture/orchestrator.md
+++ b/architecture/orchestrator.md
@@ -1,82 +1,161 @@
-# Agents Orchestrator
+# Orchestrator
 
 ## Overview
 
-The Agents Orchestrator decides which agent workloads should be running and reconciles actual state toward that goal. It is the **only service** that starts and stops agent containers.
+The Orchestrator decides which workloads should be running and reconciles actual state toward that goal. It is the **only service** that starts and stops workloads through the [Runner](runner.md).
 
-The orchestrator is a **control plane** service. It does not touch messages, proxy traffic, or hold user-facing connections. It observes demand (threads with unacknowledged messages for agent participants) and supply (running workloads), computes the diff, and acts through the [Runner](runner.md).
+The Orchestrator is a **control plane** service. It does not touch messages, proxy traffic, or hold user-facing connections. It observes demand, compares it against running supply, computes the diff, and acts.
+
+## Workload Types
+
+The Orchestrator manages multiple workload types. Each type has its own demand source, but all share the same reconciliation pattern and Runner interface.
+
+| Workload Type | Demand Source | Lifetime | Identity |
+|---------------|--------------|----------|----------|
+| **Agent** | Threads with unacked messages for agent participants | Until idle timeout or thread completes | Own [OpenZiti identity](authn.md) |
+| **MCP Server** | Agent config references MCP server; or discovery signal | While referencing agents are running; or until discovery TTL expires | Own [OpenZiti identity](authn.md) |
+
+Each workload is a separate Runner unit with its own OpenZiti network identity. Agents and MCP servers are **never co-located in the same workload** — they communicate over the network via gRPC (see [MCP Adapter](mcp-adapter.md)).
+
+### Agent Workloads
+
+An agent workload runs the agent process. Its demand comes from [Threads](threads.md) — specifically, threads with unacknowledged messages for agent participants.
+
+```
+Agent Workload
+├── Main container: agent image (our implementation or wrapped 3rd-party CLI)
+└── Sidecar: OpenZiti tunnel (network identity)
+```
+
+### MCP Server Workloads
+
+An MCP server workload runs an MCP server behind the [MCP Adapter](mcp-adapter.md). The adapter is the container entrypoint — it launches the MCP server process, bridges its native transport (stdio or HTTP) to gRPC, and exposes a uniform gRPC interface over OpenZiti.
+
+```
+MCP Workload
+├── Main container: MCP server image + adapter binary (entrypoint)
+│   adapter --mode stdio --command "npx best-mcp-server" --grpc-port 50051
+│   adapter --mode http  --command "uvx some-mcp --port 8080" --http-port 8080 --grpc-port 50051
+└── Sidecar: OpenZiti tunnel (network identity)
+```
+
+MCP servers are separate workloads (not sidecars of the agent) because:
+- Each workload has its own OpenZiti identity with independently scoped network access.
+- An MCP server may be shared across multiple agents (singleton pattern).
+- An MCP server may require different resources than the agent (e.g., GPU).
 
 ## Reconciliation
 
-The orchestrator runs a periodic reconciliation loop backed by PostgreSQL (see [Reconciliation Approach](control-data-plane.md#reconciliation-approach)).
+The Orchestrator runs a periodic reconciliation loop backed by PostgreSQL (see [Reconciliation Approach](control-data-plane.md#reconciliation)).
 
-Each pass computes a diff between demand and supply, then acts on the result:
+Each pass computes a diff between demand and supply per workload type, then acts on the result:
 
 | Outcome | Condition | Action |
 |---------|-----------|--------|
-| **Start** | Thread has unacked messages for an agent participant, no workload running | `StartWorkload` via Runner |
-| **Keep** | Thread has unacked messages, workload running | No action |
-| **Stop** | No unacked messages, workload idle beyond timeout | `StopWorkload` via Runner |
+| **Start** | Demand exists, no workload running | `StartWorkload` via Runner |
+| **Keep** | Demand exists, workload running | No action |
+| **Stop** | No demand, workload idle beyond timeout | `StopWorkload` via Runner |
 | **Restart** | Demand exists, workload in failed/stopped state | `StartWorkload` via Runner |
+
+### Dependency Ordering
+
+When an agent references MCP servers, the Orchestrator starts MCP server workloads first and waits for them to become ready before starting the agent workload. On shutdown, the agent workload is stopped first; MCP server workloads are stopped when no agents reference them.
 
 ```mermaid
 graph LR
-    subgraph Inputs
-        Demand[Demand<br/>Threads with unacked agent messages]
-        Supply[Supply<br/>Running workloads]
+    subgraph Demand
+        TD[Thread demand<br/>unacked agent messages]
+        AC[Agent config<br/>MCP references]
+        DS[Discovery signals<br/>short TTL]
     end
 
     Orch[Reconciliation Loop]
+
+    subgraph Supply
+        RA[Agent workloads]
+        RM[MCP workloads]
+    end
+
     Runner[Runner]
 
-    Demand --> Orch
-    Supply --> Orch
+    TD --> Orch
+    AC --> Orch
+    DS --> Orch
+    Orch --> RA & RM
+    RA & RM -->|actual state| Orch
     Orch -->|StartWorkload / StopWorkload| Runner
 ```
 
-### Demand: Threads with Unacked Agent Messages
+### Agent Demand
 
-The orchestrator needs to know which threads have unacknowledged messages for agent participants.
+The Orchestrator needs to know which threads have unacknowledged messages for agent participants.
 
-[Threads](threads.md) is participant-type-agnostic — it does not distinguish agents from users. The orchestrator maintains the set of agent identity IDs (received from the identity lifecycle — see [Workload Assembly](#workload-assembly)). It queries Threads for unacked messages scoped to those IDs.
+[Threads](threads.md) is participant-type-agnostic — it does not distinguish agents from users. The Orchestrator maintains the set of agent identity IDs (from agent workload lifecycle). It queries Threads for unacked messages scoped to those IDs.
 
-**Interface:** `GetParticipantsWithUnackedMessages(participant_ids: []UUID) → []{participant_id, thread_id}`. Returns the set of (participant, thread) pairs that have at least one unacknowledged message. This is a bulk query — the orchestrator passes all known agent identity IDs and gets back the full demand set in one call.
+**Interface:** `GetParticipantsWithUnackedMessages(participant_ids: []UUID) → []{participant_id, thread_id}`. Returns (participant, thread) pairs that have at least one unacknowledged message. Bulk query — the Orchestrator passes all known agent identity IDs and gets back the full demand set in one call.
 
 **Sync mechanism:** Pull + Notifications ([Consumer Sync Protocol](notifications.md#consumer-sync-protocol)).
 
 - **Pull:** Each reconciliation pass calls `GetParticipantsWithUnackedMessages` as the source of truth.
-- **Notifications:** The orchestrator subscribes to the `threads:messages:new` room. Threads publishes to this room on every `SendMessage`. The notification wakes the orchestrator to run a reconciliation pass sooner rather than waiting for the next timer tick.
+- **Notifications:** The Orchestrator subscribes to the `threads:messages:new` room. Threads publishes to this room on every `SendMessage`. The notification wakes the Orchestrator to run a reconciliation pass immediately rather than waiting for the next timer tick.
 
-The notification reduces the latency between a user sending a message and the orchestrator starting an agent workload. The pull ensures correctness — notifications are fire-and-forget and may be lost.
+The notification reduces latency between a user sending a message and the Orchestrator starting an agent workload. The pull ensures correctness — notifications are fire-and-forget and may be lost.
+
+### MCP Server Demand
+
+MCP server demand has two sources:
+
+1. **Agent dependency.** The agent config (from [Teams](teams.md)) references MCP servers via [attachments](resource-definitions.md#attachment). When the Orchestrator determines that an agent workload should be running, it resolves the agent's attached MCP servers and ensures those workloads are running first.
+
+2. **Discovery signal.** The UI can request MCP tool discovery by creating a short-TTL signal. The Orchestrator starts the MCP server workload, the UI queries it for tool listings through a dedicated platform service (the UI does not connect to the MCP workload directly), and the workload is automatically stopped when the TTL expires. See [Tool Discovery](#tool-discovery).
 
 ### Supply: Running Workloads
 
-The orchestrator maintains a synchronized view of workloads managed by the Runner.
+The Orchestrator maintains a synchronized view of all workloads it manages via the Runner.
 
 **Sync mechanism:** Pull + Notifications ([Consumer Sync Protocol](notifications.md#consumer-sync-protocol)).
 
-- **Pull:** The orchestrator queries the Runner for all workloads matching orchestrator-managed labels (e.g., `managed-by=orchestrator`). This returns the full supply set.
-- **Notifications:** The orchestrator subscribes to the `runner:workloads:status` room. Runner publishes to this room on workload state transitions (started, stopped, failed). The notification triggers an immediate reconciliation pass.
+- **Pull:** The Orchestrator queries the Runner for all workloads matching orchestrator-managed labels (e.g., `managed-by=orchestrator`). This returns the full supply set.
+- **Notifications:** The Orchestrator subscribes to the `runner:workloads:status` room. Runner publishes to this room on workload state transitions (started, stopped, failed). The notification triggers an immediate reconciliation pass.
 
-The orchestrator maintains an in-memory supply map updated by both pull results and notification events. The periodic pull re-syncs the full state and corrects any drift.
+The Orchestrator maintains an in-memory supply map updated by both pull results and notification events. The periodic pull re-syncs the full state and corrects any drift.
 
 ## State
 
-The orchestrator tracks workload assignments in PostgreSQL:
+The Orchestrator tracks workload assignments in PostgreSQL:
+
+### workload_assignments
 
 | Column | Type | Description |
 |--------|------|-------------|
 | `id` | UUID | Primary key |
-| `agent_identity_id` | UUID | The agent's platform identity |
-| `thread_id` | UUID | Thread being served |
+| `workload_type` | enum | `agent`, `mcp_server` |
+| `identity_id` | UUID | OpenZiti identity for this workload |
 | `runner_workload_id` | string | Workload ID returned by Runner (null while pending) |
 | `status` | enum | `pending`, `starting`, `running`, `stopping`, `stopped`, `failed` |
-| `last_activity_at` | timestamp | Last message timestamp on the thread |
+| `last_activity_at` | timestamp | Last demand observed |
 | `created_at` | timestamp | When assignment was created |
 | `updated_at` | timestamp | Last status change |
 | `tenant_id` | UUID | Tenant scope |
 
-This table makes the reconciliation loop idempotent. If the orchestrator crashes mid-loop, it restarts and diffs again — assignments in `pending` or `starting` states are reconciled against actual Runner state.
+### agent_assignments
+
+| Column | Type | Description |
+|--------|------|-------------|
+| `workload_assignment_id` | UUID | FK to `workload_assignments` |
+| `agent_identity_id` | UUID | The agent's platform identity |
+| `thread_id` | UUID | Thread being served |
+
+### mcp_assignments
+
+| Column | Type | Description |
+|--------|------|-------------|
+| `workload_assignment_id` | UUID | FK to `workload_assignments` |
+| `mcp_server_id` | UUID | Teams MCP server resource ID |
+| `discovery` | boolean | `true` if started for tool discovery |
+| `ttl_expires_at` | timestamp (nullable) | Discovery TTL expiration (null for agent-demand MCP) |
+
+This structure makes the reconciliation loop idempotent. If the Orchestrator crashes mid-loop, it restarts and diffs again — assignments in `pending` or `starting` states are reconciled against actual Runner state.
 
 ### Status Transitions
 
@@ -86,8 +165,8 @@ stateDiagram-v2
     pending --> starting: StartWorkload issued
     starting --> running: Runner confirms workload running
     starting --> failed: StartWorkload error
-    running --> stopping: Idle timeout exceeded
-    running --> failed: Workload crashed (Runner notification)
+    running --> stopping: Idle timeout / no demand / TTL expired
+    running --> failed: Workload crashed
     stopping --> stopped: Runner confirms workload stopped
     failed --> starting: Demand still exists (retry)
     stopped --> [*]
@@ -95,40 +174,63 @@ stateDiagram-v2
 
 ## Workload Assembly
 
-When starting an agent workload, the orchestrator assembles the full `StartWorkloadRequest` for the Runner:
+When starting a workload, the Orchestrator assembles the `StartWorkloadRequest` for the Runner.
 
-1. **Resolve agent config** from [Teams](teams.md) — image, model, system prompt, behavior settings, attached MCP servers, workspace configuration.
-2. **Build container specs** — main agent container + MCP server sidecars + workspace volumes.
-3. **Provision identity** — request an [OpenZiti identity](authn.md) for the agent container. The identity is created before the container starts and deleted when the container stops.
-4. **Inject configuration** — thread ID, agent identity, platform service endpoints, OpenZiti enrollment token — passed as environment variables or mounted config.
+### Agent Workload Assembly
 
-The orchestrator does not fetch the full agent config on every reconciliation pass. Config is fetched when starting a new workload. For running workloads, config changes are not hot-reloaded — the agent runs with the config it was started with.
+1. **Resolve agent config** from [Teams](teams.md) — image, model, system prompt, behavior settings, workspace configuration.
+2. **Resolve MCP server dependencies** — ensure all referenced MCP server workloads are running and ready.
+3. **Provision identity** — create an [OpenZiti identity](authn.md) for the agent. The identity is created before the workload starts and deleted when it stops.
+4. **Build container spec** — agent image, environment variables (thread ID, agent identity, platform service endpoints, MCP server gRPC endpoints, OpenZiti enrollment token).
+
+### MCP Server Workload Assembly
+
+1. **Resolve MCP server config** from [Teams](teams.md) — image, command, transport mode, workspace configuration.
+2. **Provision identity** — create an [OpenZiti identity](authn.md) scoped to the network access this MCP server requires.
+3. **Build container spec** — MCP server image with the [MCP Adapter](mcp-adapter.md) binary as entrypoint. Environment variables include the MCP server command, transport mode, gRPC port, and OpenZiti enrollment token.
+
+The Orchestrator does not fetch configs on every reconciliation pass. Config is fetched when starting a new workload. Running workloads are not hot-reloaded.
 
 ## Idle Timeout
 
-The orchestrator owns idle timeout enforcement. During each reconciliation pass, it checks `last_activity_at` for running workloads against the configured timeout. If the timeout is exceeded and no unacknowledged messages remain for the agent participant, the orchestrator stops the workload via `Runner.StopWorkload`.
+The Orchestrator owns idle timeout enforcement for agent workloads. During each reconciliation pass, it checks `last_activity_at` for running agent workloads against the configured timeout. If the timeout is exceeded and no unacknowledged messages remain for the agent participant, the Orchestrator stops the workload.
 
 `last_activity_at` is derived from the demand query — if a thread has unacked messages, the agent is not idle. The absence of the agent's identity from the demand result, combined with elapsed time since the last demand was observed, determines idleness.
 
-The agent container does not implement idle detection. It may exit naturally (process completion, crash), but the orchestrator is the authority for lifecycle management.
+MCP server workloads are stopped when no agent workloads reference them (no remaining demand). Discovery MCP workloads are stopped when their TTL expires.
+
+The agent container does not implement idle detection. It may exit naturally (process completion, crash), but the Orchestrator is the authority for lifecycle management.
+
+## Tool Discovery
+
+The UI can discover available tools from an MCP server without a running agent. The flow:
+
+1. UI creates a **discovery signal** — a short-TTL request specifying the MCP server resource ID.
+2. The Orchestrator's reconciliation loop picks up the signal and starts the MCP server workload with the `discovery` flag and a TTL.
+3. The MCP server starts and the adapter exposes gRPC.
+4. The UI queries the MCP server's tool listing through a dedicated platform service (the UI does not connect to the MCP workload directly).
+5. When the TTL expires, the Orchestrator stops the MCP server workload.
+
+This reuses the same reconciliation loop — no special synchronous path. The discovery signal is just another demand source for MCP server workloads.
 
 ## Failure Handling
 
 | Failure | Behavior |
 |---------|----------|
 | `StartWorkload` fails | Assignment marked `failed`. Retried on next reconciliation pass if demand still exists |
-| Agent container crashes | Runner publishes workload status change. Orchestrator detects demand without supply on next pass → restarts |
-| Runner unreachable | Orchestrator cannot confirm supply. Logs error, retries next pass. Running agents continue independently (they communicate with Threads/Notifications directly) |
+| Workload crashes | Runner publishes workload status change. Orchestrator detects demand without supply on next pass → restarts |
+| Runner unreachable | Orchestrator cannot confirm supply. Logs error, retries next pass. Running workloads continue independently |
 | Orchestrator crashes | Restarts, loads assignments from PostgreSQL, queries Runner for actual state, reconciles the diff |
+| MCP server fails to start | Agent workload start is deferred. MCP server restart is retried. Agent only starts when all dependencies are ready |
 
 ## Notification Rooms
 
-The orchestrator introduces two source-oriented notification rooms:
+The Orchestrator uses two source-oriented notification rooms:
 
 | Room | Publisher | Event | Subscriber |
 |------|-----------|-------|------------|
-| `threads:messages:new` | Threads | New message sent | Orchestrator (+ any future consumer needing message-level events) |
-| `runner:workloads:status` | Runner | Workload state transition | Orchestrator (+ any future consumer needing workload lifecycle events) |
+| `threads:messages:new` | Threads | New message sent | Orchestrator |
+| `runner:workloads:status` | Runner | Workload state transition | Orchestrator |
 
 These rooms are **broadcast topics** — any consumer interested in the event type can subscribe. They complement the existing per-recipient rooms (`thread_participant:{id}`, `workload:{id}`) which serve individual consumers.
 
@@ -137,7 +239,7 @@ These rooms are **broadcast topics** — any consumer interested in the event ty
 ```mermaid
 graph TB
     subgraph Control Plane
-        Orch[Agents Orchestrator]
+        Orch[Orchestrator]
         Teams[Teams]
     end
 
@@ -149,13 +251,12 @@ graph TB
 
     DB[(PostgreSQL<br/>workload_assignments)]
 
-    Teams -->|agent config| Orch
+    Teams -->|agent + MCP config| Orch
     Threads -->|unacked agent messages| Orch
     Runner -->|workload state| Orch
-    Notif -->|threads:messages:new| Orch
-    Notif -->|runner:workloads:status| Orch
+    Notif -->|threads:messages:new<br/>runner:workloads:status| Orch
     Orch -->|StartWorkload / StopWorkload| Runner
     Orch --> DB
 ```
 
-The orchestrator reads from Threads, Teams, and Runner. It writes only to Runner (start/stop) and its own PostgreSQL database. It does not write messages, manage configs, or hold any user-facing connections.
+The Orchestrator reads from Threads, Teams, and Runner. It writes only to Runner (start/stop) and its own PostgreSQL database. It does not write messages, manage configs, or hold any user-facing connections.

--- a/architecture/resource-definitions.md
+++ b/architecture/resource-definitions.md
@@ -32,12 +32,11 @@ All fields are optional (the schema uses `.partial()`).
 
 ## MCP Server
 
-An MCP server definition that describes how to run an MCP tool server as a separate workload. Each MCP server runs behind the [MCP Adapter](mcp-adapter.md), which launches the server process and exposes a uniform gRPC interface over OpenZiti.
+An MCP server definition. Runs as a sidecar within an [agent workload](orchestrator.md#agent-workload) via the [MCP Adapter](mcp-adapter.md).
 
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
 | `namespace` | string | `""` | Namespace prefix for exposed tools. Tools are named `<namespace>_<toolName>` |
-| `image` | string | | Container image containing the MCP server runtime (e.g., `node:22`, `python:3.12`) |
 | `command` | string | `"mcp start --stdio"` | Command to start the MCP server process (executed by the adapter) |
 | `transport` | enum | `"stdio"` | `"stdio"` — adapter communicates via stdin/stdout. `"http"` — adapter communicates via Streamable HTTP |
 | `httpPort` | integer | | Port the MCP server listens on (required when `transport` is `"http"`) |
@@ -50,7 +49,9 @@ An MCP server definition that describes how to run an MCP tool server as a separ
 | `restart.maxAttempts` | integer | `5` | Maximum restart attempts during resilient start |
 | `restart.backoffMs` | integer | `2000` | Base backoff (ms) between restart attempts |
 
-All fields are optional except `image` and `command`.
+All fields are optional except `command`.
+
+The container image is determined by the workspace, not by this resource.
 
 ---
 

--- a/architecture/resource-definitions.md
+++ b/architecture/resource-definitions.md
@@ -32,12 +32,15 @@ All fields are optional (the schema uses `.partial()`).
 
 ## MCP Server
 
-An MCP server definition that describes how to start and connect to an MCP tool server inside a workspace container.
+An MCP server definition that describes how to run an MCP tool server as a separate workload. Each MCP server runs behind the [MCP Adapter](mcp-adapter.md), which launches the server process and exposes a uniform gRPC interface over OpenZiti.
 
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
 | `namespace` | string | `""` | Namespace prefix for exposed tools. Tools are named `<namespace>_<toolName>` |
-| `command` | string | `"mcp start --stdio"` | Startup command executed inside the container |
+| `image` | string | | Container image containing the MCP server runtime (e.g., `node:22`, `python:3.12`) |
+| `command` | string | `"mcp start --stdio"` | Command to start the MCP server process (executed by the adapter) |
+| `transport` | enum | `"stdio"` | `"stdio"` — adapter communicates via stdin/stdout. `"http"` — adapter communicates via Streamable HTTP |
+| `httpPort` | integer | | Port the MCP server listens on (required when `transport` is `"http"`) |
 | `workdir` | string | | Working directory inside the container |
 | `env` | array | | Environment variables: `[{name: string, value: string \| reference}]` |
 | `requestTimeoutMs` | integer | | Per-request timeout (ms) |
@@ -47,7 +50,7 @@ An MCP server definition that describes how to start and connect to an MCP tool 
 | `restart.maxAttempts` | integer | `5` | Maximum restart attempts during resilient start |
 | `restart.backoffMs` | integer | `2000` | Base backoff (ms) between restart attempts |
 
-All fields are optional.
+All fields are optional except `image` and `command`.
 
 ---
 

--- a/architecture/runner.md
+++ b/architecture/runner.md
@@ -87,4 +87,4 @@ A workload consists of:
 
 The docker-runner currently uses HMAC-based authentication with a shared secret (`DOCKER_RUNNER_SHARED_SECRET`). The target architecture uses OpenZiti network identity — the Runner enrolls using a service token and then authenticates all connections via mTLS. See [Authentication](authn.md).
 
-The Runner also manages OpenZiti identities for workload containers (agents, MCP servers): creating an identity before starting a container and deleting it when the container stops. Each workload — whether agent or MCP server — receives its own OpenZiti identity with independently scoped network access.
+The Runner also manages OpenZiti identities for agent workloads — see [Agent Identity Lifecycle](authn.md#agent-identity-lifecycle).

--- a/architecture/runner.md
+++ b/architecture/runner.md
@@ -87,4 +87,4 @@ A workload consists of:
 
 The docker-runner currently uses HMAC-based authentication with a shared secret (`DOCKER_RUNNER_SHARED_SECRET`). The target architecture uses OpenZiti network identity — the Runner enrolls using a service token and then authenticates all connections via mTLS. See [Authentication](authn.md).
 
-The Runner also manages OpenZiti identities for agent containers: creating an identity before starting a container and deleting it when the container stops.
+The Runner also manages OpenZiti identities for workload containers (agents, MCP servers): creating an identity before starting a container and deleting it when the container stops. Each workload — whether agent or MCP server — receives its own OpenZiti identity with independently scoped network access.

--- a/architecture/system-overview.md
+++ b/architecture/system-overview.md
@@ -93,7 +93,7 @@ graph TB
 | **Secrets** | Manages secret providers and secrets. Resolves secret values from external providers at runtime |
 | **Notifications** | Real-time event fanout via persistent connections (socket). All services publish state change events through Notifications |
 | **Authorization** | Fine-grained access control. Thin proxy to OpenFGA — centralizes configuration, adds observability. Services call Authorization for permission checks and relationship writes |
-| **Agents** | Orchestrator that spins up agent workloads for threads with unacknowledged messages |
+| **[Agents Orchestrator](orchestrator.md)** | Reconciles agent workloads — starts containers for threads with unacknowledged agent messages, stops idle agents. See [Orchestrator](orchestrator.md) |
 | **Agent State** | Long-term agent context persistence (APSS) |
 | **Tracing** | Ingestion and query of tracing data. Extended OpenTelemetry protocol for real-time in-progress events |
 | **Teams** | Management of team resources: agents, workspaces, MCP servers, etc. |

--- a/architecture/system-overview.md
+++ b/architecture/system-overview.md
@@ -14,7 +14,7 @@ graph TB
 
     subgraph Control Plane
         Teams[Teams]
-        AgentsOrch[Agents<br/>Orchestrator]
+        Orch[Orchestrator]
     end
 
     subgraph Data Plane
@@ -34,10 +34,10 @@ graph TB
     end
 
     subgraph Workloads
-        Agent1[Agent Container]
-        Agent2[Agent Container]
-        MCP1[MCP Server]
-        MCP2[MCP Server]
+        Agent1[Agent Workload]
+        Agent2[Agent Workload]
+        MCP1[MCP Server Workload]
+        MCP2[MCP Server Workload]
     end
 
     subgraph Monolith
@@ -57,12 +57,13 @@ graph TB
     Channels --> Threads
 
     Threads -->|publish events| Notifications
-    AgentsOrch --> Runner
-    AgentsOrch --> Threads
+    Orch --> Runner
+    Orch --> Threads
 
     Runner --> Agent1 & Agent2
-    Agent1 --> MCP1
-    Agent2 --> MCP2
+    Runner --> MCP1 & MCP2
+    Agent1 -->|gRPC over OpenZiti| MCP1
+    Agent2 -->|gRPC over OpenZiti| MCP2
     Agent1 & Agent2 --> Threads
     Agent1 & Agent2 --> Notifications
     Agent1 & Agent2 --> AgentState
@@ -77,7 +78,7 @@ graph TB
     Teams --> Authorization
     Authorization --> OpenFGA[(OpenFGA)]
 
-    Teams --> AgentsOrch
+    Teams --> Orch
 ```
 
 ## Component Summary
@@ -93,12 +94,13 @@ graph TB
 | **Secrets** | Manages secret providers and secrets. Resolves secret values from external providers at runtime |
 | **Notifications** | Real-time event fanout via persistent connections (socket). All services publish state change events through Notifications |
 | **Authorization** | Fine-grained access control. Thin proxy to OpenFGA — centralizes configuration, adds observability. Services call Authorization for permission checks and relationship writes |
-| **[Agents Orchestrator](orchestrator.md)** | Reconciles agent workloads — starts containers for threads with unacknowledged agent messages, stops idle agents. See [Orchestrator](orchestrator.md) |
+| **[Orchestrator](orchestrator.md)** | Reconciles all workloads — agents, MCP servers, and discovery signals. Starts MCP server dependencies before agents, stops idle workloads. See [Orchestrator](orchestrator.md) |
 | **Agent State** | Long-term agent context persistence (APSS) |
 | **Tracing** | Ingestion and query of tracing data. Extended OpenTelemetry protocol for real-time in-progress events |
 | **Teams** | Management of team resources: agents, workspaces, MCP servers, etc. |
 | **Runner** | Executes workloads. Implementations: docker-runner, k8s-runner |
 | **Gateway** | Exposes platform methods for external usage. Accessible at `gateway.agyn.dev` (subdomain) and `agyn.dev/apiv2/` (path-based, prefix stripped) |
+| **[MCP Adapter](mcp-adapter.md)** | Standalone binary wrapping any MCP server. Bridges stdio/HTTP to gRPC. Entrypoint of every MCP server workload |
 
 ## Data Stores
 
@@ -121,4 +123,5 @@ graph TB
 | `agynio/agent-state` | Agent State (APSS) service | Go | Standalone service |
 | `agynio/openfga-model` | OpenFGA authorization model and Terraform module | DSL, HCL | Planned |
 | `agynio/authorization` | Authorization service (thin proxy to OpenFGA) | Go | Planned |
+| `agynio/mcp-adapter` | MCP Adapter binary | Go | Planned |
 | `agynio/architecture` | This documentation | Markdown | — |

--- a/architecture/system-overview.md
+++ b/architecture/system-overview.md
@@ -14,7 +14,7 @@ graph TB
 
     subgraph Control Plane
         Teams[Teams]
-        Orch[Orchestrator]
+        AgentsOrch[Agents<br/>Orchestrator]
     end
 
     subgraph Data Plane
@@ -34,10 +34,14 @@ graph TB
     end
 
     subgraph Workloads
-        Agent1[Agent Workload]
-        Agent2[Agent Workload]
-        MCP1[MCP Server Workload]
-        MCP2[MCP Server Workload]
+        subgraph Agent1[Agent Workload]
+            A1Main[Agent]
+            A1MCP[MCP Sidecars]
+        end
+        subgraph Agent2[Agent Workload]
+            A2Main[Agent]
+            A2MCP[MCP Sidecars]
+        end
     end
 
     subgraph Monolith
@@ -57,20 +61,24 @@ graph TB
     Channels --> Threads
 
     Threads -->|publish events| Notifications
-    Orch --> Runner
-    Orch --> Threads
+    AgentsOrch --> Runner
+    AgentsOrch --> Threads
 
     Runner --> Agent1 & Agent2
-    Runner --> MCP1 & MCP2
-    Agent1 -->|gRPC over OpenZiti| MCP1
-    Agent2 -->|gRPC over OpenZiti| MCP2
-    Agent1 & Agent2 --> Threads
-    Agent1 & Agent2 --> Notifications
-    Agent1 & Agent2 --> AgentState
-    Agent1 & Agent2 --> Files
-    Agent1 & Agent2 --> TokenCounting
-    Agent1 & Agent2 --> LLM
-    Agent1 & Agent2 -.-> Tracing
+    A1Main --> Threads
+    A1Main --> Notifications
+    A1Main --> AgentState
+    A1Main --> Files
+    A1Main --> TokenCounting
+    A1Main --> LLM
+    A1Main -.-> Tracing
+    A2Main --> Threads
+    A2Main --> Notifications
+    A2Main --> AgentState
+    A2Main --> Files
+    A2Main --> TokenCounting
+    A2Main --> LLM
+    A2Main -.-> Tracing
 
     Chat --> Authorization
     Files --> Authorization
@@ -78,7 +86,7 @@ graph TB
     Teams --> Authorization
     Authorization --> OpenFGA[(OpenFGA)]
 
-    Teams --> Orch
+    Teams --> AgentsOrch
 ```
 
 ## Component Summary
@@ -94,13 +102,13 @@ graph TB
 | **Secrets** | Manages secret providers and secrets. Resolves secret values from external providers at runtime |
 | **Notifications** | Real-time event fanout via persistent connections (socket). All services publish state change events through Notifications |
 | **Authorization** | Fine-grained access control. Thin proxy to OpenFGA — centralizes configuration, adds observability. Services call Authorization for permission checks and relationship writes |
-| **[Orchestrator](orchestrator.md)** | Reconciles all workloads — agents, MCP servers, and discovery signals. Starts MCP server dependencies before agents, stops idle workloads. See [Orchestrator](orchestrator.md) |
+| **[Agents Orchestrator](orchestrator.md)** | Reconciles [agent workloads](orchestrator.md#agent-workload) — starts pods for threads with unacknowledged agent messages, stops idle agents |
 | **Agent State** | Long-term agent context persistence (APSS) |
 | **Tracing** | Ingestion and query of tracing data. Extended OpenTelemetry protocol for real-time in-progress events |
 | **Teams** | Management of team resources: agents, workspaces, MCP servers, etc. |
 | **Runner** | Executes workloads. Implementations: docker-runner, k8s-runner |
 | **Gateway** | Exposes platform methods for external usage. Accessible at `gateway.agyn.dev` (subdomain) and `agyn.dev/apiv2/` (path-based, prefix stripped) |
-| **[MCP Adapter](mcp-adapter.md)** | Standalone binary wrapping any MCP server. Bridges stdio/HTTP to gRPC. Entrypoint of every MCP server workload |
+| **[MCP Adapter](mcp-adapter.md)** | Wraps any MCP server, bridges stdio/HTTP to gRPC. See [MCP Adapter](mcp-adapter.md) |
 
 ## Data Stores
 

--- a/gaps/current-state.md
+++ b/gaps/current-state.md
@@ -19,7 +19,7 @@ graph TB
         TM[Teams<br/>resource management]
         CH[Channels<br/>Slack trigger]
         TR[Tracing<br/>removed, planned]
-        AO[Orchestrator<br/>scheduling]
+        AO[Agents Orchestrator<br/>scheduling]
     end
 
     subgraph "Monolith (agynio/platform)"
@@ -89,7 +89,7 @@ These components exist inside `agynio/platform` (`packages/platform-server`) and
 | Threads (messaging) | `packages/platform-server/src/agents/threads.controller.ts` | Standalone Threads service |
 | Teams (resource management) | Partially extracted (Gateway proxies to platform-server) | Standalone Teams service |
 | Channels (Slack trigger) | `packages/platform-server/src/nodes/` (trigger nodes) | Standalone Channels service |
-| Orchestrator | `packages/platform-server/src/agents/` | Standalone control plane service |
+| Agents Orchestrator | `packages/platform-server/src/agents/` | Standalone Agents Orchestrator service |
 | Tracing | Removed (issue #760). Historical references remain | New standalone Tracing service |
 
 ### Platform UI — API Consumption

--- a/gaps/current-state.md
+++ b/gaps/current-state.md
@@ -19,7 +19,7 @@ graph TB
         TM[Teams<br/>resource management]
         CH[Channels<br/>Slack trigger]
         TR[Tracing<br/>removed, planned]
-        AO[Agents Orchestrator<br/>scheduling]
+        AO[Orchestrator<br/>scheduling]
     end
 
     subgraph "Monolith (agynio/platform)"
@@ -89,7 +89,7 @@ These components exist inside `agynio/platform` (`packages/platform-server`) and
 | Threads (messaging) | `packages/platform-server/src/agents/threads.controller.ts` | Standalone Threads service |
 | Teams (resource management) | Partially extracted (Gateway proxies to platform-server) | Standalone Teams service |
 | Channels (Slack trigger) | `packages/platform-server/src/nodes/` (trigger nodes) | Standalone Channels service |
-| Agents orchestrator | `packages/platform-server/src/agents/` | Standalone control plane service |
+| Orchestrator | `packages/platform-server/src/agents/` | Standalone control plane service |
 | Tracing | Removed (issue #760). Historical references remain | New standalone Tracing service |
 
 ### Platform UI — API Consumption

--- a/gaps/migration-roadmap.md
+++ b/gaps/migration-roadmap.md
@@ -21,7 +21,7 @@ graph LR
 
     subgraph "Phase 3: New Services"
         S8[Channels service]
-        S9[Orchestrator]
+        S9[Agents Orchestrator]
         S10[Tracing service]
         S11[k8s-runner]
         S12[Files service]
@@ -86,13 +86,13 @@ New service implementing the channel interface:
 - Live connections to 3rd-party APIs (data plane side).
 - Replace Slack trigger node from platform-server.
 
-### Orchestrator
+### Agents Orchestrator
 
 New control plane service:
 
 - Watch for threads with pending messages.
-- Reconcile agent workloads via Runner.
-- Manage agent lifecycle (start, monitor, stop).
+- Reconcile agent workloads (agent + MCP sidecars) via Runner.
+- Manage agent lifecycle (start, monitor, idle timeout, stop).
 
 ### Tracing Service
 

--- a/gaps/migration-roadmap.md
+++ b/gaps/migration-roadmap.md
@@ -21,7 +21,7 @@ graph LR
 
     subgraph "Phase 3: New Services"
         S8[Channels service]
-        S9[Agents orchestrator]
+        S9[Orchestrator]
         S10[Tracing service]
         S11[k8s-runner]
         S12[Files service]
@@ -86,7 +86,7 @@ New service implementing the channel interface:
 - Live connections to 3rd-party APIs (data plane side).
 - Replace Slack trigger node from platform-server.
 
-### Agents Orchestrator
+### Orchestrator
 
 New control plane service:
 

--- a/open-questions.md
+++ b/open-questions.md
@@ -36,14 +36,13 @@ Unresolved architectural decisions requiring discussion.
 
 ---
 
-## Scheduler Service
+## Orchestrator Horizontal Scaling
 
-**Context:** Currently the Runner is purely data plane (executes workloads). A separate **Scheduler** service may be needed in the control plane to decide *what* and *when* to run.
+**Context:** The [Agents Orchestrator](architecture/orchestrator.md) runs a single reconciliation loop. For horizontal scaling, reconciliation passes need to be partitioned across instances.
 
 **Questions:**
-- Is the Scheduler the same as the Agents orchestrator, or a lower-level service that the orchestrator delegates to?
-- Does the Scheduler manage only agent workloads, or also workspace lifecycle and TTL?
-- What is the scheduling interface? (Request/response? Queue-based? Watch-based?)
+- Sharding strategy: tenant-based, consistent hashing over agent identity IDs, or leader election?
+- How is shard assignment coordinated? (Lease-based via PostgreSQL? External coordination service?)
 
 
 ---

--- a/open-questions.md
+++ b/open-questions.md
@@ -38,7 +38,7 @@ Unresolved architectural decisions requiring discussion.
 
 ## Orchestrator Horizontal Scaling
 
-**Context:** The [Agents Orchestrator](architecture/orchestrator.md) runs a single reconciliation loop. For horizontal scaling, reconciliation passes need to be partitioned across instances.
+**Context:** The [Orchestrator](architecture/orchestrator.md) runs a single reconciliation loop. For horizontal scaling, reconciliation passes need to be partitioned across instances.
 
 **Questions:**
 - Sharding strategy: tenant-based, consistent hashing over agent identity IDs, or leader election?
@@ -49,7 +49,7 @@ Unresolved architectural decisions requiring discussion.
 
 ## OpenZiti Integration
 
-**Context:** The platform uses OpenZiti for network-level identity and mTLS for agents, channels, runners, and the Agents Orchestrator. Service tokens bootstrap enrollment. See [Authentication](architecture/authn.md).
+**Context:** The platform uses OpenZiti for network-level identity and mTLS for agents, MCP servers, channels, and runners. Service tokens bootstrap enrollment. See [Authentication](architecture/authn.md).
 
 **Questions:**
 - How does Runner integrate with the OpenZiti Controller API to manage agent identities? (SDK? CLI? REST?)
@@ -60,6 +60,7 @@ Unresolved architectural decisions requiring discussion.
 - How does an external runner enroll with the platform's OpenZiti network? (Same service token flow?)
 - What services can agent containers on external runners access? (Only Gateway? Direct access to Threads, Files?)
 - How is end-user identity propagated across internal service boundaries? (gRPC metadata key convention?)
+- How are OpenZiti service policies scoped per MCP server workload? (Per-MCP-server identity? Derived from MCP server config?)
 
 ---
 

--- a/open-questions.md
+++ b/open-questions.md
@@ -36,31 +36,42 @@ Unresolved architectural decisions requiring discussion.
 
 ---
 
-## Orchestrator Horizontal Scaling
+## Agents Orchestrator Horizontal Scaling
 
-**Context:** The [Orchestrator](architecture/orchestrator.md) runs a single reconciliation loop. For horizontal scaling, reconciliation passes need to be partitioned across instances.
+**Context:** The [Agents Orchestrator](architecture/orchestrator.md) runs a single reconciliation loop. For horizontal scaling, reconciliation passes need to be partitioned across instances.
 
 **Questions:**
 - Sharding strategy: tenant-based, consistent hashing over agent identity IDs, or leader election?
 - How is shard assignment coordinated? (Lease-based via PostgreSQL? External coordination service?)
 
+---
+
+## MCP Discovery Service
+
+**Context:** MCP servers run as sidecars within agent workloads. For tool discovery (e.g., UI listing available tools from an MCP server), an ephemeral MCP workload must be started without an agent. This is handled by a separate MCP Discovery service, not the Agents Orchestrator.
+
+**Questions:**
+- What is the interface for requesting tool discovery? (gRPC API? Signal table in PostgreSQL?)
+- How does the UI query the running MCP server's tool listing? (Through a platform service? Direct gRPC?)
+- How is the ephemeral workload composed? (Adapter sidecar + OpenZiti sidecar, no agent container?)
+- What identity does a discovery workload use? (Ephemeral identity? Service-scoped identity?)
+- How is the TTL managed? (Discovery service reconciliation loop? Timer?)
 
 ---
 
 ## OpenZiti Integration
 
-**Context:** The platform uses OpenZiti for network-level identity and mTLS for agents, MCP servers, channels, and runners. Service tokens bootstrap enrollment. See [Authentication](architecture/authn.md).
+**Context:** The platform uses OpenZiti for network-level identity and mTLS for agents, channels, and runners. Service tokens bootstrap enrollment. See [Authentication](architecture/authn.md).
 
 **Questions:**
 - How does Runner integrate with the OpenZiti Controller API to manage agent identities? (SDK? CLI? REST?)
-- What is the identity lifecycle for agent containers on crash/orphan? (Runner cleanup? TTL on identity? Reconciliation?)
+- What is the identity lifecycle for agent workloads on crash/orphan? (Runner cleanup? TTL on identity? Reconciliation?)
 - How are OpenZiti service policies managed? (Per-agent? Per-tenant? Static set of allowed services?)
 - How does Gateway extract identity from OpenZiti mTLS connections?
 - Can OpenZiti identities carry tenant metadata, or must the platform maintain a separate identity-to-tenant mapping?
 - How does an external runner enroll with the platform's OpenZiti network? (Same service token flow?)
 - What services can agent containers on external runners access? (Only Gateway? Direct access to Threads, Files?)
 - How is end-user identity propagated across internal service boundaries? (gRPC metadata key convention?)
-- How are OpenZiti service policies scoped per MCP server workload? (Per-MCP-server identity? Derived from MCP server config?)
 
 ---
 


### PR DESCRIPTION
## Summary

Rewrites the orchestrator architecture from an agents-only orchestrator to a general workload orchestrator that manages agents, MCP servers, and discovery signals. Adds the MCP Adapter as a new component.

### Key design decisions

**Orchestrator scope expansion:**
- Renamed from "Agents Orchestrator" to "Orchestrator" — reconciles all workload types.
- **MCP servers are separate workloads**, not sidecars. Each MCP server gets its own OpenZiti identity with independently scoped network access.
- **Dependency ordering** — Orchestrator starts MCP server workloads first, waits for readiness, then starts agent workloads. On shutdown, agents stop first; MCP servers stop when no agents reference them.
- **MCP server demand** has two sources: agent config references (agent dependency) and discovery signals (short-TTL for tool listing from UI).
- **Tool discovery** — UI creates a short-TTL signal, Orchestrator starts MCP workload, UI queries tools through a platform service, workload auto-stops on TTL expiry. Reuses the same reconciliation loop.
- State tables split: `workload_assignments` (shared) + `agent_assignments` + `mcp_assignments`.

**MCP Adapter (new component):**
- Standalone binary added to any MCP server image as the container entrypoint.
- Launches the MCP server process as a subprocess and bridges its native transport to gRPC.
- **stdio mode**: communicates with the subprocess via stdin/stdout (JSON-RPC). Supports the majority of existing MCP servers distributed via `npx`, `uvx`, etc.
- **HTTP mode**: launches the subprocess, waits for it to listen, connects via Streamable HTTP locally, exposes gRPC externally.
- Agents always talk gRPC to MCP servers over OpenZiti — uniform interface regardless of underlying MCP transport.
- Configuration via CLI flags: `adapter --mode stdio --command "npx best-mcp-server" --grpc-port 50051`.

**MCP Server resource definition updated:**
- New fields: `image` (required), `transport` (stdio/http), `httpPort`.
- `image` and `command` now required (MCP server is its own workload, needs an image).

### Files changed

**New:**
- `architecture/mcp-adapter.md` — MCP Adapter architecture

**Rewritten:**
- `architecture/orchestrator.md` — general workload orchestrator

**Updated (cross-references and naming):**
- `architecture/agent/overview.md` — MCP servers as separate workloads, gRPC over OpenZiti
- `architecture/system-overview.md` — component diagram, summary, repo map
- `architecture/control-data-plane.md` — renamed, updated reconciliation resources
- `architecture/resource-definitions.md` — MCP Server fields
- `architecture/authn.md` — MCP server identities
- `architecture/notifications.md` — broadcast rooms
- `architecture/runner.md` — identity management for all workload types
- `README.md` — doc index
- `gaps/current-state.md` — renamed
- `gaps/migration-roadmap.md` — renamed
- `open-questions.md` — updated references, added MCP identity scoping question