### PR TITLE
Replace APSS with disk-based agent state, document data concern isolation

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Target architecture of the platform. Describes how the system should work.
 | [API Tokens](architecture/api-tokens.md) | Long-lived opaque tokens for programmatic access (CI, integrations, developer tooling) |
 | [Control Plane & Data Plane](architecture/control-data-plane.md) | Boundary definitions, criteria, service classification |
 | [Resource Definitions](architecture/resource-definitions.md) | Canonical schemas for all agent-managed resources |
-| [Agent](architecture/agent/) | Agent contract, our implementation, state persistence |
+| [Agent](architecture/agent/) | Agent contract, our implementation, disk-based state persistence |
 | [agyn-cli](architecture/agyn-cli.md) | Platform CLI — Gateway API access for admins, developers, and agents |
 | [agynd-cli](architecture/agynd-cli.md) | Agent wrapper daemon — bridges agent CLIs with platform services |
 | [Agent Init Container](architecture/agent-init.md) | Init container design for injecting platform binaries into agent pods |
@@ -54,7 +54,7 @@ Target architecture of the platform. Describes how the system should work.
 | [k8s-runner](architecture/k8s-runner.md) | Kubernetes-native Runner implementation |
 | [Agents Orchestrator](architecture/agents-orchestrator.md) | Agent workload reconciliation — start, monitor, stop |
 | [Agents Service](architecture/agents-service.md) | Agent resource management |
-| [Tracing](architecture/tracing.md) | Span ingestion and query — standard OTLP with upsert for in-progress spans |
+| [Tracing](architecture/tracing.md) | Span ingestion and query — standard OTLP with upsert for in-progress spans. Captures full LLM call context |
 | [Gateway](architecture/gateway.md) | External API surface — ConnectRPC (gRPC + HTTP/JSON) |
 | [API Contracts](architecture/api-contracts.md) | Proto schema conventions for internal and external APIs |
 

--- a/architecture/agent/README.md
+++ b/architecture/agent/README.md
@@ -4,4 +4,4 @@
 |----------|-------------|
 | [Overview](overview.md) | Agent contract, tools, wrapper model, lifecycle, configuration |
 | [Implementation](implementation.md) | Our agent: LLM loop, summarization, state persistence |
-| [State](state.md) | Agent Persistent State Service (APSS) |
+| [State](state.md) | State persistence model — disk-based, agent-owned, volume-scoped lifetime |

--- a/architecture/agent/implementation.md
+++ b/architecture/agent/implementation.md
@@ -1,6 +1,6 @@
 # Agent Implementation
 
-Our agent implementation ([`agn`](../agn-cli.md)). This is the primary agent — a Go-based LLM loop with rolling summarization and pluggable state persistence.
+Our agent implementation ([`agn`](../agn-cli.md)). This is the primary agent — a Go-based LLM loop with rolling summarization and disk-based state persistence.
 
 For the general agent contract, lifecycle, and tools, see [Agent](overview.md).
 
@@ -21,12 +21,11 @@ graph TB
 
     subgraph External
         LLMProvider[LLM Provider<br/>OpenAI Responses API]
-        AgentState[Agent State Service<br/>gRPC]
         TracingDep[Tracing<br/>optional]
     end
 
     LLMLoop --> LLMProvider
