### PR TITLE
Update agent-init architecture docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ Target architecture of the platform. Describes how the system should work.
 | [Agent](architecture/agent/) | Agent contract, our implementation, state persistence |
 | [agyn-cli](architecture/agyn-cli.md) | Platform CLI — Gateway API access for admins, developers, and agents |
 | [agynd-cli](architecture/agynd-cli.md) | Agent wrapper daemon — bridges agent CLIs with platform services |
+| [Agent Init Container](architecture/agent-init.md) | Init container design for injecting platform binaries into agent pods |
 | [agn-cli](architecture/agn-cli.md) | Our agent loop implementation — LLM reasoning with tool use |
 | [Chat](architecture/chat.md) | Built-in web/mobile app chat on top of Threads |
 | [Channels](architecture/channels.md) | Bidirectional interface for 3rd-party and own apps |

--- a/architecture/agent-init.md
+++ b/architecture/agent-init.md
@@ -84,7 +84,7 @@ One init image per supported agent type, each in its own repository:
 | Image | Repository | Contents |
 |-------|------------|----------|
 | `ghcr.io/agynio/agent-init-codex:<version>` | `agynio/agent-init-codex` | `agynd` + `codex` (static musl binary) + `config.json` with `sdk: codex` |
-| `ghcr.io/agynio/agent-init-claude:<version>` | `agynio/agent-init-claude` | `agynd` + `claude` (standalone binary) + `config.json` with `sdk: claude` |
+| `ghcr.io/agynio/agent-init-claude:<version>` | `agynio/agent-init-claude` | `agynd` + `claude` (static musl binary) + `config.json` with `sdk: claude` |
 | `ghcr.io/agynio/agent-init-agn:<version>` | `agynio/agent-init-agn` | `agynd` + `agn` (static Go binary) + `config.json` with `sdk: agn` |
 
 #### Repository Structure
@@ -136,6 +136,8 @@ ARG AGYND_VERSION
 ARG CODEX_VERSION
 ARG TARGETARCH
 
+RUN mkdir -p /tools
+
 # Download agynd from agynio/agynd-cli releases
 RUN apk add --no-cache curl && \
     curl -fsSL "https://github.com/agynio/agynd-cli/releases/download/v${AGYND_VERSION}/agynd-linux-${TARGETARCH}" \
@@ -143,10 +145,14 @@ RUN apk add --no-cache curl && \
     chmod +x /tools/agynd
 
 # Download Codex CLI from upstream releases
-RUN ARCH_SUFFIX=$([ "$TARGETARCH" = "amd64" ] && echo "x86_64" || echo "aarch64") && \
-    curl -fsSL "https://github.com/openai/codex/releases/download/v${CODEX_VERSION}/codex-${ARCH_SUFFIX}-unknown-linux-musl.tar.gz" \
+RUN case "${TARGETARCH}" in \
+      amd64) ARCH="x86_64" ;; \
+      arm64) ARCH="aarch64" ;; \
+      *) echo "Unsupported architecture: ${TARGETARCH}" >&2; exit 1 ;; \
+    esac && \
+    curl -fsSL "https://github.com/openai/codex/releases/download/rust-v${CODEX_VERSION}/codex-${ARCH}-unknown-linux-musl.tar.gz" \
       | tar -xz -C /tools/ && \
-    mv /tools/codex-* /tools/codex && \
+    mv "/tools/codex-${ARCH}-unknown-linux-musl" /tools/codex && \
     chmod +x /tools/codex
 
 COPY config.json /tools/config.json
@@ -164,7 +170,7 @@ All binaries are statically linked and run on any Linux base image:
 |--------|-------|--------|
 | `agynd` | Go, `CGO_ENABLED=0` | Yes |
 | Codex CLI | Rust, musl target (`codex-x86_64-unknown-linux-musl`) | Yes |
-| Claude Code CLI | Standalone native binary from Anthropic installer | Yes |
+| Claude Code CLI | musl variant from Anthropic distribution (GCS bucket) | Yes (musl variant only) |
 | agn CLI | Go, `CGO_ENABLED=0` | Yes |
 
 #### CI
