### PR TITLE
add terminal-proxy as standalone service

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ Target architecture of the platform. Describes how the system should work.
 | [Token Counting](architecture/token-counting.md) | Per-message token counting service |
 | [Providers, Models, and Secrets](architecture/providers.md) | LLM provider / model and secret provider / secret resource ownership |
 | [LLM](architecture/llm.md) | LLM provider/model management and LLM call proxy |
+| [Terminal Proxy](architecture/terminal-proxy.md) | Standalone WebSocket service for interactive terminal access to workload containers |
 | [Secrets](architecture/secrets.md) | Secret provider/secret management and secret resolution |
 | [Notifications](architecture/notifications.md) | Real-time event fanout service |
 | [Runner](architecture/runner.md) | Workload execution service |

--- a/architecture/gateway.md
+++ b/architecture/gateway.md
@@ -74,6 +74,7 @@ Only methods intended for external use appear in gateway proto services. Interna
 | `TracingGateway` | [Tracing](tracing.md) | Ingest, Query |
 | `SecretsGateway` | [Secrets](secrets.md) | ResolveSecretValue |
 | `UsersGateway` | [Users](users.md) | CreateAPIToken, ListAPITokens, RevokeAPIToken |
+| `RunnerGateway` | [Runner](runner.md) | FindWorkloadsByLabels, InspectWorkload |
 
 ### Handler Implementation
 

--- a/architecture/system-overview.md
+++ b/architecture/system-overview.md
@@ -36,6 +36,7 @@ graph TB
         Identity[Identity]
         AppsService[Apps Service]
         LLMProxy[LLM Proxy]
+        TerminalProxy[Terminal Proxy]
     end
 
     subgraph Apps
@@ -63,6 +64,8 @@ graph TB
     Gateway --> TokenCounting
     Gateway --> Tracing
     LLMProxy --> LLM
+    WebApp & MobileApp -- "/terminal/" --> TerminalProxy
+    TerminalProxy -->|OpenZiti| Runner
     LLMProxy --> ZitiMgmt
     LLMProxy --> Users
     LLMProxy --> Authorization
@@ -90,6 +93,7 @@ graph TB
     Threads --> Authorization
     Agents --> Authorization
     Organizations --> Authorization
+    TerminalProxy --> Authorization
     Authorization --> OpenFGA[(OpenFGA)]
 
     AppsService --> Identity
@@ -115,6 +119,7 @@ graph TB
 | **Token Counting** | Per-message token counting for LLM messages |
 | **LLM** | Manages LLM providers and models. Provides model resolution (model ID → provider endpoint, token, remote name) for the LLM Proxy |
 | **[LLM Proxy](llm-proxy.md)** | Exposes an OpenAI-compatible Responses API endpoint for agents. Authenticates callers, resolves models via LLM service, forwards requests to external providers |
+| **[Terminal Proxy](terminal-proxy.md)** | Standalone WebSocket service for interactive terminal access to workload containers. Authenticates callers, bridges WebSocket sessions to Runner Exec RPC via OpenZiti |
 | **Secrets** | Manages secret providers and secrets. Resolves secret values from external providers at runtime |
 | **Notifications** | Real-time event fanout via persistent connections (socket). All services publish state change events through Notifications |
 | **Authorization** | Fine-grained access control. Thin proxy to OpenFGA — centralizes configuration, adds observability. Services call Authorization for permission checks and relationship writes |
@@ -167,6 +172,7 @@ See [Agent State](agent/state.md) for the persistence model.
 | `agynio/codex-sdk-go` | Go client library for Codex CLI | Go | Active |
 | `agynio/agn-cli` | Agent loop implementation — LLM reasoning with tool use | Go | Planned |
 | `agynio/llm-proxy` | LLM Proxy — OpenAI-compatible Responses API endpoint for agents | Go | Planned |
+| `agynio/terminal-proxy` | Terminal Proxy — WebSocket terminal access to workload containers | Go | Planned |
 | `agynio/agent-init-codex` | Init container image: agynd + Codex CLI | Dockerfile | Active |
 | `agynio/agent-init-claude` | Init container image: agynd + Claude Code CLI | Dockerfile | Active |
 | `agynio/agent-init-agn` | Init container image: agynd + agn CLI | Dockerfile | Active |

--- a/architecture/terminal-proxy.md
+++ b/architecture/terminal-proxy.md
@@ -11,6 +11,7 @@ The Terminal Proxy is a standalone service that provides interactive web-based t
 | **WebSocket endpoint** | Accept WebSocket upgrade requests for terminal sessions |
 | **Authentication** | Authenticate callers via OIDC bearer token (same mechanism as the [Gateway](gateway.md)) |
 | **Authorization** | Call the [Authorization](authz.md) service to verify the caller can access the workload |
