### PR TITLE
fix(llm-proxy): correct Agent Configuration section for Codex

### DIFF
--- a/architecture/llm-proxy.md
+++ b/architecture/llm-proxy.md
@@ -152,12 +152,23 @@ The ingress route is defined as an Istio VirtualService in `agynio/bootstrap` (s
 
 Agents are configured with the LLM Proxy as their LLM endpoint. The wrapper daemon ([`agynd`](agynd-cli.md)) sets the endpoint when preparing the agent environment.
 
-**Codex CLI** uses `OPENAI_BASE_URL` and `OPENAI_API_KEY`:
+**Codex CLI** uses a custom model provider in `config.toml`:
 
-```bash
-OPENAI_BASE_URL=https://llm.agyn.dev/v1   # or OpenZiti address
-OPENAI_API_KEY=agyn_...                     # platform API token (unused over OpenZiti)
+`agynd` writes `$CODEX_HOME/config.toml` with a custom provider pointing at the LLM Proxy. The custom provider avoids inheriting OpenAI-specific behavior (remote compaction via `POST /responses/compact`, realtime WebSocket) that the LLM Proxy does not implement.
+
+```toml
+model_provider = "platform"
+
+[model_providers.platform]
+name = "Agyn LLM"
+base_url = "https://llm.agyn.dev/v1"  # or OpenZiti address
+env_key = "OPENAI_API_KEY"
+wire_api = "responses"
 ```
+
+`agynd` sets `OPENAI_API_KEY` in the Codex subprocess environment. Over OpenZiti, the token value is unused (authentication is via mTLS). Over the public endpoint, the token must be a valid platform API token (`agyn_...`).
+
+> **Note:** Using `OPENAI_BASE_URL` env var to override the built-in OpenAI provider does not work with `codex app-server`. The built-in provider has `name = "OpenAI"` which triggers remote compaction (`POST /responses/compact`) and has `env_key: None` which prevents the `OPENAI_API_KEY` env var from being used for Bearer authentication in the subprocess auth pipeline.
 
 **[`agn`](agn-cli.md)** uses `llm.endpoint` in its configuration:
 


### PR DESCRIPTION
## Summary

Corrects the Agent Configuration section in `llm-proxy.md` to document the custom `config.toml` provider approach that `agynd` actually implements, replacing the incorrect `OPENAI_BASE_URL` + `OPENAI_API_KEY` env var recommendation.

## Why

The `OPENAI_BASE_URL` + `OPENAI_API_KEY` approach does not work with `codex app-server`:

1. **Remote compaction breaks** — built-in OpenAI provider has `name = "OpenAI"` → `is_openai() == true` → triggers `POST /responses/compact` which the LLM Proxy does not serve (404)
2. **Auth token never reaches HTTP requests** — built-in provider has `env_key: None`, so `OPENAI_API_KEY` is not read in the subprocess auth pipeline (`auth_provider_from_auth`). `codex app-server` also disables `CODEX_API_KEY` env (`enable_codex_api_key_env: false`)
3. **Deprecation** — `OPENAI_BASE_URL` env var is deprecated in Codex (warns on startup)

## What Changed

Replaced the Codex section with documentation of the custom config.toml provider (`name = "Agyn LLM"`, `env_key = "OPENAI_API_KEY"`, `wire_api = "responses"`) that avoids all three issues. Added a note explaining why the env var approach doesn't work.