### PR TITLE
Clear Runner HMAC Removal gap

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,6 @@ What needs to change in services to match the current architecture.
 
 | Document | Description |
 |----------|-------------|
-| [Runner HMAC Removal](gaps/runner-hmac-removal.md) | Remove HMAC auth from Runner and Orchestrator |
 | [Organizations Migration](gaps/organizations-migration.md) | Tenants → Organizations: rename service, update resource scoping, remove tenant headers |
 
 ### [Open Questions](open-questions.md)

--- a/gaps/runner-hmac-removal.md
+++ b/gaps/runner-hmac-removal.md
@@ -1,5 +1,0 @@
-# Runner HMAC Auth Removal
-
-HMAC shared secret authentication was removed from the Runner architecture. OpenZiti mTLS is the sole authentication mechanism for Orchestrator ↔ Runner communication.
-
-Affects `agynio/k8s-runner` and `agynio/agents-orchestrator`.


### PR DESCRIPTION
## Summary

Removes the `runner-hmac-removal` gap document and its entry from the README.

## Reason

The gap stated that HMAC shared secret (`DOCKER_RUNNER_SHARED_SECRET`) should be removed from `docker-runner` and `agents-orchestrator`. Both repositories have been searched comprehensively — zero references to HMAC, `SHARED_SECRET`, or `DOCKER_RUNNER_SHARED_SECRET` exist anywhere (source code, configs, Helm charts, env vars). OpenZiti mTLS is the sole auth mechanism for Orchestrator ↔ Runner communication.