@@ -182,11 +188,11 @@ Each init image repo has its own CI workflow following the platform [CI/CD conve
 |-----------|--------------------|
 | `agynd` | ~15 MB |
 | Codex CLI (musl) | ~30 MB |
-| Claude Code CLI | ~50 MB |
+| Claude Code CLI (musl) | ~225 MB |
 | agn CLI | ~15 MB |
 | Alpine base | ~5 MB |
 
-Each init image is ~50–70 MB compressed. Pulled once per node via the Kubernetes image cache.
+Codex and agn init images are ~50–70 MB compressed; the Claude init image is ~225 MB compressed. Pulled once per node via the Kubernetes image cache.
 
 ## Startup Sequence
 

--- a/architecture/agents-orchestrator.md
+++ b/architecture/agents-orchestrator.md
@@ -120,6 +120,14 @@ The orchestrator assembles the full workload specification from multiple sources
 8. **Skills** (from Agents): prompt fragments — passed as part of agent configuration, not as separate containers.
 9. **OpenZiti enrollment JWT** (from Ziti Management): passed to the agent container for network identity bootstrap.
 
+The orchestrator also wires the init container flow:
+
+- Read `init_image` from the agent definition (fall back to `DEFAULT_INIT_IMAGE`).
+- Add `agyn-bin` ephemeral volume.
+- Build init container with the init image.
+- Set main container command to `/agyn-bin/agynd`.
+- Mount `agyn-bin` in the main container.
+
 The orchestrator is the only service that performs this assembly. The Runner receives an opaque workload spec — it does not know about agents, agent resources, or secrets.
 
 ## Agent Stop Flow

--- a/architecture/agents-service.md
+++ b/architecture/agents-service.md
@@ -16,7 +16,7 @@ Defined in `agynio/api` at `proto/agynio/api/agents/v1/agents.proto`. Exposed ex
 
 | Resource | Description | CRUD |
 |----------|-------------|------|
-| **Agents** | Agent definitions: identity, model, image, compute resources, behavioral configuration | ✓ |
+| **Agents** | Agent definitions: identity, model, image, init image, compute resources, behavioral configuration | ✓ |
 | **Volumes** | Volume definitions: persistence, mount path, size | ✓ |
 | **Volume Attachments** | Relationships between volumes and containers (agents, MCPs, hooks) | Create, Get, Delete, List |
 | **MCPs** | MCP server definitions: image, command, compute resources. Belong to an agent | ✓ |

--- a/architecture/agynd-cli.md
+++ b/architecture/agynd-cli.md
@@ -64,6 +64,8 @@ agynd
 | **Claude Code** | `claude-sdk-go` | Custom JSONL | `claude --output-format stream-json --input-format stream-json --verbose` |
 | **agn** | `agn-sdk-go` | JSON-RPC v2 | `agn serve` |
 
+Only `codex-sdk-go` is integrated in the initial implementation; `claude-sdk-go` does not exist as a repo and `agn-sdk-go` lives in `agn-cli/sdk/` but is not wired into `agynd`, so Claude and agn return `unsupported` at runtime.
+
 ### SDK responsibilities
 
 Each SDK module is responsible for:

--- a/architecture/k8s-runner.md
+++ b/architecture/k8s-runner.md
@@ -24,6 +24,7 @@ The Runner [workload model](runner.md#workload-model) maps to Kubernetes primiti
 | Workload | Pod |
 | Main container | Pod container |
 | Sidecar | Additional Pod container (shared network namespace is native to Pods) |
+| Init container | Pod initContainer |
 | Ephemeral volume (`persistent: false`) | `emptyDir` volume |
 | Persistent volume (`persistent: true`) | PersistentVolumeClaim |
 | Labels | Pod labels |
@@ -49,8 +50,10 @@ graph TB
 When `StartWorkload` is called, the k8s-runner:
 
 1. Creates any PersistentVolumeClaims required by persistent volumes (if they don't already exist).
-2. Builds a Pod spec with all containers (main + sidecars), volume mounts, environment variables, resource requests/limits, and labels.
+2. Builds a Pod spec with init containers (if any), main + sidecars, volume mounts, environment variables, resource requests/limits, and labels.
 3. Creates the Pod via the Kubernetes API.
+
+Init containers run before the main and sidecar containers and can populate shared volumes (for example, `/agyn-bin`).
 
 The Pod's `restartPolicy` is `Never` — the Agents Orchestrator owns lifecycle decisions. If a container crashes, the Runner reports the failure; it does not restart the Pod.
 

--- a/architecture/operations/e2e-testing.md
+++ b/architecture/operations/e2e-testing.md
@@ -152,7 +152,7 @@ functions:
                     sleep 1; elapsed=$((elapsed + 1))
                     [ "$elapsed" -ge 120 ] && { echo "ERROR: sync timeout" >&2; exit 1; }
                   done
-                  buf generate buf.build/agynio/api --path agynio/api/threads/v1 --path agynio/api/notifications/v1
+                  buf generate buf.build/agynio/api --include-imports --path agynio/api/threads/v1 --path agynio/api/notifications/v1
                   exec go run ./cmd/threads
               volumeMounts:
                 - name: data

--- a/architecture/operations/new-service.md
+++ b/architecture/operations/new-service.md
@@ -155,6 +155,8 @@ See [E2E Testing](https://github.com/agynio/architecture/blob/main/architecture/
 
 The service generates Go code from `agynio/api` protos locally using `buf generate` with a `buf.gen.yaml` pointing at `buf.build/agynio/api`. Generated code is written to an internal `.gen/` directory. It is not committed — generated at build time (in Dockerfile and CI).
 
+When using `buf generate` with `--path` filters, include `--include-imports` so dependent protos are generated.
+
 ### Helm Chart
 
 The chart inherits from the shared base chart:

--- a/architecture/resource-definitions.md
+++ b/architecture/resource-definitions.md
@@ -56,6 +56,7 @@ An agent definition that determines how an agent workload behaves when processin
 | `model` | string (UUID) | | Reference to a [Model](providers.md#model) resource in the LLM service |
 | `configuration` | JSON string | `"{}"` | Agent behavioral configuration. Opaque to the Agents service — interpreted by the agent runtime |
 | `image` | string | | Container image for the agent pod (e.g., `ghcr.io/agynio/agent:latest`) |
+| `init_image` | string | | Platform init image reference (e.g., `ghcr.io/agynio/agent-init-codex:v1.0.0`). Contains agynd + agent CLI. Runs as init container |
 | `resources` | object | | Compute resources for the agent container (see [Compute Resources](#compute-resources)) |
 
 The `configuration` field contains agent implementation-specific behavioral parameters (system prompt, summarization settings, message buffering, etc.). Different agent implementations define different configuration schemas. The Agents service stores the field as an opaque JSON string without validation. See [Agent](agent/) for the platform's own agent implementation and its configuration schema.

--- a/architecture/runner.md
+++ b/architecture/runner.md
@@ -14,7 +14,7 @@ Defined in `agynio/api` at `proto/agynio/api/runner/v1/runner.proto`.
 
 | RPC | Description |
 |-----|-------------|
-| `StartWorkload` | Start a workload (main container + optional sidecars with shared network) |
+| `StartWorkload` | Start a workload (init containers + main container + optional sidecars with shared network) |
 | `StopWorkload` | Stop a running workload |
 | `RemoveWorkload` | Remove a workload and optionally its volumes |
 | `InspectWorkload` | Inspect workload state (id, image, labels, mounts, status) |
@@ -60,6 +60,7 @@ Exec supports:
 ```mermaid
 graph TB
     subgraph Workload
+        Init[Init Container]
         Main[Main Container]
         S1[Sidecar 1]
         S2[Sidecar 2]
@@ -67,6 +68,7 @@ graph TB
         V2[Volume: ephemeral]
     end
 
+    Init --> Main
     Main ---|shared network| S1
     Main ---|shared network| S2
     V1 --> Main
@@ -74,6 +76,7 @@ graph TB
 ```
 
 A workload consists of:
+- **Init containers** — run before the main container to populate shared volumes.
 - **Main container** — the primary process.
 - **Sidecars** — optional containers sharing the same network namespace.
 - **Volumes** — ephemeral or named (persistent), mounted into containers.

--- a/architecture/system-overview.md
+++ b/architecture/system-overview.md
@@ -150,7 +150,11 @@ graph TB
 | `agynio/agents` | Agents service (agent resource management) | Go | Planned |
 | `agynio/agyn-cli` | Platform CLI — Gateway API access | Go | Planned |
 | `agynio/agynd-cli` | Agent wrapper daemon — bridges agent CLIs with platform | Go | Planned |
+| `agynio/codex-sdk-go` | Go client library for Codex CLI | Go | Active |
 | `agynio/agn-cli` | Agent loop implementation — LLM reasoning with tool use | Go | Planned |
+| `agynio/agent-init-codex` | Init container image: agynd + Codex CLI | Dockerfile | Active |
+| `agynio/agent-init-claude` | Init container image: agynd + Claude Code CLI | Dockerfile | Active |
+| `agynio/agent-init-agn` | Init container image: agynd + agn CLI | Dockerfile | Active |
 | `agynio/k8s-runner` | Kubernetes-native Runner implementation | Go | Planned |
 | `agynio/terraform-provider-agyn` | Terraform provider for agent resource management | Go | Planned |
 | `agynio/apps` | Apps Service | Go | Planned |


### PR DESCRIPTION
## Summary
- update agent-init docs with init image details and Dockerfile alignment
- document init container wiring in runner, orchestrator, and resource definitions
- refresh repo map entries and ops guidance

## Testing
- Not run (no tests or linters configured)

Closes #72