### PR TITLE
Add Runners service architecture

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ Target architecture of the platform. Describes how the system should work.
 | [LLM](architecture/llm.md) | LLM provider/model management and LLM call proxy |
 | [Secrets](architecture/secrets.md) | Secret provider/secret management and secret resolution |
 | [Notifications](architecture/notifications.md) | Real-time event fanout service |
+| [Runners](architecture/runners.md) | Runner registration and workload runtime state |
 | [Runner](architecture/runner.md) | Workload execution service |
 | [k8s-runner](architecture/k8s-runner.md) | Kubernetes-native Runner implementation |
 | [Agents Orchestrator](architecture/agents-orchestrator.md) | Agent workload reconciliation — start, monitor, stop |

--- a/architecture/agents-orchestrator.md
+++ b/architecture/agents-orchestrator.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-The Agents Orchestrator is a **control plane** service that ensures every thread with unacknowledged agent messages has a running agent workload processing it. It is a background reconciler with no external API — it observes desired state (threads needing agents) and actual state (running workloads), and converges them.
+The Agents Orchestrator is a **control plane** service that ensures every thread with unacknowledged agent messages has a running agent workload processing it. It is a background reconciler — it observes desired state (threads needing agents) and actual state (running workloads via the [Runners](runners.md) service), and converges them.
 
 The orchestrator does not decide which agent should be on a thread. It does not manage thread participants. By the time the orchestrator acts, the agent is already a participant on the thread. The orchestrator's job is: **if a thread has unacked messages for an agent participant, ensure a workload is running for that agent on that thread.**
 
@@ -18,6 +18,7 @@ graph TB
     Notifications -->|message.created events| Reconciler
     Agents -->|agent definitions + sub-resources| Reconciler
     Secrets -->|secret resolution for ENVs| Reconciler
+    Runners[Runners] -->|workload state| Reconciler
     Reconciler -->|start/stop workloads| Runner
     Reconciler -->|create/delete identities| ZitiMgmt[Ziti Management]
 ```
@@ -28,6 +29,7 @@ graph TB
 | **Notifications** | Subscribe to `message.created` events for fast reactivity |
 | **Agents** | Fetch agent definitions and sub-resources (MCPs, volumes, ENVs, init scripts, hooks, skills) |
 | **Secrets** | Resolve secret values for ENVs that reference secrets |
+| **[Runners](runners.md)** | Read and write workload runtime state (which workloads are running, on which runner) |
 | **Runner** | Start and stop agent workloads (via OpenZiti SDK — see [Authentication](authn.md#sdk-embedding)) |
 | **Ziti Management** | Create and delete OpenZiti identities for agent containers |
 
@@ -41,7 +43,7 @@ Threads with unacknowledged messages for agent participants. The orchestrator qu
 
 ### Actual State
 
-Running agent workloads. The orchestrator queries Runner (`FindWorkloadsByLabels`) to discover what is currently running.
+Running agent workloads. The orchestrator queries the [Runners](runners.md) service to discover what is currently running.
 
 ### Loop
 
@@ -54,11 +56,11 @@ graph LR
     Wait --> Fetch
 ```
 
-1. On startup, the orchestrator subscribes to Notifications for `message.created` events and fetches the current state from Threads and Runner.
+1. On startup, the orchestrator subscribes to Notifications for `message.created` events and fetches the current state from Threads and the [Runners](runners.md) service.
 2. **Compare:** For each agent participant with unacked messages — check if a workload is running. For each running workload — check if it still has unacked messages or recent activity.
 3. **Act:**
-   - **Start:** If an agent has unacked messages and no running workload → assemble workload spec → create OpenZiti identity → start workload via Runner.
-   - **Stop:** If a running workload has been idle beyond the configured timeout → stop workload via Runner → delete OpenZiti identity.
+   - **Start:** If an agent has unacked messages and no running workload → assemble workload spec → create OpenZiti identity → start workload via Runner → record workload in [Runners](runners.md) service.
+   - **Stop:** If a running workload has been idle beyond the configured timeout → stop workload via Runner → remove workload from [Runners](runners.md) service → delete OpenZiti identity.
 4. **Wait:** Block until a notification arrives or the poll interval expires, then repeat from step 2.
 
 The polling loop is a consistency fallback. Notifications handle the latency-sensitive path — when a new message arrives on a thread, the `message.created` event wakes the orchestrator to re-evaluate immediately.
