### PR TITLE
architecture: expand Tracing service documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Target architecture of the platform. Describes how the system should work.
 | [k8s-runner](architecture/k8s-runner.md) | Kubernetes-native Runner implementation |
 | [Agents Orchestrator](architecture/agents-orchestrator.md) | Agent workload reconciliation — start, monitor, stop |
 | [Agents Service](architecture/agents-service.md) | Agent resource management |
-| [Tracing](architecture/tracing.md) | Tracing ingestion and query service |
+| [Tracing](architecture/tracing.md) | Span ingestion and query — standard OTLP with upsert for in-progress spans |
 | [Gateway](architecture/gateway.md) | External API surface — ConnectRPC (gRPC + HTTP/JSON) |
 | [API Contracts](architecture/api-contracts.md) | Proto schema conventions for internal and external APIs |
 

--- a/architecture/api-contracts.md
+++ b/architecture/api-contracts.md
@@ -27,6 +27,7 @@ Services **do not** commit generated schema code in their own repositories. They
 | Agent State | `agynio/api/agent_state/v1/agent_state.proto` |
 | Threads | `agynio/api/threads/v1/threads.proto` |
 | Chat | `agynio/api/chat/v1/chat.proto` |
+| Tracing | `agynio/api/tracing/v1/tracing.proto` |
 
 ### Conventions
 

--- a/architecture/notifications.md
+++ b/architecture/notifications.md
@@ -83,6 +83,7 @@ Rooms are scoped by resource type and ID:
 | `thread_participant:{id}` | `thread_participant:550e8400-...` | Threads → message recipients (agents, channels, users) |
 | `workload:{id}` | `workload:7c9e6679-...` | Runner → workload status changes, log events |
 | `agent:{id}` | `agent:f47ac10b-...` | Agents → agent resource updates |
+| `trace:{trace_id}` | `trace:5b8efff7-...` | Tracing → span created/updated events for a trace |
 
 Consumers subscribe to rooms matching their identity or the resources they observe. A channel subscribes to `thread_participant:{channelId}`. A UI client displaying agent logs subscribes to `workload:{workloadId}`.
 

--- a/architecture/system-overview.md
+++ b/architecture/system-overview.md
@@ -105,7 +105,7 @@ graph TB
 | **Authorization** | Fine-grained access control. Thin proxy to OpenFGA — centralizes configuration, adds observability. Services call Authorization for permission checks and relationship writes |
 | **[Agents Orchestrator](agents-orchestrator.md)** | Reconciles agent workloads for threads with unacknowledged messages |
 | **Agent State** | Long-term agent context persistence (APSS) |