+| **Runner resolution** | Query the [Runners](runners.md) service to resolve which runner hosts the target workload |
 | **Shell detection** | Execute a non-interactive command via Runner `Exec` to detect the available shell before starting the interactive session |
 | **Exec bridging** | Open a bidirectional streaming `Exec` RPC to the Runner and bridge stdin/stdout between the WebSocket and the exec stream |
 
@@ -58,12 +59,15 @@ sequenceDiagram
     participant UI as Web App
     participant TP as Terminal Proxy
     participant Auth as Authorization
+    participant RS as Runners Service
     participant R as Runner
 
     UI->>TP: WebSocket upgrade /terminal/ws?workloadId=...&containerId=...
     TP->>TP: Authenticate (OIDC bearer token)
     TP->>Auth: Check(identity, can_access, workload)
     Auth-->>TP: allowed / denied
+    TP->>RS: GetWorkload(workloadId)
+    RS-->>TP: workload (runner_id, containers)
     TP->>R: Exec (non-interactive, shell detection)
     R-->>TP: detected shell path
     TP->>R: Exec (bidirectional stream, TTY, detected shell)
@@ -102,6 +106,8 @@ The Terminal Proxy starts the Runner `Exec` RPC with:
 ### Workload Container Selection
 
 A workload consists of multiple containers (main container, MCP server sidecars, hook sidecars). The `containerId` parameter identifies which container to exec into. The Terminal Proxy passes this to the Runner's `Exec` RPC, which targets the specified container within the workload's pod.
+
+The Terminal Proxy resolves the hosting runner by calling `GetWorkload` on the [Runners](runners.md) service, which returns the `runner_id`. The Terminal Proxy then dials that specific runner via OpenZiti to issue the `Exec` RPC.
 
 ## Authentication
 
@@ -145,6 +151,7 @@ The ingress route is defined as an Istio VirtualService in `agynio/bootstrap`. U
 
 | Field | Source | Description |
 |-------|--------|-------------|
+| `RUNNERS_SERVICE_ADDRESS` | Deployment config | gRPC address of the [Runners](runners.md) service |
 | `AUTHORIZATION_SERVICE_ADDRESS` | Deployment config | gRPC address of the [Authorization](authz.md) service |
 | `ZITI_MANAGEMENT_ADDRESS` | Deployment config | gRPC address of the [Ziti Management](openziti.md) service |
 | `OIDC_ISSUER` | Deployment config | OIDC issuer URL for token validation |
@@ -158,4 +165,4 @@ The ingress route is defined as an Istio VirtualService in `agynio/bootstrap`. U
 | Language | Go |
 | HTTP framework | Standard `net/http` with `nhooyr.io/websocket` for WebSocket handling |
 | OpenZiti | Embedded SDK (`openziti/sdk-golang`) for dialing Runners |
-| Internal calls | Standard gRPC clients for Authorization and Ziti Management |
+| Internal calls | Standard gRPC clients for Runners, Authorization, and Ziti Management |

