### PR TITLE
Remove docker-runner references from documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ What needs to change in services to match the current architecture.
 
 | Document | Description |
 |----------|-------------|
-| [Runner HMAC Removal](gaps/runner-hmac-removal.md) | Remove HMAC auth from docker-runner and Orchestrator |
+| [Runner HMAC Removal](gaps/runner-hmac-removal.md) | Remove HMAC auth from Runner and Orchestrator |
 | [Organizations Migration](gaps/organizations-migration.md) | Tenants → Organizations: rename service, update resource scoping, remove tenant headers |
 
 ### [Open Questions](open-questions.md)

--- a/architecture/k8s-runner.md
+++ b/architecture/k8s-runner.md
@@ -9,7 +9,7 @@ The k8s-runner is the Kubernetes-native implementation of the [Runner](runner.md
 | **Plane** | Data |
 | **Language** | Go |
 | **Repository** | `agynio/k8s-runner` |
-| **API** | gRPC — same `RunnerService` as docker-runner |
+| **API** | gRPC (`RunnerService`) |
 | **Backend** | Kubernetes API (in-cluster) |
 | **Authentication** | OpenZiti network identity (SDK-embedded) |
 
@@ -107,7 +107,7 @@ The k8s-runner translates the gRPC bidirectional stream into the Kubernetes SPDY
 | `PutArchive` | Exec `tar` inside the target container to extract the uploaded archive |
 | `RemoveVolume` | Delete the PVC |
 
-`PutArchive` opens an exec session to the target container, pipes the tar archive into `tar -x`, and reports success or failure. This matches the docker-runner approach (Docker's `PUT /containers/{id}/archive` also extracts a tar inside the container).
+`PutArchive` opens an exec session to the target container, pipes the tar archive into `tar -x`, and reports success or failure.
 
 ## Namespace
 

--- a/architecture/operations/e2e-testing.md
+++ b/architecture/operations/e2e-testing.md
@@ -344,13 +344,13 @@ deployments:
         containers:
           - image: ${E2E_IMAGE}
         labels:
-          app.kubernetes.io/name: docker-runner-e2e
+          app.kubernetes.io/name: my-service-e2e
 
 dev:
   e2e-runner:
     namespace: ${SERVICE_NAMESPACE}
     labelSelector:
-      app.kubernetes.io/name: docker-runner-e2e
+      app.kubernetes.io/name: my-service-e2e
     command: ["sleep", "infinity"]
     workingDir: /opt/app/data
     sync:
@@ -367,7 +367,7 @@ pipelines:
       start_dev e2e-runner &
       sleep 5
       exec_container \
-        --label-selector "app.kubernetes.io/name=docker-runner-e2e" \
+        --label-selector "app.kubernetes.io/name=my-service-e2e" \
         -n ${SERVICE_NAMESPACE} \
         -- bash -c 'cd /opt/app/data && pnpm install --frozen-lockfile && pnpm test:e2e'
       EXIT_CODE=$?

--- a/architecture/runner.md
+++ b/architecture/runner.md
@@ -4,12 +4,7 @@
 
 The Runner executes workloads (agent containers, workspace containers, sidecars). It is a **data plane** service — it does not decide what to run, it executes what it is told.
 
-Multiple implementations exist for different backends:
-
-| Implementation | Backend | Status |
-|----------------|---------|--------|
-| `docker-runner` | Docker Engine | Existing (`agynio/docker-runner`) |
-| [`k8s-runner`](k8s-runner.md) | Kubernetes | Planned |
+The current implementation is the [`k8s-runner`](k8s-runner.md), which translates workload operations into Kubernetes API calls.
 
 ## gRPC API
 

--- a/architecture/system-overview.md
+++ b/architecture/system-overview.md
@@ -107,7 +107,7 @@ graph TB
 | **Agent State** | Long-term agent context persistence (APSS) |
 | **Tracing** | Span ingestion and query. Implements standard OTLP TraceService/Export with upsert semantics for in-progress spans |
 | **[Agents](agents-service.md)** | Management of agent resources: agents, volumes, MCP servers, skills, hooks, etc. |
-| **Runner** | Executes workloads. Implementations: docker-runner, k8s-runner |
+| **Runner** | Executes workloads. Current implementation: [k8s-runner](k8s-runner.md) |
 | **Gateway** | Exposes platform methods for external usage via [ConnectRPC](gateway.md#connectrpc) (gRPC + HTTP/JSON). Accessible at `gateway.agyn.dev` (subdomain) and `agyn.dev/api/` (path-based, prefix stripped) |
 | **Ziti Management** | Manages OpenZiti identities, services, and policies. Encapsulates all OpenZiti Controller API interactions |
 

--- a/gaps/runner-hmac-removal.md
+++ b/gaps/runner-hmac-removal.md
@@ -1,5 +1,5 @@
 # Runner HMAC Auth Removal
 
-HMAC shared secret (`DOCKER_RUNNER_SHARED_SECRET`) was removed from the Runner architecture. OpenZiti mTLS is the sole authentication mechanism for Orchestrator ↔ Runner communication.
+HMAC shared secret authentication was removed from the Runner architecture. OpenZiti mTLS is the sole authentication mechanism for Orchestrator ↔ Runner communication.
 
-Affects `agynio/docker-runner` and `agynio/agents-orchestrator`.
+Affects `agynio/k8s-runner` and `agynio/agents-orchestrator`.


### PR DESCRIPTION
## Summary

k8s-runner has replaced docker-runner as the sole Runner implementation. This PR removes all docker-runner references from the architecture documentation to reflect the current state.

## Changes

| File | Change |
|------|--------|
| `architecture/runner.md` | Replaced multi-implementation table with single-line k8s-runner reference |
| `architecture/k8s-runner.md` | Removed "same RunnerService as docker-runner" and docker-runner comparison in PutArchive |
| `architecture/system-overview.md` | Updated Runner description in component summary |
| `architecture/operations/e2e-testing.md` | Replaced `docker-runner-e2e` labels with generic `my-service-e2e` in TypeScript example |
| `gaps/runner-hmac-removal.md` | Updated affected services from docker-runner to k8s-runner, removed env var name |
| `README.md` | Updated gaps table description |

## Context

We replaced docker-runner with k8s-runner. Other runner implementations may be maintained in the future, but for now the documentation should reflect only the current k8s-runner implementation.