### PR TITLE
docs(operations): add e2e CI job

### DIFF
--- a/architecture/operations/ci-cd.md
+++ b/architecture/operations/ci-cd.md
@@ -74,6 +74,45 @@ ENTRYPOINT ["/app/service"]
 
 **Steps:** Lint, test, build — service-specific.
 
+### E2E Job
+
+Services with in-cluster E2E suites add a dedicated `e2e` job to `ci.yml`. The job provisions a k3d-backed bootstrap cluster, installs tooling, and runs DevSpace tests against the cluster.
+
+**Job definition:**
+
+- `runs-on: ubuntu-latest`
+- `timeout-minutes: 60`
+- `permissions`: `contents: read`, `packages: write`
+
+**Disk space reclamation:** remove preinstalled toolchains to make room for the k3d cluster (Java/JDKs, .NET SDKs, Swift toolchain, Haskell/GHC, Julia, Android SDKs).
+
+**PR image build + push:**
+
+1. Set `PR_IMAGE=ghcr.io/agynio/<service>:pr-${{ github.event.pull_request.number || github.run_id }}-${{ github.sha }}` in the job environment.
+2. Build and push the image with Docker Buildx after logging into GHCR.
+
+**Bootstrap checkout:** checkout `agynio/bootstrap` at `main` into `bootstrap/`.
+
+**Tool installation:**
+
+- kubectl v1.28.7
+- k3d v5.7.5
+- Terraform 1.6.6
+- DevSpace v6.3.20
+
+**Cluster provisioning:** run `bootstrap/apply.sh -y`. The script applies Terraform stacks in order (`k8s`, `system`, `routing`, `deps`, `ziti`, `data`, `platform`, `apps`) with a CA install step between `system` and `routing`. The kubeconfig is written to `bootstrap/stacks/k8s/.kube/agyn-local-kubeconfig.yaml`.
+
+**Platform health verification:** run `bootstrap/.github/scripts/verify_platform_health.sh` to poll ArgoCD applications, check pod and job health, and verify Ziti overlay readiness.
+
+**E2E execution:** run `devspace run-pipeline test-e2e` with `KUBECONFIG` pointing at the bootstrap kubeconfig and `PR_IMAGE` set to the PR tag. Additional test-suite variables (for example, Argos metadata for Playwright) are passed as needed.
+
+**Service patching modes:**
+
+- **Source-sync (Go services):** CI runs `devspace dev` first to patch the service deployment with a dev container and synced source. `devspace run-pipeline test-e2e` runs afterward against the patched pod.
+- **Image-swap (frontends/built artifacts):** CI builds and pushes the PR image. The `test-e2e` pipeline swaps the deployment image via `kubectl set image` using `PR_IMAGE` before running tests.
+
+**Artifacts:** upload Playwright reports and traces with `actions/upload-artifact` when applicable (for example, always upload `playwright-report/`, upload `test-results/` on failures).
+
 ## Base Helm Chart
 
 All service Helm charts inherit from the shared library chart:

--- a/architecture/operations/ci-cd.md
+++ b/architecture/operations/ci-cd.md
@@ -78,13 +78,13 @@ ENTRYPOINT ["/app/service"]
 
 Services with in-cluster E2E suites add a dedicated e2e job to `ci.yml`. The job provisions a k3d-backed bootstrap cluster, installs tooling, and runs DevSpace tests against the cluster. The job follows this algorithm:
 
-1. Run on ubuntu-latest with a 60-minute timeout and permissions limited to repository contents read and packages write.
+1. Run on ubuntu-latest with permissions limited to repository contents read and packages write.
 2. Reclaim disk space by removing preinstalled toolchains (Java/JDKs, .NET SDKs, Swift toolchain, Haskell/GHC, Julia, Android SDKs).
 3. Checkout the service repository and the bootstrap repository, with bootstrap placed in a subdirectory.
 4. Install tooling at fixed versions: kubectl v1.28.7, k3d v5.7.5, Terraform 1.6.6, DevSpace v6.3.20.
 5. Provision the cluster by running the bootstrap apply script in auto-approve mode. The script applies Terraform stacks in order (k8s, system, routing, deps, ziti, data, platform, apps), installs the CA between system and routing, and writes kubeconfig to bootstrap/stacks/k8s/.kube/agyn-local-kubeconfig.yaml.
 6. Verify platform health with the bootstrap verification script, which polls ArgoCD applications, checks pod and job health, and validates Ziti overlay readiness.
