### PR TITLE
Close resolved open questions, update stale references

### DIFF
--- a/architecture/agent/implementation.md
+++ b/architecture/agent/implementation.md
@@ -106,11 +106,7 @@ Rolling summarization keeps the LLM context within a token budget. When context 
 
 ### Packaging
 
-Summarization is currently embedded in the agent code. How it should be packaged is an [open question](../../open-questions.md#summarization-packaging):
-
-- As part of the agent service code (current state).
-- As a separate reusable package that different agent implementations can import.
-- As a standalone service with its own API.
+Summarization is embedded in the agent code. Extraction into a shared package or standalone service will be evaluated when a second agent loop implementation is introduced.
 
 ## State Persistence
 

--- a/architecture/agynd-cli.md
+++ b/architecture/agynd-cli.md
@@ -35,7 +35,7 @@ Before spawning the agent CLI, `agynd` fetches the agent configuration from the 
 
 This approach mirrors how tools like Claude Code and Codex CLI receive their configuration — through filesystem conventions and environment rather than a custom protocol.
 
-The exact configuration strategy differs per agent CLI (e.g., where skills are placed, how MCP servers are connected, what environment variables are set). See [Open Questions — agynd Configuration Strategies per Agent](../open-questions.md#agynd-configuration-strategies-per-agent) for the full discussion.
+The configuration strategy per agent CLI (where skills are placed, how MCP servers are connected, what environment variables are set) is determined by the [Agent Init Container](agent-init.md) — the init image's `config.json` specifies which SDK module `agynd` uses.
 
 ### 3. Agent Process Management
 
@@ -158,7 +158,3 @@ sequenceDiagram
     GW-->>D: message.created
     Note over D: Resume message processing
 ```
-
-## Open Questions
-
-- **Configuration strategies per agent.** How `agynd` prepares the environment for different agent CLIs (`agn`, Claude Code, Codex CLI). See [Open Questions](../open-questions.md#agynd-configuration-strategies-per-agent).

--- a/architecture/k8s-runner.md
+++ b/architecture/k8s-runner.md
@@ -113,7 +113,6 @@ The k8s-runner translates the gRPC bidirectional stream into the Kubernetes SPDY
 
 All workload Pods are created in a single dedicated namespace (e.g., `agyn-workloads`). The namespace is configurable at deployment time.
 
-> **Open question:** Per-organization namespaces may be needed for stronger isolation (network policies, resource quotas per organization). For now, a single namespace is sufficient. See [Open Questions](../open-questions.md).
 
 ## RBAC
 

--- a/open-questions.md
+++ b/open-questions.md
@@ -16,26 +16,6 @@ Unresolved architectural decisions requiring discussion.
 
 ---
 
-## Threads Service Data Store
-
-**Context:** Threads is being extracted into a standalone service.
-
-**Questions:**
-- Dedicated PostgreSQL schema or separate database?
-
----
-
-## Channel Interface Definition
-
-**Context:** Channels need a formal interface that all implementations (Slack, etc.) must satisfy.
-
-**Questions:**
-- Is the channel interface a gRPC service contract, a container contract, or an SDK/library interface?
-- How are channel credentials managed and rotated?
-- How does the control plane detect unhealthy channel connections for reconciliation?
-
----
-
 ## OpenZiti: Agent-to-Agent Private Networking
 
 **Context:** Future capability. Agents should be able to expose a port and share it with specific other agents over a private OpenZiti connection. Other agents must not be able to connect. See [OpenZiti Integration — Dynamic Policies](architecture/openziti.md#dynamic-policies-future).
@@ -44,39 +24,6 @@ Unresolved architectural decisions requiring discussion.
 - How does the agent request port sharing? (Platform API tool? Agent SDK primitive?)
 - What is the resource model? (Does the platform define "agent networks" as a team resource, or is each share ad-hoc?)
 - Does the binding agent create the OpenZiti service dynamically, or does the Ziti Management service pre-provision it?
-
----
-
-## OpenZiti: User-to-Agent Direct Connection
-
-**Context:** Future capability. Users should be able to connect directly to a specific agent from their machine via OpenZiti, bypassing the Gateway for certain use cases. The platform will ship a CLI that enrolls the user's machine. See [OpenZiti Integration — Dynamic Policies](architecture/openziti.md#dynamic-policies-future).
-
-**Questions:**
-- What is the CLI enrollment UX? (OIDC browser flow → enrollment JWT → local identity file?)
-- What protocol does the user use to connect to the agent? (Raw TCP? HTTP? gRPC?)
-- How is the direct connection authorized relative to the user's organization permissions?
-
----
-
-## Summarization Packaging
-
-**Context:** Summarization is currently embedded in the agent code. As we support multiple agent implementations, summarization logic needs to be reusable.
-
-**Options:**
-
-1. **Part of the agent service** — Each agent implementation bundles its own summarization. Current state.
-   - *Pros:* Simple. No external dependencies. Full control per implementation.
-   - *Cons:* Duplicated across implementations. Hard to share improvements.
-
-2. **Reusable package** — Shared library (e.g., `@agyn/summarization`) imported by agent implementations.
-   - *Pros:* Single source of truth. Each agent can opt in. Language-portable (publish for TS, Go, etc.).
-   - *Cons:* Package versioning and compatibility. Must be general enough for different agent architectures.
-
-3. **Standalone service** — Dedicated summarization service with its own gRPC API.
-   - *Pros:* Language-agnostic. Centralized. Can be scaled and monitored independently.
-   - *Cons:* Network overhead per summarization call. Another service to operate. Latency-sensitive.
-
-**Decision:** TBD
 
 ---
 
@@ -100,40 +47,6 @@ Unresolved architectural decisions requiring discussion.
 - What is the directory convention for skills on the filesystem?
 - How does `agn` discover its MCP server? (Stdio command, socket path, environment variable?)
 - What is the schema for state persistence backend selection? (Flag, config field, environment variable?)
-
----
-
-## agynd Configuration Strategies per Agent
-
-**Context:** [`agynd`](architecture/agynd-cli.md) prepares the runtime environment before spawning an agent CLI. Different agent CLIs expect different configuration conventions — skills in specific directories, environment variables, config files, MCP server setup, etc. `agynd` needs a strategy for each supported agent type.
-
-**Known agent CLIs requiring strategies:**
-
-| Agent CLI | Configuration Needs |
-|-----------|-------------------|
-| **[`agn`](architecture/agn-cli.md)** | Skills directory, LLM endpoint, MCP server, state persistence backend. Format TBD (see [agn Configuration Structure](#agn-configuration-structure)) |
-| **Claude Code** | `CLAUDE.md` files in workspace, environment variables for API keys, MCP server config via `claude_desktop_config.json` or CLI flags |
-| **Codex CLI** | `AGENTS.md` or instructions file, environment variables, MCP server configuration |
-
-**Questions:**
-- How does `agynd` know which strategy to apply? (Agent resource field? Image convention? Explicit strategy name in configuration?)
-- Is the strategy a hard-coded mapping per agent type, or a pluggable adapter?
-- How are agent-type-specific configuration conventions discovered and maintained as 3rd-party CLIs evolve?
-
-**Decision:** TBD
-
----
-
-## k8s-runner: Namespace Strategy
-
-**Context:** The [k8s-runner](architecture/k8s-runner.md) currently creates all workload Pods in a single dedicated namespace. As the platform grows, per-organization namespaces may provide stronger isolation.
-
-**Questions:**
-- Should workload Pods be isolated into per-organization namespaces for network policy and resource quota enforcement?
-- If per-organization, who creates and manages organization namespaces — the k8s-runner or an external controller?
-- What is the migration path from single namespace to per-organization if needed later?
-
-**Decision:** Single namespace for now. Revisit when organizational isolation requirements are clarified.
 
 ---
 
@@ -197,7 +110,6 @@ Unresolved architectural decisions requiring discussion.
 - Should cluster-scoped runners be registered resources in the platform (like apps), rather than self-enrolling infrastructure?
 - If unified, does Terraform create the runner resource via the Runners service API, receive an enrollment token, and pass it to the deployment?
 - What changes to the current internal runner self-enrollment flow are needed?
-
 
 ---
 


### PR DESCRIPTION
## Summary

Closes 6 open questions that are resolved or no longer relevant, and updates all cross-references in architecture docs.

### Removed open questions

| Question | Reason |
|----------|--------|
| **Threads Service Data Store** | Infrastructure decision, not architectural |
| **Channel Interface Definition** | Obsolete — channels refactored and extended into Apps |
| **OpenZiti: User-to-Agent Direct Connection** | Solved by API tokens + CLI authentication through Gateway |
| **Summarization Packaging** | Single Go implementation; revisit when a second agent loop exists |
| **agynd Configuration Strategies per Agent** | Resolved by Agent Init Container design (`config.json` with `sdk` + `bin`) |
| **k8s-runner: Namespace Strategy** | Decided — single namespace, no plans for per-org namespaces |

### Updated references

- **`architecture/agynd-cli.md`** — Replaced open question link with reference to Agent Init Container. Removed the now-empty "Open Questions" section.
- **`architecture/k8s-runner.md`** — Removed open question callout from Namespace section.
- **`architecture/agent/implementation.md`** — Updated summarization packaging text to reflect the decision.

### Remaining open questions (10)

1. Agent Batching Protocol
2. OpenZiti: Agent-to-Agent Private Networking
3. Authorization Model Completeness
4. agn Configuration Structure
5. OpenZiti: Service Identity Self-Enrollment Authorization
6. App Permission Model
7. Org-Scoped Apps and Runners
8. Runner Selection Strategy
9. Unified Runner Registration
10. Tracing AuthN/AuthZ (added by remote)