### PR TITLE
Remove monolith references

### DIFF
--- a/architecture/gateway.md
+++ b/architecture/gateway.md
@@ -9,9 +9,9 @@ The gateway is accessible via two ingress paths:
 | Path | Host | Prefix stripped | Use case |
 |------|------|-----------------|----------|
 | Subdomain | `gateway.agyn.dev` | No | Direct access, service-to-service |
-| Path-based | `agyn.dev/apiv2/` | Yes (`/apiv2/` → `/`) | UI consumption (same origin as the web app) |
+| Path-based | `agyn.dev/api/` | Yes (`/api/` → `/`) | UI consumption (same origin as the web app) |
 
-The path-based route allows the web app (platform-ui) to call new gateway-backed APIs without cross-origin requests. Legacy monolith APIs remain at `/api` on the same domain.
+The path-based route allows the web app (platform-ui) to call gateway APIs without cross-origin requests.
 
 ## Responsibilities
 
@@ -111,6 +111,6 @@ The gateway (`agynio/gateway`, Go) uses:
 The gateway receives traffic through two Istio VirtualService routes (defined in `agynio/bootstrap`, `stacks/platform/main.tf`):
 
 1. **Subdomain route** (`virtualservice_gateway`): `gateway.agyn.dev/*` → `gateway-gateway:8080`. No URI rewrite.
-2. **Path-based route** (`virtualservice_platform_ui`): `agyn.dev/apiv2/*` → `gateway-gateway:8080` with URI rewrite (`/apiv2/` → `/`). This route is defined on the same VirtualService as the platform-ui and platform-server routes.
+2. **Path-based route** (`virtualservice_platform_ui`): `agyn.dev/api/*` → `gateway-gateway:8080` with URI rewrite (`/api/` → `/`). This route is defined on the same VirtualService as the platform-ui route.
 
-The UI uses the path-based route (`/apiv2/`) so that both the legacy monolith API (`/api`) and the new gateway API (`/apiv2/`) are served from the same origin, avoiding CORS overhead.
+The UI uses the path-based route (`/api/`) so that the gateway API is served from the same origin as the web app, avoiding CORS overhead.

--- a/architecture/operations/local-development.md
+++ b/architecture/operations/local-development.md
@@ -49,15 +49,15 @@ After the health check completes, the pipeline calls `stop_dev` so the session c
 | `stop_dev` | Deregisters active dev sessions and tears down sync/forwarding. | Allows DevSpace to exit while leaving the patched pod in place. |
 | `WaitDev()` | Blocks only while dev sessions are registered. | Exits immediately after `stop_dev` in default mode; remains running in watch mode. |
 
-### Example: Platform Server
+### Example: Gateway
 
 ```bash
-cd platform/packages/platform-server
+cd gateway
 devspace dev
 ```
 
 This:
-- Pauses Argo CD auto-sync for the platform-server Application.
+- Pauses Argo CD auto-sync for the gateway Application.
 - Syncs local source into the running container.
 - Starts the dev server with hot-reload.
 - Restores auto-sync on session exit.

--- a/architecture/runner.md
+++ b/architecture/runner.md
@@ -8,7 +8,7 @@ Multiple implementations exist for different backends:
 
 | Implementation | Backend | Status |
 |----------------|---------|--------|
-| `docker-runner` | Docker Engine | Existing (`agynio/platform`) |
+| `docker-runner` | Docker Engine | Existing (`agynio/docker-runner`) |
 | [`k8s-runner`](k8s-runner.md) | Kubernetes | Planned |
 
 ## gRPC API

--- a/architecture/system-overview.md
+++ b/architecture/system-overview.md
@@ -44,12 +44,7 @@ graph TB
         MCP2[MCP Server]
     end
 
-    subgraph Monolith
-        PS[platform-server]
-    end
-
-    WebApp & MobileApp -- "/apiv2/" --> Gateway
-    WebApp & MobileApp -- "/api" --> PS
+    WebApp & MobileApp -- "/api/" --> Gateway
     ThirdParty <--> Channels
 
     Gateway --> ZitiMgmt
@@ -113,7 +108,7 @@ graph TB
 | **Tracing** | Ingestion and query of tracing data. Extended OpenTelemetry protocol for real-time in-progress events |
 | **[Agents](agents-service.md)** | Management of agent resources: agents, volumes, MCP servers, skills, hooks, etc. |
 | **Runner** | Executes workloads. Implementations: docker-runner, k8s-runner |
-| **Gateway** | Exposes platform methods for external usage via [ConnectRPC](gateway.md#connectrpc) (gRPC + HTTP/JSON). Validates tenant access per-request via Authorization. Accessible at `gateway.agyn.dev` (subdomain) and `agyn.dev/apiv2/` (path-based, prefix stripped) |
+| **Gateway** | Exposes platform methods for external usage via [ConnectRPC](gateway.md#connectrpc) (gRPC + HTTP/JSON). Validates tenant access per-request via Authorization. Accessible at `gateway.agyn.dev` (subdomain) and `agyn.dev/api/` (path-based, prefix stripped) |
 | **Ziti Management** | Manages OpenZiti identities, services, and policies. Encapsulates all OpenZiti Controller API interactions |
 
 ## Data Stores
@@ -131,7 +126,6 @@ graph TB
 | Repository | Contents | Language | Status |
 |------------|----------|----------|--------|
 | `agynio/api` | API schemas: protobuf (internal gRPC + external gateway ConnectRPC) | Proto | Active |
-| `agynio/platform` | Monolith: platform-server, docker-runner, LLM package, platform-ui | TypeScript | Active (being decomposed) |
 | `agynio/notifications` | Notifications service | Go | Standalone service |
 | `agynio/gateway` | Gateway service | Go | Standalone service |
 | `agynio/agent-state` | Agent State (APSS) service | Go | Standalone service |

--- a/gaps/runner-hmac-removal.md
+++ b/gaps/runner-hmac-removal.md
@@ -2,4 +2,4 @@
 
 HMAC shared secret (`DOCKER_RUNNER_SHARED_SECRET`) was removed from the Runner architecture. OpenZiti mTLS is the sole authentication mechanism for Orchestrator ↔ Runner communication.
 
-Affects `agynio/platform` (docker-runner) and `agynio/agents-orchestrator`.
+Affects `agynio/docker-runner` and `agynio/agents-orchestrator`.

--- a/open-questions.md
+++ b/open-questions.md
@@ -18,7 +18,7 @@ Unresolved architectural decisions requiring discussion.
 
 ## Threads Service Data Store
 
-**Context:** Threads is being extracted from the monolith into a standalone service.
+**Context:** Threads is being extracted into a standalone service.
 
 **Questions:**
 - Dedicated PostgreSQL schema or separate database?


### PR DESCRIPTION
## Summary
- update gateway path references to `/api/` and remove monolith mentions
- refresh local development example and docker-runner repo references
- clean up system overview diagram and repository map

## Testing
- Not run (no tests or lint configured)

Refs #47