### PR TITLE
Clear k8s-runner gap

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,6 @@ What needs to change in services to match the current architecture.
 
 | Document | Description |
 |----------|-------------|
-| [k8s-runner](gaps/k8s-runner.md) | New service — full implementation needed |
 | [OpenZiti SDK Embedding](gaps/openziti-sdk-embedding.md) | Orchestrator, Runner, Gateway: embed SDK, remove sidecar/tunneler |
 | [Runner HMAC Removal](gaps/runner-hmac-removal.md) | Remove HMAC auth from docker-runner and Orchestrator |
 | [Organizations Migration](gaps/organizations-migration.md) | Tenants → Organizations: rename service, update resource scoping, remove tenant headers |

--- a/gaps/k8s-runner.md
+++ b/gaps/k8s-runner.md
@@ -1,7 +1,0 @@
-# k8s-runner
-
-New service was introduced: [k8s-runner](../architecture/k8s-runner.md).
-
-Kubernetes-native Runner implementation (`agynio/k8s-runner`, Go). Implements the same `RunnerService` gRPC API as docker-runner, backed by the Kubernetes API (Pod, PVC, emptyDir, exec, log streaming). Embeds the OpenZiti Go SDK to bind the `runner` service. Identity provisioned by Terraform, loaded from Kubernetes Secret.
-
-Repository `agynio/k8s-runner` does not exist yet.


### PR DESCRIPTION
## Summary

Removes the `k8s-runner` gap document and its entry from the README.

## Reason

The gap stated that `agynio/k8s-runner` did not exist yet. The repository now exists with a full implementation aligned to the [architecture spec](architecture/k8s-runner.md):

- All `RunnerService` RPCs implemented (workload lifecycle, query, exec, streaming, storage)
- Kubernetes mapping matches architecture (Pod, emptyDir, PVC, `restartPolicy: Never`)
- OpenZiti Go SDK embedded for authentication
- CI, Dockerfile, Helm chart, DevSpace config, unit tests, and E2E tests present