-    Persistence --> AgentState
+    Persistence --> Disk[(Persistent Volume)]
     LLMLoop -.-> TracingDep
 ```
 
@@ -34,7 +33,7 @@ graph TB
 |-----------|---------------|
 | **LLM Loop** | Orchestrates the turn: load context → summarize → call model → route → call tools → save |
 | **Summarization** | Reduces context size to fit within the token budget |
-| **State Persistence** | Reads and writes conversation state (messages, summaries) |
+| **State Persistence** | Reads and writes conversation state (messages, summaries) to the local filesystem |
 | **MCP Tool Servers** | Provides tools to the LLM via MCP protocol |
 
 ## LLM Loop
@@ -110,17 +109,9 @@ Summarization is embedded in the agent code. Extraction into a shared package or
 
 ## State Persistence
 
-The agent persists conversation state (messages, summaries) across turns:
+The agent persists conversation state (messages, summaries) on the local filesystem. State is written to a path backed by a persistent volume. See [Agent State](state.md) for the persistence model.
 
-| Strategy | Store | Use Case |
-|----------|-------|----------|
-| Local | Filesystem | Development, offline usage, no external dependencies |
-| Remote (APSS) | [Agent State](state.md) service via [Gateway](../gateway.md) | Production — durable, shared |
-
-The remote strategy uses the Agent Persistent State Service (APSS). It provides:
-- Append/list/replace/delete conversation messages.
-- Context snapshots for LLM call reproducibility.
-- Keyed by `conversationId` (mapping from threadId/nodeId is handled by the agent).
+The state format and storage layout are owned by the agent implementation. The platform provides the volume — the agent decides what to store and how to organize it.
 
 ## Configuration
 

--- a/architecture/agent/state.md
+++ b/architecture/agent/state.md
@@ -1,66 +1,33 @@
-# Agent State (APSS)
+# Agent State
 
 ## Overview
 
-The Agent Persistent State Service (APSS) stores agent conversation context for long-term persistence. It uses `conversationId` as the primary routing key (threadId/nodeId mapping is handled outside the service).
+Agent state is managed entirely by each agent implementation and persisted locally on disk. The platform provides a persistent volume — the agent decides what to store and how to organize it. There is no platform-level state service, schema, or contract for agent state.
 
-## gRPC API
+## Design Principles
 
-Defined in `agynio/api` at `proto/agynio/api/agent_state/v1/agent_state.proto`.
+- **Agent-owned.** Each agent implementation (our [`agn`](../agn-cli.md), wrapped Codex, wrapped Claude, custom agents) defines its own state format and storage layout. The platform does not interpret or validate agent state.
+- **Disk-based.** State is written to a filesystem path backed by a persistent volume. No external service dependency for state persistence.
+- **Volume-scoped lifetime.** State lives as long as the persistent volume exists. The [Volume](../resource-definitions.md#volume) resource's lifecycle (creation, deletion) determines when state is created and lost.
 
-### Conversation Messages
+## How It Works
 
-| RPC | Description |
-|-----|-------------|
-| `AppendConversationMessages` | Append a batch of messages |
-| `ListConversationMessages` | List with role/kind filtering and pagination (oldest → newest) |
-| `ListConversationMessageIds` | List message IDs with pagination |
-| `ReplaceConversationMessagesRange` | Replace a contiguous range with references |
-| `DeleteConversationMessagesRange` | Delete a contiguous range |
-| `GetConversation` | Get conversation metadata (count, timestamps) |
+The [Agents Orchestrator](../agents-orchestrator.md) assembles the workload spec with persistent volumes defined as [Volume](../resource-definitions.md#volume) resources. The [Runner](../runner.md) creates PersistentVolumeClaims on first use and reuses them on subsequent starts. When the agent container starts, the persistent volume is mounted at the configured path, and the agent reads/writes state to it as a regular filesystem.
 
-### Context Snapshots
+When the agent is stopped (idle timeout, crash, or explicit stop), the PVC survives. On the next start, the same PVC is mounted, and the agent resumes from its persisted state.
 
-Materialized copies of the exact context sent to an LLM call. Guarantees reproducibility after trims/edits.
+## Isolation
 
-| RPC | Description |
-|-----|-------------|
-| `CreateSnapshot` | Create from an ordered list of message IDs |
-| `ListSnapshotMessages` | List materialized messages in a snapshot |
-| `ListSnapshotMessageIds` | List message IDs in a snapshot |
+Agent state is one of three distinct data concerns in the platform, each with its own storage and lifecycle:
 
-## Data Model
+| Concern | What it stores | Storage | Lifetime |
+|---------|---------------|---------|----------|
+| **Chat / Threads** | User messages and agent responses | PostgreSQL ([Threads](../threads.md)) | Long-lived. The conversation record |
+| **Agent state** | Internal working memory — conversation context, summaries, tool state, any agent-specific data | Disk (persistent volume) | Lives as long as the volume exists |
+| **Tracing** | Full LLM call context (complete request bodies sent to the model) for observability and debugging | PostgreSQL ([Tracing](../tracing.md)) | Shorter retention due to data volume |
 
-### Message
+These concerns are cleanly separated:
 
-| Field | Type | Description |
-|-------|------|-------------|
-| `id` | string (UUID) | Server-assigned |
-| `conversation_id` | string | Routing key |
-| `role` | enum | `user`, `assistant`, `tool` |
-| `kind` | string | Free-form tag (`system`, `summary`, `memory`, `tool_output`) |
-| `body` | oneof | `TextBody` or `ToolOutputBody` |
-| `created_at` | timestamp | |
-
-### Message Body
-
-**TextBody:** `{ text: string }`
-
-**ToolOutputBody:**
-
-| Field | Type |
-|-------|------|
-| `tool_name` | string |
-| `tool_call_id` | string |
-| `output` | oneof: `ToolTextOutput` or `ToolImageOutput` |
-| `metadata` | map<string, string> |
-
-### Context Snapshot
-
-| Field | Type |
-|-------|------|
-| `snapshot_id` | string (UUID) |
-| `conversation_id` | string |
-| `created_at` | timestamp |
-
-Each snapshot item includes a `body_sha256` integrity hash.
+- **Threads** is the shared conversation record visible to all participants. Already stored in PostgreSQL. No changes.
+- **Agent state** is private to the agent. No external service reads or writes it. The agent manages its own state without platform involvement.
+- **Tracing** captures the full LLM context for each request as observability data. Due to the volume of data (complete message arrays per LLM call), tracing data has shorter retention than conversation records.

--- a/architecture/agn-cli.md
+++ b/architecture/agn-cli.md
@@ -81,14 +81,14 @@ graph TB
     subgraph External
         LLM[LLM Endpoint]
         MCP[MCP Server]
-        StateStore[State Store<br/>Agent State / Local]
+        Disk[(Persistent Volume / Local FS)]
     end
 
     LLMLoop --> LLM
     LLMLoop --> MCP
     LLMLoop <--> Summarization
     LLMLoop <--> Persistence
-    Persistence --> StateStore
+    Persistence --> Disk
 ```
 
 ## LLM Loop
