### PR TITLE
fix(tracing): correct ingestion routing and add authn/z open question

### DIFF
--- a/architecture/tracing.md
+++ b/architecture/tracing.md
@@ -190,11 +190,11 @@ The [Gateway](gateway.md) exposes the Tracing query API via `TracingGateway`:
 | `GetSpan` | `TracingService.GetSpan` |
 | `GetTrace` | `TracingService.GetTrace` |
 
-The ingestion endpoint (`TraceService/Export`) is the standard OTLP gRPC interface and is also exposed through the Gateway for producers that connect via the external API.
+The ingestion endpoint (`TraceService/Export`) is not proxied through the Gateway. Producers (agents) connect directly to the Tracing service's gRPC endpoint using the standard OTLP exporter configuration.
 
 ## Authorization
 
-Access control for tracing data will be handled via ReBAC. The specific relationships and permissions are not yet defined — traces are independent resources not directly associated with an organization. The authorization model will be determined as the broader [ReBAC migration](authz.md) progresses.
+Access control for tracing data will be handled via ReBAC. The specific relationships and permissions are not yet defined — traces are independent resources not directly associated with an organization. The authorization model will be determined as the broader [ReBAC migration](authz.md) progresses. See [open question: Tracing AuthN/AuthZ](../open-questions.md#tracing-authnz).
 
 ## Classification
 

--- a/open-questions.md
+++ b/open-questions.md
@@ -198,3 +198,14 @@ Unresolved architectural decisions requiring discussion.
 - If unified, does Terraform create the runner resource via the Runners service API, receive an enrollment token, and pass it to the deployment?
 - What changes to the current internal runner self-enrollment flow are needed?
 
+
+---
+
+## Tracing AuthN/AuthZ
+
+**Context:** The Tracing service exposes two gRPC interfaces: the standard OTLP `TraceService/Export` for ingestion and the custom `TracingService` for queries. Ingestion is accessed directly by producers (agents) without going through the Gateway. The query API is proxied through the Gateway via `TracingGateway`. Neither interface currently has authentication or authorization.
+
+**Questions:**
+- How is the ingestion endpoint authenticated? (Istio mTLS for internal producers? Service tokens for external producers? Unauthenticated within the cluster?)
+- How is the ingestion endpoint authorized? (Any authenticated producer can export spans? Scoped to specific agents or organizations?)
+- How are query results scoped? (Organization-level visibility, per-agent restriction, or full access for any authenticated user?)


### PR DESCRIPTION
## Changes

### `architecture/tracing.md`
- **External API section**: Corrected the ingestion routing description. The OTLP `TraceService/Export` endpoint is **not** proxied through the Gateway — producers (agents) connect directly to the Tracing service. The previous text incorrectly stated it was exposed through the Gateway.
- **Authorization section**: Added a link to the new open question for traceability.

### `open-questions.md`
- **Added "Tracing AuthN/AuthZ"** open question covering three areas:
  - Ingestion endpoint authentication (Istio mTLS, service tokens, or unauthenticated)
  - Ingestion endpoint authorization (any producer, or scoped)
  - Query result scoping (org-level, per-agent, or full access)