-7. For pull requests, invoke the DevSpace dev workflow to patch the service deployment with source and sync. For main/release runs, skip this step so tests run against pinned release images.
+7. Invoke the DevSpace dev workflow to patch the service deployment with source and sync.
 8. Run the DevSpace test-e2e pipeline against the cluster using the bootstrap kubeconfig so tests execute inside the cluster against the currently deployed services.
 9. Upload test artifacts when produced by the suite (Playwright report on every run, Playwright traces on failures).
 

--- a/architecture/operations/ci-cd.md
+++ b/architecture/operations/ci-cd.md
@@ -76,42 +76,17 @@ ENTRYPOINT ["/app/service"]
 
 ### E2E Job
 
-Services with in-cluster E2E suites add a dedicated `e2e` job to `ci.yml`. The job provisions a k3d-backed bootstrap cluster, installs tooling, and runs DevSpace tests against the cluster.
+Services with in-cluster E2E suites add a dedicated e2e job to `ci.yml`. The job provisions a k3d-backed bootstrap cluster, installs tooling, and runs DevSpace tests against the cluster. The job follows this algorithm:
 
-**Job definition:**
-
-- `runs-on: ubuntu-latest`
-- `timeout-minutes: 60`
-- `permissions`: `contents: read`, `packages: write`
-
-**Disk space reclamation:** remove preinstalled toolchains to make room for the k3d cluster (Java/JDKs, .NET SDKs, Swift toolchain, Haskell/GHC, Julia, Android SDKs).
-
-**PR image build + push:**
-
-1. Set `PR_IMAGE=ghcr.io/agynio/<service>:pr-${{ github.event.pull_request.number || github.run_id }}-${{ github.sha }}` in the job environment.
-2. Build and push the image with Docker Buildx after logging into GHCR.
-
-**Bootstrap checkout:** checkout `agynio/bootstrap` at `main` into `bootstrap/`.
-
-**Tool installation:**
-
-- kubectl v1.28.7
-- k3d v5.7.5
-- Terraform 1.6.6
-- DevSpace v6.3.20
-
-**Cluster provisioning:** run `bootstrap/apply.sh -y`. The script applies Terraform stacks in order (`k8s`, `system`, `routing`, `deps`, `ziti`, `data`, `platform`, `apps`) with a CA install step between `system` and `routing`. The kubeconfig is written to `bootstrap/stacks/k8s/.kube/agyn-local-kubeconfig.yaml`.
-
-**Platform health verification:** run `bootstrap/.github/scripts/verify_platform_health.sh` to poll ArgoCD applications, check pod and job health, and verify Ziti overlay readiness.
-
-**E2E execution:** run `devspace run-pipeline test-e2e` with `KUBECONFIG` pointing at the bootstrap kubeconfig and `PR_IMAGE` set to the PR tag. Additional test-suite variables (for example, Argos metadata for Playwright) are passed as needed.
-
-**Service patching modes:**
-
-- **Source-sync (Go services):** CI runs `devspace dev` first to patch the service deployment with a dev container and synced source. `devspace run-pipeline test-e2e` runs afterward against the patched pod.
-- **Image-swap (frontends/built artifacts):** CI builds and pushes the PR image. The `test-e2e` pipeline swaps the deployment image via `kubectl set image` using `PR_IMAGE` before running tests.
-
-**Artifacts:** upload Playwright reports and traces with `actions/upload-artifact` when applicable (for example, always upload `playwright-report/`, upload `test-results/` on failures).
+1. Run on ubuntu-latest with a 60-minute timeout and permissions limited to repository contents read and packages write.
+2. Reclaim disk space by removing preinstalled toolchains (Java/JDKs, .NET SDKs, Swift toolchain, Haskell/GHC, Julia, Android SDKs).
+3. Checkout the service repository and the bootstrap repository, with bootstrap placed in a subdirectory.
+4. Install tooling at fixed versions: kubectl v1.28.7, k3d v5.7.5, Terraform 1.6.6, DevSpace v6.3.20.
+5. Provision the cluster by running the bootstrap apply script in auto-approve mode. The script applies Terraform stacks in order (k8s, system, routing, deps, ziti, data, platform, apps), installs the CA between system and routing, and writes kubeconfig to bootstrap/stacks/k8s/.kube/agyn-local-kubeconfig.yaml.
+6. Verify platform health with the bootstrap verification script, which polls ArgoCD applications, checks pod and job health, and validates Ziti overlay readiness.
+7. For pull requests, invoke the DevSpace dev workflow to patch the service deployment with source and sync. For main/release runs, skip this step so tests run against pinned release images.
+8. Run the DevSpace test-e2e pipeline against the cluster using the bootstrap kubeconfig so tests execute inside the cluster against the currently deployed services.
+9. Upload test artifacts when produced by the suite (Playwright report on every run, Playwright traces on failures).
 
 ## Base Helm Chart
 