@@ -126,7 +126,7 @@ See [Agent Implementation](agent/implementation.md) for detailed stage descripti
 | **Network identity** | [OpenZiti](authn.md#network-identity-openziti) mTLS — automatic when the environment provides it | Inside agent containers where `agynd` has enrolled an OpenZiti identity |
 | **Auth token** | Token stored in `~/.agyn/credentials` and sent to the [Gateway](gateway.md) | Local development — running `agn` on a developer machine |
 
-Authentication is only required when `agn` connects to platform services (Agent State). When running fully locally with filesystem persistence, no authentication is needed.
+Authentication is required when `agn` connects to platform services. When running fully locally (local LLM endpoint, local MCP servers, filesystem state), no authentication is needed.
 
 ## Configuration
 
@@ -179,25 +179,18 @@ When running locally, the developer writes `~/.agyn/agn/config.yaml` manually. `
 
 ### Future configuration
 
-Additional configuration (MCP servers, skills directory, state persistence backend, summarization parameters) will be added to this file as those features are implemented.
+Additional configuration (MCP servers, skills directory, summarization parameters) will be added to this file as those features are implemented.
 
 ## State Persistence
 
-`agn` persists conversation state (messages, summaries) across turns. Two backends:
-
-| Backend | Store | Use Case |
-|---------|-------|----------|
-| **Remote** | [Agent State (APSS)](agent/state.md) service via gRPC | Platform usage — durable, shared |
-| **Local** | Filesystem | Local development — no external dependencies |
-
-The local backend enables running `agn` fully offline without any platform dependencies.
+`agn` persists conversation state (messages, summaries) on the local filesystem. State is written to a path backed by a persistent volume when running on the platform, or to a local directory when running standalone. See [Agent State](agent/state.md) for the persistence model.
 
 ## Relationship to Other Components
 
 | Component | Relationship |
 |-----------|-------------|
 | [`agynd`](agynd-cli.md) | Spawns `agn` via `agn-sdk-go`, prepares its environment, feeds messages, collects output |
-| [Agent State](agent/state.md) | Optional remote persistence backend |
+| [Agent State](agent/state.md) | Disk-based persistence model |
 | [Agent Implementation](agent/implementation.md) | Detailed LLM loop design, summarization algorithm, routing decisions |
 | LLM Endpoint | Configured by `agynd` or manually; `agn` calls it for model completions |
 | MCP Server | Configured by `agynd` (aggregated proxy) or manually; `agn` calls it for tool execution |

--- a/architecture/api-contracts.md
+++ b/architecture/api-contracts.md
@@ -24,7 +24,6 @@ Services **do not** commit generated schema code in their own repositories. They
 | Runner | `agynio/api/runner/v1/runner.proto` |
 | Notifications | `agynio/api/notifications/v1/notifications.proto` |
 | Files | `agynio/api/files/v1/files.proto` |
-| Agent State | `agynio/api/agent_state/v1/agent_state.proto` |
 | Threads | `agynio/api/threads/v1/threads.proto` |
 | Chat | `agynio/api/chat/v1/chat.proto` |
 | Tracing | `agynio/api/tracing/v1/tracing.proto` |
@@ -56,7 +55,6 @@ The external API is defined by **gateway proto services** in `agynio/api`. These
 | ChatGateway | `agynio/api/gateway/v1/chat.proto` | [Chat](chat.md) |
 | NotificationsGateway | `agynio/api/gateway/v1/notifications.proto` | [Notifications](notifications.md) |
 | FilesGateway | `agynio/api/gateway/v1/files.proto` | [Files](media.md) |
-| AgentStateGateway | `agynio/api/gateway/v1/agent_state.proto` | [Agent State](agent/state.md) |
 | TokenCountingGateway | `agynio/api/gateway/v1/token_counting.proto` | [Token Counting](token-counting.md) |
 | TracingGateway | `agynio/api/gateway/v1/tracing.proto` | [Tracing](tracing.md) |
 | SecretsGateway | `agynio/api/gateway/v1/secrets.proto` | [Secrets](secrets.md) |

--- a/architecture/control-data-plane.md
+++ b/architecture/control-data-plane.md
@@ -32,7 +32,6 @@ graph LR
         Threads
         Notifications
         Runner
-        AgentState[Agent State]
         Tracing
         Files
         TokenCounting[Token Counting]
@@ -64,7 +63,6 @@ graph LR
 | **Threads** | Data | Carries conversation messages between participants |
 | **Notifications** | Data | Holds persistent connections, fans out real-time events |
 | **Gateway** | Data | Routes external API requests to internal services |
-| **Agent State** | Data | Stores and retrieves agent conversation context |
 | **Tracing** | Data | Ingests and serves tracing data |
 | **Files** | Data | Stores files in object storage, serves metadata and pre-signed download URLs |
 | **Token Counting** | Data | Counts tokens per message on the hot path during agent execution |

--- a/architecture/gateway.md
+++ b/architecture/gateway.md
@@ -70,7 +70,6 @@ Only methods intended for external use appear in gateway proto services. Interna
 | `ChatGateway` | [Chat](chat.md) | All methods |
 | `NotificationsGateway` | [Notifications](notifications.md) | Subscribe (server-streaming) |
 | `FilesGateway` | [Files](media.md) | UploadFile (client-streaming), GetFileMetadata, GetDownloadURL |
-| `AgentStateGateway` | [Agent State](agent/state.md) | All methods |
 | `TokenCountingGateway` | [Token Counting](token-counting.md) | All methods |
 | `TracingGateway` | [Tracing](tracing.md) | Ingest, Query |
 | `SecretsGateway` | [Secrets](secrets.md) | ResolveSecretValue |

--- a/architecture/media.md
+++ b/architecture/media.md
@@ -227,4 +227,4 @@ Consumers (Gateway, agent) resolve file IDs to metadata and download URLs by cal
 
 ## Context Size and Summarization
 
-Media files consume tokens that cannot be estimated from text length. The [Token Counting](token-counting.md) service provides accurate per-message token counts, including media content. Token counts are stored in the Agent State service and used by the summarization reducer.
+Media files consume tokens that cannot be estimated from text length. The [Token Counting](token-counting.md) service provides accurate per-message token counts, including media content. Token counts are stored in agent state on disk and used by the summarization reducer.

--- a/architecture/organizations.md
+++ b/architecture/organizations.md
@@ -70,7 +70,6 @@ Independent resources have no `organization_id`. Access is governed by [ReBAC pe
 |---------|-----------|-------------|
 | [Threads](threads.md) | Threads, Messages, MessageRecipients | ReBAC permissions on the thread |
 | [Files](media.md) | File metadata and objects | ReBAC permissions via the thread that references the file |
-| [Agent State](agent/state.md) | Agent state records | Owned by agent (`agent_id`) via ReBAC |
 | [Runner](runner.md) | Workloads | Owned by agent via ReBAC |
 | [Identity](identity.md) | Identity records | System-wide, no org association |
 | [Users](users.md) | User records and profiles | System-wide, no org association |

--- a/architecture/system-overview.md
+++ b/architecture/system-overview.md
@@ -29,7 +29,6 @@ graph TB
         Secrets[Secrets]
         Notifications[Notifications]
         Runner[Runner]
-        AgentState[Agent State]
         Tracing[Tracing]
         Authorization[Authorization]
         ZitiMgmt[Ziti Management]
@@ -61,7 +60,6 @@ graph TB
     Gateway --> Notifications
     Gateway --> Secrets
     Gateway --> Threads
-    Gateway --> AgentState
     Gateway --> TokenCounting
     Gateway --> Tracing
     LLMProxy --> LLM
@@ -121,8 +119,7 @@ graph TB
 | **Notifications** | Real-time event fanout via persistent connections (socket). All services publish state change events through Notifications |
 | **Authorization** | Fine-grained access control. Thin proxy to OpenFGA — centralizes configuration, adds observability. Services call Authorization for permission checks and relationship writes |
 | **[Agents Orchestrator](agents-orchestrator.md)** | Reconciles agent workloads for threads with unacknowledged messages |
-| **Agent State** | Long-term agent context persistence (APSS) |
-| **Tracing** | Span ingestion and query. Implements standard OTLP TraceService/Export with upsert semantics for in-progress spans |
+| **Tracing** | Span ingestion and query. Implements standard OTLP TraceService/Export with upsert semantics for in-progress spans. Captures full LLM call context for observability |
 | **[Agents](agents-service.md)** | Management of agent resources: agents, volumes, MCP servers, skills, hooks, etc. |
 | **Runner** | Executes workloads. Current implementation: [k8s-runner](k8s-runner.md) |
 | **Gateway** | Exposes platform methods for external usage via [ConnectRPC](gateway.md#connectrpc) (gRPC + HTTP/JSON). Accessible at `gateway.agyn.dev` (subdomain) and `agyn.dev/api/` (path-based, prefix stripped) |
@@ -130,13 +127,25 @@ graph TB
 | **[Apps Service](apps-service.md)** | App registration, profiles, and enrollment. Manages the lifecycle of [apps](apps.md) |
 | **[Reminders](apps/reminders.md)** | Platform-provided [app](apps.md). Delivers delayed messages to threads on behalf of agents |
 
+## Data Concerns
+
+The platform separates three distinct data concerns, each with its own storage and lifecycle:
+
+| Concern | What it stores | Storage | Lifetime |
+|---------|---------------|---------|----------|
+| **Chat / Threads** | User messages and agent responses — the conversation record | PostgreSQL ([Threads](threads.md)) | Long-lived |
+| **Agent state** | Internal working memory managed by each agent implementation | Disk (persistent volume) | Lives as long as the volume exists |
+| **Tracing** | Full LLM call context (complete request bodies) for observability and debugging | PostgreSQL ([Tracing](tracing.md)) | Shorter retention due to data volume |
+
+See [Agent State](agent/state.md) for the persistence model.
+
 ## Data Stores
 
 | Store | Current Usage |
 |-------|--------------|
-| PostgreSQL | Primary relational store (agent state, platform data, user records, identity registry, organizations) |
+| PostgreSQL | Primary relational store (platform data, user records, identity registry, organizations, tracing) |
 | Redis | Pub/sub for notifications, caching |
-| Filesystem | Graph store (agent graph definitions persisted as filesystem dataset) |
+| Persistent Volumes | Agent state — managed by each agent implementation on disk |
 | Object Storage (S3) | Media file storage (MinIO locally, any S3-compatible in production) |
 | OpenFGA | Relationship-based access control (authorization model and relationship tuples). PostgreSQL-backed |
 
@@ -147,7 +156,6 @@ graph TB
 | `agynio/api` | API schemas: protobuf (internal gRPC + external gateway ConnectRPC) | Proto | Active |
 | `agynio/notifications` | Notifications service | Go | Standalone service |
 | `agynio/gateway` | Gateway service | Go | Standalone service |
-| `agynio/agent-state` | Agent State (APSS) service | Go | Standalone service |
 | `agynio/tracing` | Tracing service — span ingestion and query | Go | Planned |
 | `agynio/authorization` | Authorization service (thin proxy to OpenFGA) + authorization model & Terraform | Go, DSL, HCL | Planned |
 | `agynio/identity` | Identity registry service | Go | Planned |

--- a/architecture/token-counting.md
+++ b/architecture/token-counting.md
@@ -61,4 +61,4 @@ The response array has the same length as the input `messages` array. Each eleme
 
 ## Token Storage
 
-The agent counts tokens once when it processes a message and persists the count in the Agent State service. The summarization reducer reads stored token counts from agent state rather than re-counting. It sums the per-message counts to decide whether to summarize (`maxTokens` threshold) and uses them for the head/tail split (`keepTokens` budget).
+The agent counts tokens once when it processes a message and persists the count in agent state on disk. The summarization reducer reads stored token counts from agent state rather than re-counting. It sums the per-message counts to decide whether to summarize (`maxTokens` threshold) and uses them for the head/tail split (`keepTokens` budget).

--- a/architecture/tracing.md
+++ b/architecture/tracing.md
@@ -4,6 +4,8 @@
 
 The Tracing service ingests, stores, and queries span data. It implements the standard [OpenTelemetry](https://opentelemetry.io/) Collector `TraceService/Export` gRPC interface with one behavioral extension: **upsert semantics for in-progress spans**. Standard OpenTelemetry assumes spans are exported once after completion. Agyn needs visibility into ongoing agent operations, so producers export the same span multiple times — first while in progress, then again when completed. The Tracing service detects duplicates by `(trace_id, span_id)` and patches the existing record instead of inserting a new one.
 
+Tracing captures the **full LLM call context** — the complete request body (all messages sent to the model) for each LLM call. This makes tracing the primary source for debugging and inspecting what the model saw at each step. Due to the volume of data, tracing has shorter retention than conversation records in [Threads](threads.md). See [Agent State — Isolation](agent/state.md#isolation) for how this fits into the platform's data separation model.
+
 ## Responsibilities
 
 - **Ingest** spans via the standard OTLP gRPC interface with upsert semantics.

--- a/changes/2025-07-21-remove-apss.md
+++ b/changes/2025-07-21-remove-apss.md
@@ -1,0 +1,23 @@
+# Remove Agent Persistent State Service (APSS)
+
+## Target
+
+- [Agent State](../architecture/agent/state.md)
+- [Agent Implementation](../architecture/agent/implementation.md)
+- [System Overview](../architecture/system-overview.md)
+
+## Delta
+
+The architecture now describes agent state as disk-based (persistent volume), managed by each agent implementation. The current implementation includes the APSS service (`agynio/agent-state` repository) with a gRPC API backed by PostgreSQL. This service, its proto definitions (`agynio/api/agent_state/v1/`), and the Gateway proxy (`AgentStateGateway`) need to be removed.
+
+## Acceptance Signal
+
+- `agynio/agent-state` repository is archived or deleted.
+- Agent state proto definitions (`agent_state/v1/`) and gateway proto (`gateway/v1/agent_state.proto`) are removed from `agynio/api`.
+- `agn` uses only filesystem-based state persistence (remote/APSS backend removed).
+- Agent containers use a persistent volume for state; no gRPC calls to Agent State service.
+
+## Notes
+
+- The `agynio/agent-state` service is currently deployed and in use.
+- Migration path: agents switch to filesystem persistence backed by PVCs. Existing APSS data does not need migration — agent state is ephemeral by nature and will be rebuilt from threads on next activation.

--- a/open-questions.md
+++ b/open-questions.md
@@ -29,7 +29,7 @@ Unresolved architectural decisions requiring discussion.
 
 ## Authorization Model Completeness
 
-**Context:** The authorization approach is decided — OpenFGA with a dedicated Authorization service (see [Authorization](architecture/authz.md)). The initial model covers threads, files, organization roles, and agent state. The full model needs to cover all resource types and access patterns.
+**Context:** The authorization approach is decided — OpenFGA with a dedicated Authorization service (see [Authorization](architecture/authz.md)). The initial model covers threads, files, and organization roles. The full model needs to cover all resource types and access patterns.
 
 **Questions:**
 - What are the complete relation definitions for all resource types (models, workspaces, MCP servers, channels, secrets)? How do org-scoped vs independent resources differ in their relation definitions?


### PR DESCRIPTION
## Summary

Replace the Agent Persistent State Service (APSS) with disk-based agent state managed by each agent implementation. Document the three-way data concern isolation model.

## Architecture Changes

### Agent State (`agent/state.md`)
Replaced the APSS service spec (gRPC API, data model, context snapshots) with the new persistence model:
- **Agent-owned**: each agent implementation defines its own state format and storage layout
- **Disk-based**: state written to a filesystem path backed by a persistent volume
- **Volume-scoped lifetime**: state lives as long as the PVC exists

### Data Concern Isolation
Documented the clean separation of three data concerns:

| Concern | Storage | Lifetime |
|---------|---------|----------|
| **Chat / Threads** | PostgreSQL | Long-lived conversation record |
| **Agent state** | Disk (PVC) | Volume lifetime |
| **Tracing** | PostgreSQL | Shorter retention (full LLM context per request) |

### Removed APSS References From
- `system-overview.md` — component diagram, component summary, data stores, repository map
- `gateway.md` — `AgentStateGateway` proxy
- `api-contracts.md` — internal + gateway proto definitions
- `control-data-plane.md` — diagram and classification table
- `organizations.md` — independent resources table
- `agent/implementation.md` — remote/APSS backend
- `agn-cli.md` — remote backend, architecture diagram
- `media.md`, `token-counting.md` — inline references
- `open-questions.md` — authorization model scope

### Added
- `tracing.md` — note about full LLM context capture and shorter retention
- `system-overview.md` — new "Data Concerns" section
- `changes/2025-07-21-remove-apss.md` — implementation delta

## Files Changed (15)

```
M  README.md
M  architecture/agent/README.md
M  architecture/agent/implementation.md
M  architecture/agent/state.md
M  architecture/agn-cli.md
M  architecture/api-contracts.md
M  architecture/control-data-plane.md
M  architecture/gateway.md
M  architecture/media.md
M  architecture/organizations.md
M  architecture/system-overview.md
M  architecture/token-counting.md
M  architecture/tracing.md
A  changes/2025-07-21-remove-apss.md
M  open-questions.md
```