-| **Tracing** | Ingestion and query of tracing data. Extended OpenTelemetry protocol for real-time in-progress events |
+| **Tracing** | Span ingestion and query. Implements standard OTLP TraceService/Export with upsert semantics for in-progress spans |
 | **[Agents](agents-service.md)** | Management of agent resources: agents, volumes, MCP servers, skills, hooks, etc. |
 | **Runner** | Executes workloads. Implementations: docker-runner, k8s-runner |
 | **Gateway** | Exposes platform methods for external usage via [ConnectRPC](gateway.md#connectrpc) (gRPC + HTTP/JSON). Validates tenant access per-request via Authorization. Accessible at `gateway.agyn.dev` (subdomain) and `agyn.dev/api/` (path-based, prefix stripped) |
@@ -129,6 +129,7 @@ graph TB
 | `agynio/notifications` | Notifications service | Go | Standalone service |
 | `agynio/gateway` | Gateway service | Go | Standalone service |
 | `agynio/agent-state` | Agent State (APSS) service | Go | Standalone service |
+| `agynio/tracing` | Tracing service — span ingestion and query | Go | Planned |
 | `agynio/openfga-model` | OpenFGA authorization model and Terraform module | DSL, HCL | Planned |
 | `agynio/authorization` | Authorization service (thin proxy to OpenFGA) | Go | Planned |
 | `agynio/identity` | Identity registry service | Go | Planned |

--- a/architecture/tracing.md
+++ b/architecture/tracing.md
@@ -2,14 +2,204 @@
 
 ## Overview
 
-The Tracing service ingests and queries tracing data. It implements an **extended version of the OpenTelemetry protocol** to support real-time in-progress events — standard OpenTelemetry only captures completed spans, while Agyn needs visibility into ongoing agent operations.
+The Tracing service ingests, stores, and queries span data. It implements the standard [OpenTelemetry](https://opentelemetry.io/) Collector `TraceService/Export` gRPC interface with one behavioral extension: **upsert semantics for in-progress spans**. Standard OpenTelemetry assumes spans are exported once after completion. Agyn needs visibility into ongoing agent operations, so producers export the same span multiple times — first while in progress, then again when completed. The Tracing service detects duplicates by `(trace_id, span_id)` and patches the existing record instead of inserting a new one.
 
 ## Responsibilities
 
-- **Ingest** tracing data from agents and platform services.
-- **Query** traces and spans for observability UI.
-- **Real-time events** for in-progress operations (e.g., agent currently processing a tool call).
+- **Ingest** spans via the standard OTLP gRPC interface with upsert semantics.
+- **Store** spans in PostgreSQL.
+- **Query** traces and spans for the observability UI (list, filter, detail).
+- **Push notifications** on span creation and update so the UI receives real-time changes without polling.
 
 ## Integration
 
-Tracing is an **optional** dependency for agents. Agents can run without a tracing server configured.
+Tracing is an **optional** dependency for agents. Agents can run without a tracing endpoint configured.
+
+## Ingestion
+
+### Protocol
+
+The Tracing service implements the standard OTLP Collector gRPC interface:
+
+```
+opentelemetry.proto.collector.trace.v1.TraceService/Export
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `resource_spans` | repeated `ResourceSpans` | Standard OTLP envelope — resources → scopes → spans |
+
+Standard OTel SDK exporters (Go, Python, JS, etc.) can point their OTLP gRPC exporter at the Tracing service endpoint without modification.
+
+### Upsert Semantics
+
+For each span in the request, the service performs an upsert keyed on `(trace_id, span_id)`:
+
+- **No existing record** → insert.
+- **Existing record** → patch all fields with the incoming values.
+
+This allows producers to export a span multiple times during its lifecycle. The first export creates the record; subsequent exports update it as the operation progresses (new attributes, events, status changes, end time).
+
+### In-Progress Detection
+
+A span is considered **in-progress** when `end_time_unix_nano = 0`. A non-zero `end_time_unix_nano` indicates the span is **completed**.
+
+Producers set `end_time_unix_nano = 0` on intermediate exports and set the real end time on the final export.
+
+### Response
+
+The service returns the standard `ExportTraceServiceResponse`:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `partial_success.rejected_spans` | int64 | Number of spans rejected (0 = fully accepted) |
+| `partial_success.error_message` | string | Human-readable explanation if spans were rejected |
+
+## Data Model
+
+### Span (stored)
+
+Each span is stored as a row in PostgreSQL. The schema follows the [OTel Span](https://buf.build/opentelemetry/opentelemetry/docs/main:opentelemetry.proto.trace.v1#opentelemetry.proto.trace.v1.Span) data model.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `trace_id` | bytes (16) | Trace identifier |
+| `span_id` | bytes (8) | Span identifier |
+| `trace_state` | string | W3C trace-context trace state |
+| `parent_span_id` | bytes (8) | Parent span identifier (empty for root spans) |
+| `flags` | uint32 | W3C trace flags + OTel span flags |
+| `name` | string | Operation name |
+| `kind` | enum | `UNSPECIFIED`, `INTERNAL`, `SERVER`, `CLIENT`, `PRODUCER`, `CONSUMER` |
+| `start_time_unix_nano` | fixed64 | Span start time (nanoseconds since epoch) |
+| `end_time_unix_nano` | fixed64 | Span end time (0 = in-progress) |
+| `attributes` | repeated KeyValue | Span attributes |
+| `events` | repeated Event | Timestamped span events |
+| `links` | repeated Link | Links to other spans |
+| `status` | Status | Status code (`UNSET`, `OK`, `ERROR`) and message |
+| `dropped_attributes_count` | uint32 | Number of dropped attributes |
+| `dropped_events_count` | uint32 | Number of dropped events |
+| `dropped_links_count` | uint32 | Number of dropped links |
+
+**Resource** and **InstrumentationScope** metadata from the OTLP envelope are stored alongside the span (flattened or as JSONB columns — implementation detail).
+
+Primary key: `(trace_id, span_id)`.
+
+### Indexes
+
+| Index | Purpose |
+|-------|---------|
+| `(trace_id)` | Fetch all spans for a trace |
+| `(start_time_unix_nano)` | Time-range queries and ordering |
+| `(parent_span_id)` | Tree reconstruction |
+
+## Query API
+
+Defined in `agynio/api` at `proto/agynio/api/tracing/v1/tracing.proto`.
+
+| RPC | Description |
+|-----|-------------|
+| `ListSpans` | Paginated span listing with filters |
+| `GetSpan` | Single span by `(trace_id, span_id)` |
+| `GetTrace` | All spans for a `trace_id` |
+
+### ListSpans
+
+Returns a paginated list of spans matching the provided filters.
+
+**Request:**
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `filter` | `SpanFilter` | Filter criteria (all optional, AND-combined) |
+| `page_size` | int32 | Maximum number of spans to return |
+| `page_token` | string | Pagination cursor from previous response |
+| `order_by` | enum | `START_TIME_DESC` (default), `START_TIME_ASC` |
+
+**SpanFilter:**
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `trace_id` | bytes | Filter by trace |
+| `parent_span_id` | bytes | Filter by parent span |
+| `name` | string | Filter by operation name (exact match) |
+| `kind` | SpanKind | Filter by span kind |
+| `start_time_min` | fixed64 | Start time lower bound (inclusive) |
+| `start_time_max` | fixed64 | Start time upper bound (inclusive) |
+| `in_progress` | optional bool | `true` = only in-progress, `false` = only completed, unset = both |
+
+**Response:**
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `spans` | repeated `Span` | Matching spans |
+| `next_page_token` | string | Cursor for next page (empty = no more results) |
+
+### GetSpan
+
+Returns a single span.
+
+**Request:**
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `trace_id` | bytes (16) | Trace identifier |
+| `span_id` | bytes (8) | Span identifier |
+
+**Response:**
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `span` | `Span` | The span |
+
+### GetTrace
+
+Returns all spans belonging to a trace.
+
+**Request:**
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `trace_id` | bytes (16) | Trace identifier |
+
+**Response:**
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `spans` | repeated `Span` | All spans in the trace |
+
+## Notifications
+
+On every span insert or update, the Tracing service publishes an event to the [Notifications](notifications.md) service.
+
+| Event | Room | Published when |
+|-------|------|----------------|
+| `span.created` | `trace:{trace_id}` | A new span is inserted |
+| `span.updated` | `trace:{trace_id}` | An existing span is patched via upsert |
+
+The UI subscribes to `trace:{trace_id}` to receive real-time updates for all spans within a trace being viewed. This enables live visualization of in-progress operations without polling.
+
+## External API
+
+The [Gateway](gateway.md) exposes the Tracing query API via `TracingGateway`:
+
+| Gateway RPC | Internal RPC |
+|-------------|-------------|
+| `ListSpans` | `TracingService.ListSpans` |
+| `GetSpan` | `TracingService.GetSpan` |
+| `GetTrace` | `TracingService.GetTrace` |
+
+The ingestion endpoint (`TraceService/Export`) is the standard OTLP gRPC interface and is also exposed through the Gateway for producers that connect via the external API.
+
+## Authorization
+
+Access control for tracing data will be handled via ReBAC. The specific relationships and permissions are not yet defined — traces are independent resources not directly associated with an organization. The authorization model will be determined as the broader [ReBAC migration](authz.md) progresses.
+
+## Classification
+
+| Aspect | Detail |
+|--------|--------|
+| **Plane** | Data |
+| **API** | gRPC — OTLP `TraceService/Export` (ingestion) + `TracingService` (query) |
+| **State** | PostgreSQL |
+| **Scaling** | Scales with ingestion volume and query traffic |
+| **Failure impact** | Temporary loss drops incoming spans; existing data remains queryable after recovery |


### PR DESCRIPTION
## Summary

Replaces the Tracing stub with a full architecture document and updates cross-references across the repo.

### Tracing service doc (`architecture/tracing.md`)

- **Ingestion**: Standard OTLP `TraceService/Export` gRPC interface. Producers use unmodified OTel SDK exporters. The server applies upsert semantics keyed on `(trace_id, span_id)` — duplicate span IDs patch the existing record instead of inserting.
- **In-progress spans**: `end_time_unix_nano = 0` means in-progress; non-zero means completed. Producers re-export the same span as the operation progresses.
- **Data model**: Full OTel Span schema stored in PostgreSQL with `(trace_id, span_id)` primary key.
- **Query API**: `ListSpans` (paginated, filtered), `GetSpan`, `GetTrace` — defined in `agynio/api` at `proto/agynio/api/tracing/v1/tracing.proto`.
- **Notifications**: Publishes `span.created` / `span.updated` events to `trace:{trace_id}` rooms for real-time UI updates.
- **Authorization**: ReBAC placeholder — traces are independent resources; model TBD as the broader ReBAC migration progresses.
- **Classification**: Data plane, PostgreSQL-backed, scales with ingestion/query volume.

### Cross-reference updates

- `architecture/notifications.md` — added `trace:{trace_id}` to room naming convention table.
- `architecture/api-contracts.md` — added Tracing proto path to services table.
- `architecture/system-overview.md` — added `agynio/tracing` to repository map; updated component summary description.
- `README.md` — updated Tracing description in the index table.