### PR TITLE
Add changes/ section for tracking pending deltas

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,10 @@ Architecture documentation for the Agyn AI agent orchestrator platform.
 
 The desired state of the system. Declarative descriptions of all services, patterns, protocols, and contracts. No references to current implementation state, no transitional statements, no legacy caveats. When the architecture changes, this directory is updated to reflect the new target — not annotated with "currently X, will become Y."
 
+### `/changes` — Pending Deltas
+
+Gaps between the desired architecture described in `/architecture` and current implementation. Each file represents a single delta. When the implementation matches the desired state, the file is deleted. Git history preserves the full record.
+
 ### `/open-questions` — Unresolved Decisions
 
 Topics that require further investigation and a decision from a supervisor. Implementation of system parts that are not clearly described in the architecture should be avoided. Raise an open question or wait for a decision instead of building on assumptions that may change.
@@ -60,6 +64,10 @@ How services are built, deployed, run locally, and configured.
 | [Local Development](architecture/operations/local-development.md) | Bootstrap cluster and DevSpace inner loop |
 | [Terraform Provider](architecture/operations/terraform-provider.md) | Recommended configuration-as-code interface |
 | [New Service Development](architecture/operations/new-service.md) | End-to-end process: API schema → implementation → CI/CD → bootstrap → E2E tests |
+
+### [Changes](changes/) — Pending Deltas
+
+Gaps between desired architecture and current implementation. See [Changes README](changes/README.md) for lifecycle rules.
 
 ### [Open Questions](open-questions.md)
 

--- a/changes/README.md
+++ b/changes/README.md
@@ -1,0 +1,47 @@
+# Changes
+
+Pending deltas between the desired architecture described in `/architecture` and current implementation.
+
+## Lifecycle
+
+1. An `/architecture` document is created or updated to describe a new desired state.
+2. A change file is created here recording the delta.
+3. When the implementation matches the desired state, the change file is deleted.
+
+Git history preserves the full record of past changes.
+
+## File Naming
+
+```
+YYYY-MM-DD-<slug>.md
+```
+
+Date is when the desired state was defined, not when work starts or ends.
+
+## File Structure
+
+```markdown
+# <Title>
+
+## Target
+
+Link to the `/architecture` document this change relates to.
+
+## Delta
+
+What specifically differs between current implementation and desired architecture.
+
+## Acceptance Signal
+
+How to know the delta is closed.
+
+## Notes
+
+Optional context, related issues, dependencies.
+```
+
+## Rules
+
+- A change file must reference an `/architecture` document. If no spec exists, write the spec first.
+- Change files are not modified to track progress. They either exist (delta open) or are deleted (delta closed).
+- No implementation details. Changes describe what is missing, not how to build it.


### PR DESCRIPTION
Adds a `changes/` directory to the architecture repo, mirroring the same pattern introduced in the new `agynio/product` repo.

## What

- `changes/README.md` — lifecycle rules, file naming convention, template structure
- `README.md` — updated to document the new section alongside `/architecture` and `/open-questions`

## Why

Both repos now share a consistent structure for tracking deltas between desired state and current reality:

- `/architecture` (or `/product`) — declarative desired state
- `/changes` — pending deltas (file exists = open, file deleted = closed)
- `/open-questions` — unresolved decisions

Change files are binary: they exist while the gap is open and are deleted when reality matches the spec. Git history preserves the full record.