--- a/architecture/operations/e2e-testing.md
+++ b/architecture/operations/e2e-testing.md
@@ -682,7 +682,7 @@ All three layers run on every PR. E2E tests also run on push to `main`. Exceptio
 
 ## CI Integration
 
-CI uses the same DevSpace commands as developers. The two workflows differ only in whether `devspace dev` is called first.
+CI uses the same DevSpace commands as developers. The two workflows differ only in whether `devspace dev` is called first. See [CI/CD](ci-cd.md#e2e-job) for the GitHub Actions job that provisions the bootstrap cluster and installs tooling.
 
 ### Pull request workflow
 

--- a/architecture/operations/e2e-testing.md
+++ b/architecture/operations/e2e-testing.md
@@ -684,33 +684,21 @@ All three layers run on every PR. E2E tests also run on push to `main`. Exceptio
 
 CI uses the same DevSpace commands as developers and always invokes `devspace dev` before `devspace run test-e2e`. See [CI/CD](ci-cd.md#e2e-job) for the GitHub Actions job that provisions the bootstrap cluster and installs tooling.
 
-### Pull request workflow
+### CI workflow
 
-A PR needs to test the branch's code. CI calls two commands sequentially:
+CI always runs the same two-step sequence to test the service under development while bootstrap pins the rest of the platform images:
 
 ```bash
-# Step 1: Deploy the service from PR source code
+# Step 1: Deploy the service from source code
 devspace dev
 
 # Step 2: Run E2E tests against the now-modified cluster
 devspace run test-e2e
 ```
 
-`devspace dev` (default mode) patches the service pod, syncs source, waits for the health check, then exits. The patched pod keeps running. `devspace run test-e2e` then deploys the test pod and runs tests against the cluster — which now has the PR's code running in the service pod.
+`devspace dev` (default mode) patches the service pod, syncs source, waits for the health check, then exits. The patched pod keeps running. `devspace run test-e2e` then deploys the test pod and runs tests against the cluster — which now has the service's source code running in the service pod.
 
 These are **separate CI steps**, not a single combined command. The `test-e2e` pipeline must not contain any service deployment logic.
-
-### Push to `main` / release workflow
-
-Pushes to `main` and releases use the same two-step sequence:
-
-```bash
-# Step 1: Deploy the service from source
-devspace dev
-
-# Step 2: Run E2E tests against the now-modified cluster
-devspace run test-e2e
-```
 
 The bootstrap repository pins the rest of the platform images; CI overlays the service under test via `devspace dev` and then runs the test pod against the updated cluster.
 

--- a/architecture/operations/e2e-testing.md
+++ b/architecture/operations/e2e-testing.md
@@ -682,7 +682,7 @@ All three layers run on every PR. E2E tests also run on push to `main`. Exceptio
 
 ## CI Integration
 
-CI uses the same DevSpace commands as developers. The two workflows differ only in whether `devspace dev` is called first. See [CI/CD](ci-cd.md#e2e-job) for the GitHub Actions job that provisions the bootstrap cluster and installs tooling.
+CI uses the same DevSpace commands as developers and always invokes `devspace dev` before `devspace run test-e2e`. See [CI/CD](ci-cd.md#e2e-job) for the GitHub Actions job that provisions the bootstrap cluster and installs tooling.
 
 ### Pull request workflow
 
@@ -702,18 +702,21 @@ These are **separate CI steps**, not a single combined command. The `test-e2e` p
 
 ### Push to `main` / release workflow
 
-On `main`, there is no source to deploy — the goal is to verify the pinned release images:
+Pushes to `main` and releases use the same two-step sequence:
 
 ```bash
-# Only run tests — services already run their released versions
+# Step 1: Deploy the service from source
+devspace dev
+
+# Step 2: Run E2E tests against the now-modified cluster
 devspace run test-e2e
 ```
 
-No `devspace dev` is called. The cluster is unmodified. Tests verify the real deployed behavior.
+The bootstrap repository pins the rest of the platform images; CI overlays the service under test via `devspace dev` and then runs the test pod against the updated cluster.
 
 ### Why two steps, not one
 
-If `test-e2e` also deployed from source, it would be impossible to run the `main` workflow — every test run would forcibly replace the released image with source code. The separation ensures `test-e2e` is a pure test runner that works against whatever is currently deployed.
+If `test-e2e` also deployed from source, it would duplicate the `devspace dev` deployment logic and blur the boundary between deployment and test execution. Keeping them separate ensures `devspace dev` owns patching and source sync while `test-e2e` remains a pure test runner that executes against whatever is already deployed.
 
 ## Summary
 
@@ -721,7 +724,7 @@ If `test-e2e` also deployed from source, it would be impossible to run the `main
 |--------|----------|
 | Where tests live | In each service repo under `test/e2e/` |
 | Where tests run | Dedicated test pod inside the cluster (not the service pod) |
-| Service pods affected? | No — run pinned release images, untouched |
+| Service pods affected? | No — test-e2e does not patch service pods; it runs against whatever is already deployed |
 | How test pod is created | DevSpace `deployments` with `component-chart` |
 | How source reaches test pod | DevSpace sync (`dev` section) |
 | How tests are triggered | `devspace run test-e2e` |

--- a/architecture/operations/new-service.md
+++ b/architecture/operations/new-service.md
@@ -238,7 +238,7 @@ Add E2E sections to `devspace.yaml`: a `deployments.e2e-runner` (component-chart
 
 ### E2E Tests in CI
 
-CI provisions the environment using bootstrap and runs E2E tests inside the cluster. No custom docker-compose or Kind-based setups — bootstrap is the single source of truth for the test environment.
+CI provisions the environment using bootstrap and runs E2E tests inside the cluster. No custom docker-compose or Kind-based setups — bootstrap is the single source of truth for the test environment. The GitHub Actions job structure is defined in [CI/CD](ci-cd.md#e2e-job).
 
 The CI workflow has two modes:
 

--- a/architecture/operations/new-service.md
+++ b/architecture/operations/new-service.md
@@ -224,7 +224,7 @@ Register the service in `agynio/bootstrap` so it is deployed in the local cluste
 
 ## E2E Tests
 
-Each service includes end-to-end tests that verify behavior against a running environment provisioned by bootstrap. Tests run **inside the cluster** in a dedicated test pod via DevSpace — the service pods run their pinned release images untouched. See [E2E Testing](e2e-testing.md) for the full methodology.
+Each service includes end-to-end tests that verify behavior against a running environment provisioned by bootstrap. Tests run **inside the cluster** in a dedicated test pod via DevSpace — the service pods run whatever is deployed in the cluster, and the test pod is managed separately. See [E2E Testing](e2e-testing.md) for the full methodology.
 
 ### Structure
 
@@ -240,19 +240,11 @@ Add E2E sections to `devspace.yaml`: a `deployments.e2e-runner` (component-chart
 
 CI provisions the environment using bootstrap and runs E2E tests inside the cluster. No custom docker-compose or Kind-based setups — bootstrap is the single source of truth for the test environment. The GitHub Actions job structure is defined in [CI/CD](ci-cd.md#e2e-job).
 
-The CI workflow has two modes:
-
-**Pull requests** — deploy from source, then test:
+CI uses the same two-step sequence for pull requests and `main`:
 
 ```bash
-devspace dev           # patch service pod with PR source code
+devspace dev           # patch service pod with source code
 devspace run test-e2e  # run tests against the modified cluster
 ```
 
-**Push to `main`** — test pinned release images directly:
-
-```bash
-devspace run test-e2e  # services are already running released versions
-```
-
-These are separate sequential steps. The `test-e2e` command never deploys or modifies the service pod — it only manages the test pod. See [E2E Testing](e2e-testing.md) for the full rationale.
+Bootstrap pins the rest of the platform images; CI overlays the service under test via `devspace dev` before running the test pod. These are separate sequential steps. The `test-e2e` command never deploys or modifies the service pod — it only manages the test pod. See [E2E Testing](e2e-testing.md) for the full rationale.


### PR DESCRIPTION
## Summary
- document the GitHub Actions E2E job pattern in CI/CD docs
- add cross-references from E2E testing and new service docs

## Testing
- Not run (no tests/lint configured)

Refs #121