--- a/architecture/terminal-proxy.md
+++ b/architecture/terminal-proxy.md
@@ -1,0 +1,161 @@
+# Terminal Proxy
+
+## Overview
+
+The Terminal Proxy is a standalone service that provides interactive web-based terminal access to running workload containers. It accepts WebSocket connections from the UI, authenticates callers, and bridges each session to the [Runner](runner.md)'s `Exec` RPC via [OpenZiti](openziti.md).
+
+## Responsibilities
+
+| Responsibility | Description |
+|---------------|-------------|
+| **WebSocket endpoint** | Accept WebSocket upgrade requests for terminal sessions |
+| **Authentication** | Authenticate callers via OIDC bearer token (same mechanism as the [Gateway](gateway.md)) |
+| **Authorization** | Call the [Authorization](authz.md) service to verify the caller can access the workload |
+| **Shell detection** | Execute a non-interactive command via Runner `Exec` to detect the available shell before starting the interactive session |
+| **Exec bridging** | Open a bidirectional streaming `Exec` RPC to the Runner and bridge stdin/stdout between the WebSocket and the exec stream |
+
+## Classification
+
+The Terminal Proxy is a **data plane** service — it carries live interactive terminal traffic.
+
+## WebSocket Endpoint
+
+```
+/terminal/ws?workloadId={workloadId}&containerId={containerId}
+```
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `workloadId` | string (UUID) | The workload to connect to |
+| `containerId` | string | The specific container within the workload (main container or a sidecar) |
+
+### Protocol
+
+The client connects via WebSocket with a Bearer token for authentication. After authentication and authorization, the Terminal Proxy opens a bidirectional streaming `Exec` RPC to the Runner via OpenZiti and bridges the two streams.
+
+#### Client → Terminal Proxy (JSON messages)
+
+| Message | Fields | Description |
+|---------|--------|-------------|
+| `input` | `type: "input"`, `data: string` | Keyboard input from the terminal |
+| `resize` | `type: "resize"`, `cols: int`, `rows: int` | Terminal dimensions changed |
+| `ping` | `type: "ping"`, `ts: int` | Keepalive |
+| `close` | `type: "close"` | Client requests session end |
+
+#### Terminal Proxy → Client (JSON messages)
+
+| Message | Fields | Description |
+|---------|--------|-------------|
+| `output` | `type: "output"`, `data: string` | Terminal output (stdout/stderr) |
+| `status` | `type: "status"`, `phase: string`, `exitCode?: int`, `reason?: string` | Session lifecycle events. Phases: `starting`, `running`, `exited`, `error` |
+| `error` | `type: "error"`, `code: string`, `message: string` | Error notification |
+| `pong` | `type: "pong"`, `ts: int` | Keepalive response |
+
+### Flow
+
+```mermaid
+sequenceDiagram
+    participant UI as Web App
+    participant TP as Terminal Proxy
+    participant Auth as Authorization
+    participant R as Runner
+
+    UI->>TP: WebSocket upgrade /terminal/ws?workloadId=...&containerId=...
+    TP->>TP: Authenticate (OIDC bearer token)
+    TP->>Auth: Check(identity, can_access, workload)
+    Auth-->>TP: allowed / denied
+    TP->>R: Exec (non-interactive, shell detection)
+    R-->>TP: detected shell path
+    TP->>R: Exec (bidirectional stream, TTY, detected shell)
+    R-->>TP: Stream established
+    TP-->>UI: status: running
+
+    loop Interactive session
+        UI->>TP: {type: "input", data: "ls\n"}
+        TP->>R: Exec stdin
+        R-->>TP: Exec stdout
+        TP-->>UI: {type: "output", data: "..."}
+    end
+
+    UI->>TP: {type: "resize", cols: 120, rows: 40}
+    TP->>R: Resize exec
+
+    alt Container stops
+        R-->>TP: Exec stream ends (exit code)
+        TP-->>UI: {type: "status", phase: "exited", exitCode: 0}
+        TP-->>UI: WebSocket close
+    else Client closes
+        UI->>TP: {type: "close"}
+        TP->>R: Cancel exec
+        TP-->>UI: WebSocket close
+    end
+```
+
+### Exec Configuration
+
+The Terminal Proxy starts the Runner `Exec` RPC with:
+
+- **TTY mode** enabled (interactive shell).
+- **Shell** auto-detected: the Terminal Proxy executes a shell detection command via a non-interactive `Exec` call before starting the interactive session. Prefers `/bin/bash`, falls back to `/bin/sh`.
+- **No wall timeout** — sessions remain open as long as the WebSocket is connected and the container is running.
+
+### Workload Container Selection
+
+A workload consists of multiple containers (main container, MCP server sidecars, hook sidecars). The `containerId` parameter identifies which container to exec into. The Terminal Proxy passes this to the Runner's `Exec` RPC, which targets the specified container within the workload's pod.
+
+## Authentication
+
+The Terminal Proxy authenticates callers by validating the OIDC `access_token` JWT signature against the IdP's JWKS endpoint and extracting the `sub` claim. The resolved identity is used for authorization checks.
+
+The WebSocket upgrade request carries the token as a query parameter or in the `Authorization` header (browsers cannot set headers on WebSocket connections, so the query parameter path is the primary mechanism for the terminal endpoint).
+
+## Authorization
+
+The Terminal Proxy delegates authorization to the [Authorization](authz.md) service. After authentication, it calls `Check` to verify the caller can access the workload. The authorization logic is defined in the [authorization model](authz.md#authorization-model).
+
+## OpenZiti Identity
+
+The Terminal Proxy participates in the OpenZiti overlay to reach Runners. It obtains its identity at runtime via [self-enrollment](openziti.md#service-identity-self-enrollment) through [Ziti Management](openziti.md#ziti-management-service).
+
+| Aspect | Detail |
+|--------|--------|
+| Role attributes | `["terminal-proxy-hosts"]` |
+| Enrollment | Self-enrollment via Ziti Management at pod startup |
+| SDK usage | Dials the `runner` OpenZiti service to issue `Exec` RPCs |
+
+### Static Policies
+
+| Policy | Type | Identity Roles | Service Roles | Purpose |
+|--------|------|---------------|---------------|---------|
+| `terminal-proxy-dial-runner` | Dial | `#terminal-proxy-hosts` | `@runner` | Terminal Proxy can reach Runners |
+
+The Terminal Proxy does not bind any OpenZiti service — it only dials Runners. The UI reaches the Terminal Proxy via standard ingress, not OpenZiti.
+
+## Ingress
+
+The Terminal Proxy is accessible via a path-based route on the platform domain:
+
+| Path | Backend | Use case |
+|------|---------|----------|
+| `agyn.dev/terminal/` | `terminal-proxy:8080` (prefix stripped) | UI WebSocket connections |
+
+The ingress route is defined as an Istio VirtualService in `agynio/bootstrap`. Using a path on the same origin as the web app avoids CORS for WebSocket upgrades.
+
+## Configuration
+
+| Field | Source | Description |
+|-------|--------|-------------|
+| `AUTHORIZATION_SERVICE_ADDRESS` | Deployment config | gRPC address of the [Authorization](authz.md) service |
+| `ZITI_MANAGEMENT_ADDRESS` | Deployment config | gRPC address of the [Ziti Management](openziti.md) service |
+| `OIDC_ISSUER` | Deployment config | OIDC issuer URL for token validation |
+| `LISTEN_ADDRESS` | Deployment config | HTTP listen address (e.g., `:8080`) |
+
+## Implementation
+
+| Aspect | Details |
+|--------|---------|
+| Repository | `agynio/terminal-proxy` |
+| Language | Go |
+| HTTP framework | Standard `net/http` with `nhooyr.io/websocket` for WebSocket handling |
+| OpenZiti | Embedded SDK (`openziti/sdk-golang`) for dialing Runners |
+| Internal calls | Standard gRPC clients for Authorization and Ziti Management |

--- a/open-questions.md
+++ b/open-questions.md
@@ -121,3 +121,14 @@ Unresolved architectural decisions requiring discussion.
 - How is the ingestion endpoint authenticated? (Istio mTLS for internal producers? Service tokens for external producers? Unauthenticated within the cluster?)
 - How is the ingestion endpoint authorized? (Any authenticated producer can export spans? Scoped to specific agents or organizations?)
 - How are query results scoped? (Organization-level visibility, per-agent restriction, or full access for any authenticated user?)
+
+---
+
+## Workload Discovery and Runner Routing
+
+**Context:** The UI needs to list running containers for a conversation (to populate the container popover in the chat header) and the [Terminal Proxy](architecture/terminal-proxy.md) needs to reach the specific runner instance hosting a workload. Currently, all runners bind the same `runner` OpenZiti service — `Dial("runner")` load-balances across instances, with no mechanism to target a specific runner.
+
+**Questions:**
+- Where does workload discovery live? The UI needs a service that can answer "what containers are running for thread X?" The [Agents Orchestrator](architecture/agents-orchestrator.md) tracks workload state in PostgreSQL but has no external API. Options: (a) a dedicated query service reading from the orchestrator's store, (b) extending the [Agents Service](architecture/agents-service.md) with runtime workload state, (c) the orchestrator exposes read-only query methods.
+- How does the Terminal Proxy route to the correct runner instance? Options: (a) per-runner OpenZiti services (e.g., `runner-{id}`) with dynamic policies, (b) the orchestrator or discovery service returns a runner-specific address, (c) a runner-side routing layer that forwards exec requests to the correct instance.
+- Does the orchestrator's `FindWorkloadsByLabels` call have the same routing problem? If multiple runners exist, a single `Dial("runner")` only reaches one — how does the reconciler discover workloads across all runners?


### PR DESCRIPTION
## Summary

Adds the Terminal Proxy — a standalone service for interactive terminal access to workload containers. Single responsibility: bridge WebSocket sessions to Runner `Exec` RPC via OpenZiti.

### New file: `architecture/terminal-proxy.md`

**WebSocket endpoint** — `/terminal/ws?workloadId={workloadId}&containerId={containerId}`
- JSON message protocol: `input`, `resize`, `ping`, `close` (client→server) / `output`, `status`, `error`, `pong` (server→client)
- Mermaid sequence diagram showing the full lifecycle
- Exec config: TTY mode, shell auto-detection (bash → sh), no wall timeout
- Container selection: `containerId` targets a specific container within the workload pod

**Infrastructure**:
- Authentication: OIDC bearer token
- Authorization: delegates to Authorization service
- OpenZiti: dials Runners (does not bind any service)
- Ingress: path-based route on platform domain (`agyn.dev/terminal/`)
- Implementation: Go, `net/http`, `nhooyr.io/websocket`, OpenZiti SDK

### Changes to existing docs

- `architecture/system-overview.md`: Terminal Proxy added to component diagram, component summary table, and repository map
- `README.md`: Terminal Proxy added to architecture docs table
- `open-questions.md`: Added "Workload Discovery and Runner Routing" — where does container discovery for the UI live, and how does the Terminal Proxy route to the correct runner instance when multiple runners exist

### Related

- Product spec: [agynio/product#3](https://github.com/agynio/product/pull/3) (merged)