@@ -67,7 +69,7 @@ Follows the [Consumer Sync Protocol](notifications.md#consumer-sync-protocol) fo
 
 ### Idle Timeout
 
-The orchestrator owns idle timeout enforcement. During each reconciliation pass, it checks running agent workloads against their last activity (last message on the thread). Agents that have been idle beyond the configured timeout are stopped via `Runner.StopWorkload`.
+The orchestrator owns idle timeout enforcement. During each reconciliation pass, it checks running agent workloads against their last activity (last message on the thread). Agents that have been idle beyond the configured timeout are stopped via `Runner.StopWorkload` and removed from the [Runners](runners.md) service.
 
 The agent container does not implement idle detection. It may exit naturally (process completion, crash), but the orchestrator is the authority for lifecycle management.
 
@@ -76,7 +78,7 @@ The agent container does not implement idle detection. It may exit naturally (pr
 In addition to agent workloads, the orchestrator reconciles OpenZiti identities:
 
 1. Each reconciliation pass: call `ZitiManagement.ListManagedIdentities()`.
-2. Compare against active workloads from `Runner.FindWorkloadsByLabels()`.
+2. Compare against active workloads from the [Runners](runners.md) service.
 3. Delete OpenZiti identities that have no matching running workload via `ZitiManagement.DeleteIdentity()`.
 
 Orphaned identities arise from Runner crashes, container crashes, or orchestrator restarts. An orphaned identity with no running container is inert (the enrollment JWT has expired or the enrolled certificate is inside a stopped container), but cleanup is important for hygiene and OpenZiti Controller resource limits.
@@ -94,6 +96,7 @@ sequenceDiagram
     participant S as Secrets
     participant ZM as Ziti Management
     participant R as Runner
+    participant RS as Runners Service
 
     O->>T: Get agent definition + sub-resources
     T-->>O: Agent, MCPs, Volumes, ENVs, InitScripts, Hooks, Skills
@@ -104,6 +107,8 @@ sequenceDiagram
     ZM-->>O: enrollmentJWT, openZitiIdentityId
     O->>R: StartWorkload(spec, enrollmentJWT)
     R-->>O: workloadId
+    O->>RS: CreateWorkload(runnerId, workloadId, threadId, agentId, containers)
+    RS-->>O: OK
 ```
 
 ### Workload Spec Assembly
@@ -138,10 +143,13 @@ When the orchestrator decides an agent workload should stop (idle timeout exceed
 sequenceDiagram
     participant O as Orchestrator
     participant R as Runner
+    participant RS as Runners Service
     participant ZM as Ziti Management
 
     O->>R: StopWorkload(workloadId)
     R-->>O: OK
+    O->>RS: DeleteWorkload(workloadId)
+    RS-->>O: OK
     O->>ZM: DeleteIdentity(openZitiIdentityId)
     ZM-->>O: OK
 ```
@@ -164,7 +172,7 @@ See [Control Plane & Data Plane — Reconciliation](control-data-plane.md#reconc
 |--------|--------|
 | **Plane** | Control |
 | **API** | None — pure background reconciler |
-| **State** | PostgreSQL (workload ↔ identity mappings) |
+| **State** | Stateless — reads/writes workload state via [Runners](runners.md) service |
 | **Scaling** | Leader-elected; scales with number of agent definitions, not traffic |
 | **Failure impact** | Temporary loss delays new agent starts and idle stops; already-running agents continue |
 

--- a/architecture/gateway.md
+++ b/architecture/gateway.md
@@ -74,6 +74,7 @@ Only methods intended for external use appear in gateway proto services. Interna
 | `TracingGateway` | [Tracing](tracing.md) | Ingest, Query |
 | `SecretsGateway` | [Secrets](secrets.md) | ResolveSecretValue |
 | `UsersGateway` | [Users](users.md) | CreateAPIToken, ListAPITokens, RevokeAPIToken |
+| `RunnersGateway` | [Runners](runners.md) | ListWorkloadsByThread, GetWorkload |
 
 ### Handler Implementation
 

--- a/architecture/identity.md
+++ b/architecture/identity.md
@@ -33,7 +33,7 @@ Every service that creates an identity registers it here:
 | **User** | [Users](users.md) | On first OIDC login (user provisioning) |
 | **Agent** | [Agents](agents-service.md) | On agent resource creation |
 | **Channel** | [Channels](channels.md) | On channel creation |
-| **Runner** | Runner enrollment flow | On runner enrollment |
+| **Runner** | [Runners](runners.md) | On runner registration |
 | **App** | [Apps Service](apps-service.md) | On app registration |
 
 The registering service generates the `identity_id` (UUID) and calls `RegisterIdentity` before storing the identity in its own database.

--- a/architecture/openziti.md
+++ b/architecture/openziti.md
@@ -353,7 +353,7 @@ sequenceDiagram
 
 External runners are provisioned by an operator using a service token:
 
-1. Admin creates a Runner resource in the platform. The system generates a service token.
+1. Admin registers a runner via the [Runners](runners.md) service. The system generates a service token.
 2. Operator configures the external runner with the service token.
 3. Runner presents the token to the platform enrollment endpoint.
 4. Platform validates the token → calls `ZitiManagement.CreateRunnerIdentity(runnerId)`.

--- a/architecture/runners.md
+++ b/architecture/runners.md
@@ -1,0 +1,147 @@
+# Runners
+
+## Overview
+
+The Runners service manages runner registrations and workload runtime state. It is the central registry for:
+
+1. **Runners** — registered runner instances (cluster-scoped and org-scoped), their enrollment state, and metadata.
+2. **Workloads** — the runtime state of workloads running on registered runners. Which workloads are running, on which runner, with which containers.
+
+The [Agents Orchestrator](agents-orchestrator.md) reads and writes workload state through this service. The [Gateway](gateway.md) exposes query methods for the UI. The [Terminal Proxy](terminal-proxy.md) resolves which runner hosts a workload to route exec connections.
+
+## API
+
+### Runner Management
+
+| Method | Description |
+|--------|-------------|
+| **RegisterRunner** | Register a new runner. Creates the runner record, registers an identity (type `runner`) in [Identity](identity.md), and generates a service token |
+| **GetRunner** | Get a runner by ID |
+| **ListRunners** | List registered runners. Supports filtering by organization |
+| **DeleteRunner** | Delete a runner registration. Revokes the runner's OpenZiti identity |
+
+### Workload State
+
+| Method | Description |
+|--------|-------------|
+| **CreateWorkload** | Record a new running workload (runner ID, workload ID, thread ID, agent ID, containers, status) |
+| **UpdateWorkloadStatus** | Update workload status and container states |
+| **DeleteWorkload** | Remove a workload record |
+| **GetWorkload** | Get a workload by ID. Returns workload details including runner ID and containers |
+| **ListWorkloadsByThread** | List workloads for a thread. Used by the UI to populate the container popover |
+
+## Runner Resource
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `id` | string (UUID) | Unique runner identifier |
+| `name` | string | Display name |
+| `organization_id` | string (UUID), nullable | Organization scope. Null for cluster-scoped runners |
+| `identity_id` | string (UUID) | Runner's identity in the [Identity](identity.md) service |
+| `service_token_hash` | string | SHA-256 hash of the service token |
+| `status` | enum | `pending`, `enrolled`, `offline` |
+| `created_at` | timestamp | Creation time |
+| `updated_at` | timestamp | Last modification time |
+
+### Organization Scoping
+
+Cluster-scoped runners (`organization_id: null`) are available to all organizations. Org-scoped runners are available only to the owning organization. Runner selection for a workload is determined by the [Agents Orchestrator](agents-orchestrator.md) based on the agent's organization and available runners.
+
+## Workload Resource
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `id` | string (UUID) | Workload ID (matches the ID on the Runner) |
+| `runner_id` | string (UUID) | Runner hosting this workload |
+| `thread_id` | string (UUID) | Thread this workload serves |
+| `agent_id` | string (UUID) | Agent this workload runs |
+| `organization_id` | string (UUID) | Organization scope (denormalized from agent) |
+| `status` | enum | `starting`, `running`, `stopping`, `stopped`, `failed` |
+| `containers` | list | Containers in the workload (see below) |
+| `created_at` | timestamp | Creation time |
+| `updated_at` | timestamp | Last status update |
+
+### Container
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `container_id` | string | Container identifier within the workload |
+| `name` | string | Display name |
+| `role` | enum | `main`, `sidecar`, `init` |
+| `image` | string | Container image |
+| `status` | enum | `running`, `terminated`, `waiting` |
+
+## Registration Flow
+
+```mermaid
+sequenceDiagram
+    participant Admin as Admin
+    participant RS as Runners Service
+    participant I as Identity
+    participant Auth as Authorization
+
+    Admin->>RS: RegisterRunner(name, organization_id?)
+    RS->>I: RegisterIdentity(id, type: runner)
+    RS->>Auth: Write(identity:runnerId, runner:bind, org/cluster scope)
+    RS->>RS: Generate service token, store runner record
+    RS-->>Admin: Runner record + service token
+```
+
+1. Admin calls `RegisterRunner` (via `agyn` CLI or Terraform).
+2. Runners service registers the runner's identity in the [Identity](identity.md) service with `identity_type: runner`.
+3. Runners service writes authorization tuples granting the runner its permissions.
+4. Runners service generates a service token, stores the runner record, and returns the token.
+5. The service token is provided to the runner deployment.
+
+Cluster-scoped runners are registered by the cluster admin. Org-scoped runners are registered by an organization admin.
+
+## Enrollment
+
+When a runner starts, it presents the service token to the platform enrollment endpoint. The platform validates the token against the Runners service, creates an OpenZiti identity via [Ziti Management](openziti.md), enrolls it, and returns the enrolled identity (certificate + key). This follows the same pattern as [app enrollment](apps-service.md#enrollment).
+
+After enrollment, the runner binds the `runner` OpenZiti service and begins accepting workload commands.
+
+Internal runners (deployed as platform infrastructure) use [self-enrollment](openziti.md#service-identity-self-enrollment) instead of service tokens. They are still registered as runner records — Terraform creates the runner resource at bootstrap and the runner self-enrolls at startup.
+
+## Workload State Management
+
+The [Agents Orchestrator](agents-orchestrator.md) is the sole writer of workload state. The orchestrator calls the Runners service to record workload lifecycle events:
+
+1. **Start**: orchestrator starts a workload on a runner via Runner `StartWorkload`, then calls `CreateWorkload` on the Runners service with the runner ID, workload ID, thread ID, agent ID, and initial container list.
+2. **Update**: orchestrator detects status changes during reconciliation (via Runner `InspectWorkload`) and calls `UpdateWorkloadStatus`.
+3. **Stop**: orchestrator stops a workload via Runner `StopWorkload`, then calls `DeleteWorkload`.
+
+The Runners service is a passive store — it does not interact with runners directly. It records what the orchestrator tells it.
+
+## Gateway Exposure
+
+The following methods are exposed through the [Gateway](gateway.md) for the UI:
+
+| Gateway Service | Methods |
+|----------------|---------|
+| `RunnersGateway` | `ListWorkloadsByThread`, `GetWorkload` |
+
+The UI calls `ListWorkloadsByThread` to populate the container popover in the conversation header. It calls `GetWorkload` to get container details before opening a terminal session.
+
+## Terminal Proxy Integration
+
+The [Terminal Proxy](terminal-proxy.md) needs to reach the specific runner hosting a workload. The flow:
+
+1. UI calls `GetWorkload` (via Gateway) to get workload details including `runner_id`.
+2. UI opens a WebSocket to the Terminal Proxy with `workloadId` and `containerId`.
+3. Terminal Proxy calls `GetWorkload` on the Runners service to resolve `runner_id`.
+4. Terminal Proxy dials the specific runner via OpenZiti using the runner's identity.
+
+This requires per-runner OpenZiti addressing — see [Open Questions](../open-questions.md#per-runner-openziti-addressing) for the routing mechanism.
+
+## Data Store
+
+PostgreSQL. The Runners service owns its database with `runners` and `workloads` tables.
+
+## Classification
+
+| Aspect | Detail |
+|--------|--------|
+| **Plane** | Mixed — control (registration) + data (workload state queries) |
+| **API** | gRPC (internal) + Gateway (external via ConnectRPC) |
+| **State** | PostgreSQL |

--- a/architecture/system-overview.md
+++ b/architecture/system-overview.md
@@ -14,6 +14,7 @@ graph TB
 
     subgraph Control Plane
         Agents[Agents]
+        RunnersService[Runners]
         AgentsOrch[Agents<br/>Orchestrator]
         Organizations[Organizations]
     end
@@ -89,6 +90,7 @@ graph TB
     Files --> Authorization
     Threads --> Authorization
     Agents --> Authorization
+    RunnersService --> Authorization
     Organizations --> Authorization
     Authorization --> OpenFGA[(OpenFGA)]
 
@@ -121,6 +123,7 @@ graph TB
 | **[Agents Orchestrator](agents-orchestrator.md)** | Reconciles agent workloads for threads with unacknowledged messages |
 | **Tracing** | Span ingestion and query. Implements standard OTLP TraceService/Export with upsert semantics for in-progress spans. Captures full LLM call context for observability |
 | **[Agents](agents-service.md)** | Management of agent resources: agents, volumes, MCP servers, skills, hooks, etc. |
+| **[Runners](runners.md)** | Manages runner registrations and workload runtime state. Central registry of runners (cluster-scoped and org-scoped) and running workloads |
 | **Runner** | Executes workloads. Current implementation: [k8s-runner](k8s-runner.md) |
 | **Gateway** | Exposes platform methods for external usage via [ConnectRPC](gateway.md#connectrpc) (gRPC + HTTP/JSON). Accessible at `gateway.agyn.dev` (subdomain) and `agyn.dev/api/` (path-based, prefix stripped) |
 | **Ziti Management** | Manages OpenZiti identities, services, and policies. Encapsulates all OpenZiti Controller API interactions |
@@ -162,6 +165,7 @@ See [Agent State](agent/state.md) for the persistence model.
 | `agynio/users` | Users service | Go | Planned |
 | `agynio/organizations` | Organizations service | Go | Planned |
 | `agynio/agents` | Agents service (agent resource management) | Go | Planned |
+| `agynio/runners` | Runners service — runner registration and workload state | Go | Planned |
 | `agynio/agyn-cli` | Platform CLI — Gateway API access | Go | Planned |
 | `agynio/agynd-cli` | Agent wrapper daemon — bridges agent CLIs with platform | Go | Planned |
 | `agynio/codex-sdk-go` | Go client library for Codex CLI | Go | Active |

--- a/open-questions.md
+++ b/open-questions.md
@@ -78,38 +78,37 @@ Unresolved architectural decisions requiring discussion.
 
 ---
 
-## Org-Scoped Apps and Runners
+## Org-Scoped Apps
 
-**Context:** The current design covers cluster-scoped apps and runners deployed as platform infrastructure. Future needs include org-scoped resources managed by organization administrators.
+**Context:** The current design covers cluster-scoped apps deployed as platform infrastructure. Future needs include org-scoped apps managed by organization administrators. (Runner org-scoping is handled by the [Runners](architecture/runners.md) service.)
 
 **Questions:**
-- How does an org admin register an org-scoped app or runner? (Via `agyn` CLI with org context? Via Terraform?)
-- How are org-scoped and cluster-scoped resources with the same slug resolved? (Org-scoped takes precedence? Cluster slugs are reserved?)
-- How does the enrollment flow differ for org-scoped resources? (Same service token flow, scoped to the org?)
+- How does an org admin register an org-scoped app? (Via `agyn` CLI with org context? Via Terraform?)
+- How are org-scoped and cluster-scoped apps with the same slug resolved? (Org-scoped takes precedence? Cluster slugs are reserved?)
+- How does the enrollment flow differ for org-scoped apps? (Same service token flow, scoped to the org?)
 - Are org-scoped apps visible only within their organization, or can they be shared?
 
 ---
 
 ## Runner Selection Strategy
 
-**Context:** With multiple runners (cluster-scoped and potentially org-scoped), the [Agents Orchestrator](architecture/agents-orchestrator.md) needs to choose which runner handles a given agent workload.
+**Context:** With multiple runners (cluster-scoped and org-scoped) registered in the [Runners](architecture/runners.md) service, the [Agents Orchestrator](architecture/agents-orchestrator.md) needs to choose which runner handles a given agent workload.
 
 **Questions:**
 - What criteria determine runner selection? (Organization affinity? Agent resource definition? Labels/tags? Capacity?)
 - Can an agent resource definition specify a runner preference or requirement?
-- How does the orchestrator discover available runners and their capabilities?
 - What is the fallback behavior if a preferred runner is unavailable?
 
 ---
 
-## Unified Runner Registration
+## Per-Runner OpenZiti Addressing
 
-**Context:** Internal (cluster-scoped) runners are currently deployed via IaC with self-enrollment through Ziti Management. External runners use a service token enrollment flow. [Apps](architecture/apps.md) and runners should follow a unified registration model.
+**Context:** The [Runners](architecture/runners.md) service tracks which runner hosts each workload. The [Terminal Proxy](architecture/terminal-proxy.md) and [Agents Orchestrator](architecture/agents-orchestrator.md) need to reach a specific runner instance. Currently, all runners bind the same `runner` OpenZiti service — `Dial("runner")` load-balances across instances with no mechanism to target a specific one.
 
 **Questions:**
-- Should cluster-scoped runners be registered resources in the platform (like apps), rather than self-enrolling infrastructure?
-- If unified, does Terraform create the runner resource via the Runners service API, receive an enrollment token, and pass it to the deployment?
-- What changes to the current internal runner self-enrollment flow are needed?
+- How does a caller dial a specific runner? Options: (a) per-runner OpenZiti services (e.g., `runner-{runnerId}`) created dynamically at registration, (b) OpenZiti `appdata` or terminator-level identity matching, (c) a different addressing mechanism.
+- If per-runner services, who creates them? The [Runners](architecture/runners.md) service during registration via [Ziti Management](architecture/openziti.md)?
+- How do static Dial policies work with dynamic per-runner services?
 
 ---
 


### PR DESCRIPTION
## Summary

Introduces the **Runners** service — a new service that manages runner registrations and workload runtime state.

### Problem

Three architectural gaps existed:
1. **No runner registration service** — runners self-enrolled without a management layer. No way to register org-scoped runners (analogous to how Apps Service manages apps).
2. **No workload discovery** — the UI needs to list containers for a conversation; no service exposed this.
3. **Orchestrator owned state** — the Agents Orchestrator stored workload↔identity mappings in PostgreSQL, coupling reconciliation with state ownership.

### Solution

The **Runners** service handles both runner management and workload state:

**Runner Management** — `RegisterRunner`, `GetRunner`, `ListRunners`, `DeleteRunner`. Follows the same pattern as [Apps Service](architecture/apps-service.md): identity registration, service token generation, enrollment flow. Supports both cluster-scoped and org-scoped runners.

**Workload State** — `CreateWorkload`, `UpdateWorkloadStatus`, `DeleteWorkload`, `GetWorkload`, `ListWorkloadsByThread`. The orchestrator writes workload lifecycle events; the UI and Terminal Proxy read them.

The **Agents Orchestrator becomes stateless** — it reads/writes workload state through the Runners service instead of maintaining its own PostgreSQL database.

### Changes

| File | Change |
|------|--------|
| `architecture/runners.md` | **New** — full service spec |
| `architecture/agents-orchestrator.md` | Stateless, Runners dependency, updated diagrams |
| `architecture/gateway.md` | Add `RunnersGateway` |
| `architecture/identity.md` | Runner identity registered by Runners service |
| `architecture/openziti.md` | External runner registration via Runners service |
| `architecture/system-overview.md` | Add to diagram, component table, repo map |
| `README.md` | Add to docs table |
| `open-questions.md` | Resolve "Unified Runner Registration" → "Per-Runner OpenZiti Addressing", narrow "Org-Scoped Apps and Runners" → "Org-Scoped Apps", update "Runner Selection Strategy" |

### Open Questions Resolved

- **Unified Runner Registration** — resolved. Runners service handles both cluster-scoped (Terraform) and org-scoped (admin) registration.
- **Workload Discovery** — resolved. `ListWorkloadsByThread` exposed through Gateway.

### Open Questions Remaining

- **Per-Runner OpenZiti Addressing** — how does Terminal Proxy / Orchestrator dial a *specific* runner when multiple runners bind the same `runner` service?
- **Runner Selection Strategy** — criteria for choosing which runner handles a workload.

### Depends On

- PR #76 (terminal-proxy.md) — Terminal Proxy references in `runners.md` link to `terminal-proxy.md` which is in that PR. Terminal Proxy updates to reference the Runners service will be added to PR #76 after this merges.