### PR TITLE
arch: API tokens for programmable access

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ Target architecture of the platform. Describes how the system should work.
 | [Users](architecture/users.md) | User identity records, profiles, OIDC provisioning |
 | [Authentication](architecture/authn.md) | Identity types, OIDC, agent network auth, service tokens |
 | [Authorization](architecture/authz.md) | Fine-grained access control via OpenFGA. Authorization service, model, deployment |
+| [API Tokens](architecture/api-tokens.md) | Long-lived opaque tokens for programmatic access (CI, integrations, developer tooling) |
 | [Control Plane & Data Plane](architecture/control-data-plane.md) | Boundary definitions, criteria, service classification |
 | [Resource Definitions](architecture/resource-definitions.md) | Canonical schemas for all agent-managed resources |
 | [Agent](architecture/agent/) | Agent contract, our implementation, state persistence |

--- a/architecture/api-tokens.md
+++ b/architecture/api-tokens.md
@@ -1,0 +1,107 @@
+# API Tokens
+
+## Overview
+
+API tokens are long-lived, platform-issued credentials for programmatic access to the Gateway API. They are used by CI pipelines, API integrations, and developer tooling to authenticate without an interactive OIDC flow.
+
+An API token resolves to the same `identity_id` as the user who created it. Downstream services see no difference between a request authenticated via OIDC and one authenticated via API token — both produce the same identity context in gRPC metadata.
+
+## Token Format
+
+Opaque string with server-side lookup: `agyn_<random_44_chars>` — 256 bits of entropy, base62-encoded. The `agyn_` prefix identifies the token type and enables secret scanning (e.g., GitHub secret scanning).
+
+The token value is **hashed** (SHA-256) before storage. The plaintext is returned to the user exactly once at creation time. Lookup is by hash.
+
+## Token Model
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `id` | string (UUID) | Token identifier (for management — list, revoke) |
+| `identity_id` | string (UUID) | Owning user's identity ID |
+| `name` | string | Human-readable label (e.g., "CI pipeline", "local dev") |
+| `token_hash` | string | SHA-256 hash of the token value. Lookup key |
+| `token_prefix` | string | First 8 characters of the token (for identification in UI without exposing the full value) |
+| `expires_at` | timestamp (nullable) | Expiration time. Null = no expiration |
+| `created_at` | timestamp | Creation time |
+| `last_used_at` | timestamp (nullable) | Last successful authentication time |
+
+## Issuing Service
+
+The [Users](users.md) service owns API tokens. Tokens are stored in a `user_api_tokens` table in the Users service database.
+
+## Interface
+
+| Method | Description |
+|--------|-------------|
+| **CreateAPIToken** | Create a token for the calling user. Returns the plaintext token **once**. Accepts `name` and optional `expires_at` |
+| **ListAPITokens** | List tokens for the calling user. Returns metadata only (id, name, prefix, created_at, expires_at, last_used_at). Never returns the token value |
+| **RevokeAPIToken** | Delete a token by ID. Caller must own the token |
+| **ResolveAPIToken** | Look up a token by hash. Returns `identity_id` and token metadata if valid. Called by the Gateway |
+
+`CreateAPIToken`, `ListAPITokens`, and `RevokeAPIToken` are exposed through the Gateway (`UsersGateway` proto service). `ResolveAPIToken` is internal — called only by the Gateway during authentication.
+
+## Gateway Authentication Flow
+
+The Gateway distinguishes between IdP JWTs and platform API tokens by the token prefix:
+
+```
+if token starts with "agyn_":
+    → API token path
+else:
+    → OIDC path (existing flow)
+```
+
+### API Token Path
+
+```mermaid
+sequenceDiagram
+    participant Client as Client (CI / CLI / Integration)
+    participant GW as Gateway
+    participant US as Users
+
+    Client->>GW: API request (Bearer agyn_...)
+    GW->>GW: Detect "agyn_" prefix → API token path
+    GW->>GW: SHA-256 hash the token
+    GW->>US: ResolveAPIToken(token_hash)
+    US-->>GW: identity_id + token metadata (or not found / expired)
+    alt Token valid
+        GW->>GW: Propagate identity_id in gRPC metadata
+    else Token not found or expired
+        GW->>Client: 401 Unauthenticated
+    end
+```
+
+Both authentication paths produce the same output: an `identity_id` propagated in gRPC metadata. Downstream services are unaware of the authentication method.
+
+## Permissions
+
+An API token carries the same permissions as the user who created it. The resolved `identity_id` is the user's `identity_id` — [authorization](authz.md) checks in OpenFGA see the same identity regardless of authentication method. No token-level scopes.
+
+## Token Lifecycle
+
+| Concern | Behavior |
+|---------|----------|
+| **Creation** | User creates via CLI or API. Plaintext returned once |
+| **Expiration** | Optional. If set, the Gateway rejects expired tokens. If not set, the token lives until revoked |
+| **Revocation** | User revokes via CLI or API. Immediate — next request with that token is rejected |
+| **Rotation** | Manual. User creates a new token, updates the integration, then revokes the old one |
+| **`last_used_at`** | Updated on each successful `ResolveAPIToken` call |
+
+## Management
+
+| Interface | Capability |
+|-----------|-----------|
+| **CLI** | `agyn auth create-token --name "CI pipeline"` → prints token once. `agyn auth list-tokens`. `agyn auth revoke-token <id>` |
+| **Gateway API** | `UsersGateway` proto service: `CreateAPIToken`, `ListAPITokens`, `RevokeAPIToken` |
+
+## CLI Integration
+
+The created token is stored in `~/.agyn/credentials` — the same path all CLI tools already read (see [CLI Authentication](authn.md#cli-authentication)). The token format (`agyn_...`) is opaque to the CLI — it is sent as a bearer token to the Gateway like any other auth token.
+
+## Data Store
+
+PostgreSQL. `user_api_tokens` table in the [Users](users.md) service database. System-wide — not scoped to an organization.
+
+## Classification
+
+**Data plane** — token resolution is on the hot path for every API-token-authenticated request.

--- a/architecture/authn.md
+++ b/architecture/authn.md
@@ -8,7 +8,7 @@ The platform authenticates four types of identities. Each identity type has its 
 
 | Type | Description | Authentication Method |
 |------|-------------|----------------------|
-| **User** | Human operator using web/mobile app | OIDC |
+| **User** | Human operator using web/mobile app | OIDC or [API token](api-tokens.md) |
 | **Agent** | Agent container calling platform APIs | OpenZiti (network identity) |
 | **Channel** | Channel service connecting to external apps | OpenZiti (network identity) |
 | **Runner** | Runner executing workloads | OpenZiti (network identity) |
@@ -226,7 +226,7 @@ They operate on different connections:
 
 ## Authentication Boundary
 
-**External traffic**: Authenticated at the **Gateway**. Users via OIDC access token validation (JWT signature verified against IdP JWKS, identity resolved through [Users](users.md)). Agents, Channels, Runners via OpenZiti mTLS (identity extracted via [Ziti Management](openziti.md)). Organization membership is not validated at the Gateway — it is enforced by the [authorization model](authz.md) at the service level.
+**External traffic**: Authenticated at the **Gateway**. Users via OIDC access token validation (JWT signature verified against IdP JWKS, identity resolved through [Users](users.md)) or via [API token](api-tokens.md) (opaque token, identity resolved through [Users](users.md)). Agents, Channels, Runners via OpenZiti mTLS (identity extracted via [Ziti Management](openziti.md)). Organization membership is not validated at the Gateway — it is enforced by the [authorization model](authz.md) at the service level.
 
 **Internal traffic**: Authenticated by **Istio** mTLS (service identity from ServiceAccount). End-user/agent identity propagated in gRPC metadata after Gateway authentication.
 
@@ -236,7 +236,7 @@ They operate on different connections:
 
 ## CLI Authentication
 
-All platform CLI tools ([`agyn`](agyn-cli.md), [`agynd`](agynd-cli.md), [`agn`](agn-cli.md)) use the same authentication convention with two methods and a fixed priority order. The auth token stored in `~/.agyn/credentials` is any token the Gateway accepts (see [Open Questions — Long-Lived Tokens](../open-questions.md#long-lived-tokens-for-programmable-access)).
+All platform CLI tools ([`agyn`](agyn-cli.md), [`agynd`](agynd-cli.md), [`agn`](agn-cli.md)) use the same authentication convention with two methods and a fixed priority order. The auth token stored in `~/.agyn/credentials` is any token the Gateway accepts — an OIDC access token from a login flow or a long-lived [API token](api-tokens.md) created via `agyn auth create-token`.
 
 | Priority | Method | Mechanism | When Used |
 |----------|--------|-----------|-----------|

--- a/architecture/gateway.md
+++ b/architecture/gateway.md
@@ -18,7 +18,7 @@ The path-based route allows the web app (platform-ui) to call gateway APIs witho
 - Route external API requests to internal services.
 - Serve both gRPC and HTTP/JSON protocols from the same handler using [ConnectRPC](#connectrpc).
 - Stream multipart file uploads to FilesService.UploadFile (client-streaming gRPC).
-- Authenticate requests and resolve identity context. For OIDC users: validate the `access_token` JWT signature against the IdP's JWKS endpoint, extract the `sub` claim, and resolve identity via [Users](users.md) service (`ResolveUser` / `CreateUser`). For OpenZiti actors: resolve identity via [Ziti Management](openziti.md). Every request is authenticated independently via the bearer token. Organization membership is validated by the [authorization model](authz.md), checked by the service performing the operation. See [Authentication](authn.md) and [Organizations — Request Flow](organizations.md#request-flow).
+- Authenticate requests and resolve identity context. For OIDC users: validate the `access_token` JWT signature against the IdP's JWKS endpoint, extract the `sub` claim, and resolve identity via [Users](users.md) service (`ResolveUser` / `CreateUser`). For [API token](api-tokens.md) holders: hash the token and resolve identity via [Users](users.md) service (`ResolveAPIToken`). For OpenZiti actors: resolve identity via [Ziti Management](openziti.md). Every request is authenticated independently via the bearer token. Organization membership is validated by the [authorization model](authz.md), checked by the service performing the operation. See [Authentication](authn.md) and [Organizations — Request Flow](organizations.md#request-flow).
 
 ## ConnectRPC
 
@@ -75,6 +75,7 @@ Only methods intended for external use appear in gateway proto services. Interna
 | `LLMGateway` | [LLM](llm.md) | CreateChatCompletion (proxied LLM calls) |
 | `TracingGateway` | [Tracing](tracing.md) | Ingest, Query |
 | `SecretsGateway` | [Secrets](secrets.md) | ResolveSecretValue |
+| `UsersGateway` | [Users](users.md) | CreateAPIToken, ListAPITokens, RevokeAPIToken |
 
 ### Handler Implementation
 

--- a/architecture/users.md
+++ b/architecture/users.md
@@ -15,6 +15,7 @@ User records are system-wide — not scoped to an organization. User-to-organiza
 | **User profile** | Store and serve user profile data (name, nickname, photo URL) |
 | **User lookup** | Resolve a user by `identity_id` or by OIDC subject |
 | **Batch profile resolution** | Return profiles for a list of identity IDs |
+| **API token management** | Create, list, revoke, and resolve [API tokens](api-tokens.md) for programmatic access |
 
 ## User Model
 
@@ -36,6 +37,10 @@ User records are system-wide — not scoped to an organization. User-to-organiza
 | **CreateUser** | Provision a new user record from OIDC subject and profile claims. Registers the identity in the [Identity](identity.md) service. Returns `identity_id` |
 | **GetUser** | Return a user profile by `identity_id` |
 | **BatchGetUsers** | Return profiles for a list of identity IDs |
+| **CreateAPIToken** | Create an [API token](api-tokens.md) for the calling user. Returns the plaintext token once |
+| **ListAPITokens** | List API tokens for the calling user. Returns metadata only (never the token value) |
+| **RevokeAPIToken** | Delete an API token by ID. Caller must own the token |
+| **ResolveAPIToken** | Look up an API token by hash. Returns `identity_id` if valid. Called by the Gateway |
 
 ## Resolution and Provisioning Flow
 
@@ -75,13 +80,13 @@ Initial profile fields (name, email, picture) are populated from the IdP UserInf
 
 | Consumer | Usage |
 |----------|-------|
-| **Gateway** | Resolve OIDC subject → `identity_id` on every request (`ResolveUser`). Provision new users on first login (`CreateUser`) |
+| **Gateway** | Resolve OIDC subject → `identity_id` on every request (`ResolveUser`). Provision new users on first login (`CreateUser`). Resolve [API tokens](api-tokens.md) → `identity_id` (`ResolveAPIToken`) |
 | **Chat** | Resolve user profiles for message display (sender name, photo) |
 | **UI** | Display user profile, profile editing |
 
 ## Data Store
 
-PostgreSQL. System-wide `users` table.
+PostgreSQL. System-wide `users` and `user_api_tokens` tables. See [API Tokens](api-tokens.md) for the token model.
 
 ## Classification
 

--- a/open-questions.md
+++ b/open-questions.md
@@ -134,19 +134,3 @@ Unresolved architectural decisions requiring discussion.
 - What is the migration path from single namespace to per-organization if needed later?
 
 **Decision:** Single namespace for now. Revisit when organizational isolation requirements are clarified.
-
----
-
-## Long-Lived Tokens for Programmable Access
-
-**Context:** Currently, all user authentication goes through OIDC — the SPA performs the PKCE flow and sends IdP-issued access tokens to the Gateway. CLI tools (`agyn`, `agynd`, `agn`) also store a token in `~/.agyn/credentials`. For programmable access (CI pipelines, API integrations, developer tooling), short-lived IdP tokens are insufficient — users need long-lived tokens issued by the platform itself.
-
-**Questions:**
-- What is the token format? (JWT signed by the platform? Opaque token with server-side lookup?)
-- Who issues the tokens? (A dedicated endpoint on the Gateway? The Users service?)
-- What is the token lifecycle? (Expiration, revocation, rotation)
-- How does the Gateway distinguish between IdP tokens and platform-issued tokens to apply the correct validation?
-- What scopes or permissions do long-lived tokens carry? (Same as the user's OIDC identity? Restricted subset?)
-- How are tokens created and managed? (UI? CLI `agyn auth create-token`? API?)
-
-**Decision:** TBD


### PR DESCRIPTION
## Summary

Resolves the **Long-Lived Tokens for Programmable Access** open question by adding a new architecture document and updating all cross-references.

## Design Decisions

| Decision | Choice | Rationale |
|----------|--------|-----------|
| Token format | Opaque (`agyn_<random>`) with server-side lookup | Instant revocation, no key management, no info leakage, consistent with existing per-request service call pattern |
| Storage | SHA-256 hash in DB, plaintext shown once | Standard secret storage practice |
| Issuing service | Users service | Natural extension of user identity, already on Gateway hot path |
| Gateway routing | `agyn_` prefix detection | Trivial to distinguish from IdP JWTs, enables token scanner detection |
| Permissions | Same as owning user (no scopes) | Avoids parallel permission model alongside ReBAC; scoping can be layered later |
| Lifecycle | Optional expiration, manual revocation, `last_used_at` tracking | Simple, sufficient for CI/integration use cases |
| Management | CLI (`agyn auth`) + Gateway API (`UsersGateway`) | CLI-first for developer ergonomics |

## Changes

| File | Change |
|------|--------|
| `architecture/api-tokens.md` | **New** — full architecture document |
| `architecture/authn.md` | Updated identity types table, authentication boundary, and CLI auth sections to reference API tokens |
| `architecture/users.md` | Added API token responsibility, interface methods, consumer update, data store update |
| `architecture/gateway.md` | Added API token auth to responsibilities, `UsersGateway` to exposed services table |
| `README.md` | Added API Tokens row to architecture table |
| `open-questions.md` | Removed resolved "Long-Lived Tokens" question |