### PR TITLE
docs: clarify tracing gateway exposes query only, not ingestion

### DIFF
--- a/architecture/gateway.md
+++ b/architecture/gateway.md
@@ -73,7 +73,7 @@ Only methods intended for external use appear in gateway proto services. Interna
 | `AgentStateGateway` | [Agent State](agent/state.md) | All methods |
 | `TokenCountingGateway` | [Token Counting](token-counting.md) | All methods |
 | `LLMGateway` | [LLM](llm.md) | CreateChatCompletion (proxied LLM calls) |
-| `TracingGateway` | [Tracing](tracing.md) | Ingest, Query |
+| `TracingGateway` | [Tracing](tracing.md) | ListSpans, GetSpan, GetTrace |
 | `SecretsGateway` | [Secrets](secrets.md) | ResolveSecretValue |
 | `UsersGateway` | [Users](users.md) | CreateAPIToken, ListAPITokens, RevokeAPIToken |
 

--- a/architecture/tracing.md
+++ b/architecture/tracing.md
@@ -190,7 +190,7 @@ The [Gateway](gateway.md) exposes the Tracing query API via `TracingGateway`:
 | `GetSpan` | `TracingService.GetSpan` |
 | `GetTrace` | `TracingService.GetTrace` |
 
-The ingestion endpoint (`TraceService/Export`) is the standard OTLP gRPC interface and is also exposed through the Gateway for producers that connect via the external API.
+The ingestion endpoint (`TraceService/Export`) is not exposed through the Gateway. Agents send spans directly to the Tracing service over the internal network using the standard OTLP gRPC interface.
 
 ## Authorization
 


### PR DESCRIPTION
## Changes

- **gateway.md**: TracingGateway methods changed from `Ingest, Query` to `ListSpans, GetSpan, GetTrace`
- **tracing.md**: Clarified that the ingestion endpoint (`TraceService/Export`) is not exposed through the Gateway — agents send spans directly to the Tracing service over the internal network

## Context

The architecture docs incorrectly stated that OTLP ingestion would be exposed through the Gateway. Per decision, only query RPCs are exposed externally. Ingestion stays internal.

Related: agynio/gateway#93