### PR TITLE
Docs: exposed ports over OpenZiti

### DIFF
--- a/architecture/README.md
+++ b/architecture/README.md
@@ -72,6 +72,7 @@ Desired architecture state of the platform.
 - [MCP](mcp.md)
 - [files-mcp](files-mcp.md)
 - [OpenZiti](openziti.md)
+- [Expose](expose.md)
 
 ### Observability
 

--- a/architecture/agent/overview.md
+++ b/architecture/agent/overview.md
@@ -43,7 +43,7 @@ graph TB
 | **Use tools via MCP** | Connect to MCP servers for tool access |
 | **Report tracing** | Optionally emit tracing data |
 
-The agent is a **pure client** — it connects to the [Gateway](../gateway.md) and the [LLM Proxy](../llm-proxy.md) using OpenZiti service hostnames transparently intercepted by the pod's [Ziti sidecar](../openziti.md#agent-access-scope) and accesses all platform services through them. It does not expose any server or accept inbound connections.
+The agent is a **pure client** for platform APIs — it connects to the [Gateway](../gateway.md) and the [LLM Proxy](../llm-proxy.md) using OpenZiti service hostnames transparently intercepted by the pod's [Ziti sidecar](../openziti.md#agent-access-scope) and accesses all platform services through them. Agent workloads may also run user-facing servers (e.g., dev servers) and expose specific ports through the [Expose](../expose.md) service; this is explicit and not part of the core message delivery contract.
 
 ## Communication Protocol
 
@@ -90,7 +90,7 @@ sequenceDiagram
 ### Design Principles
 
 - **Pull at defined loop stages.** The `whenBusy` configuration controls when mid-run messages are picked up: between turns (`wait`) or between tool calls (`injectAfterTools`). The notification wakes the agent, but the actual message read happens at the next check point in the LLM loop.
-- **No inbound connections.** The agent connects outbound to the [Gateway](../gateway.md) only (via the `gateway.ziti` OpenZiti hostname, transparently intercepted by the pod's Ziti sidecar). The Gateway routes requests to internal services (Threads, Notifications, Files, etc.). No server, no open port, no service discovery per agent.
+- **No inbound connections for message delivery.** The agent connects outbound to the [Gateway](../gateway.md) (via the `gateway.ziti` OpenZiti hostname, transparently intercepted by the pod's Ziti sidecar). The Gateway routes requests to internal services (Threads, Notifications, Files, etc.). User-facing ports are exposed only when explicitly requested via [Expose](../expose.md).
 
 ## Tools
 

--- a/architecture/expose.md
+++ b/architecture/expose.md
@@ -17,9 +17,9 @@ Expose provisions **OpenZiti services, configs, and policies** dynamically (via 
 
 ## Responsibilities
 
-- **Port shares** — create and revoke port exposures ("shares") for agent workloads.
-- **Garbage collection** — reconcile failed provisioning and clean up orphaned shares.
-- **Idempotency** — ensure share provisioning and cleanup are safe to retry.
+- **Exposed ports** — create and revoke exposed ports for agent workloads.
+- **Garbage collection** — reconcile failed provisioning and clean up orphaned exposed ports.
+- **Idempotency** — ensure exposed-port provisioning and cleanup are safe to retry.
 
 Non-goals:
 - Not a general internet ingress.
@@ -53,7 +53,7 @@ Creates an exposed port bound to the calling agent.
 
 | Field | Type | Description |
 |------|------|-------------|
-| `share_id` | string | 8-character share identifier |
+| `port_id` | string | 8-character port ID |
 | `url` | string | URL to open (e.g., `"http://exposed-ab12cd34.ziti:5173"`) |
 | `status` | enum | `active` |
 
@@ -67,7 +67,7 @@ Revokes an exposed port.
 
 | Field | Type | Description |
 |------|------|-------------|
-| `share_id` | string | Share identifier |
+| `port_id` | string | Port identifier |
 
 **Response**
 
@@ -97,28 +97,28 @@ Each `results[]` entry:
 
 | Field | Type | Description |
 |------|------|-------------|
-| `share_id` | string | Share identifier |
+| `port_id` | string | Port identifier |
 | `status` | enum | `deleted`, `failed` |
 | `error` | string | Present when `status=failed` |
 
 **Behavior**
 
-1. Lookup all shares for `agent_id` in `status in {provisioning, active, failed}`.
+1. Lookup all exposed ports for `agent_id` in `status in {provisioning, active, failed}`.
 2. For each, run the same deletion sequence as `DeletePort`.
-3. Return per-share results; any failures are retried by GC.
+3. Return per-port results; any failures are retried by GC.
 
-## PortShare Resource
+## ExposedPort Resource
 
-Expose stores each share as a first-class resource.
+Expose stores each exposed port as a first-class resource.
 
 | Field | Type | Description |
 |------|------|-------------|
-| `share_id` | string | 8-character share identifier |
+| `port_id` | string | 8-character port ID |
 | `organization_id` | string (UUID) | Owning organization (derived from agent) |
 | `agent_id` | string (UUID) | Agent resource UUID |
-| `thread_id` | string (UUID) | Thread where the share was created |
+| `thread_id` | string (UUID) | Thread where the port was exposed |
 | `port` | int32 | Local TCP port inside the agent pod |
-| `hostname` | string | `exposed-<share_id>.ziti` |
+| `hostname` | string | `exposed-<port_id>.ziti` |
 | `description` | string | Optional display text |
 | `status` | enum | `provisioning`, `active`, `deleting`, `failed` |
 | `last_error` | string | Error message when `status=failed` |
@@ -131,30 +131,30 @@ Expose provisions OpenZiti resources through [Ziti Management](openziti.md#ziti-
 
 ### Naming
 
-All created resources use deterministic names derived from `share_id`:
+All created resources use deterministic names derived from `port_id`:
 
 | Resource | Name |
 |----------|------|
-| Service | `exposed-<share_id>` |
-| Intercept hostname | `exposed-<share_id>.ziti` |
-| Intercept config | `exposed-<share_id>-intercept-v1` |
-| Host config | `exposed-<share_id>-host-v1` |
-| Bind policy | `exposed-<share_id>-bind` |
-| Dial policy | `exposed-<share_id>-dial` |
+| Service | `exposed-<port_id>` |
+| Intercept hostname | `exposed-<port_id>.ziti` |
+| Intercept config | `exposed-<port_id>-intercept-v1` |
+| Host config | `exposed-<port_id>-host-v1` |
+| Bind policy | `exposed-<port_id>-bind` |
+| Dial policy | `exposed-<port_id>-dial` |
 
 This makes provisioning and cleanup **idempotent**.
 
-### Resources Created per Share
+### Resources Created per Exposed Port
 
-For each share, Expose ensures:
+For each exposed port, Expose ensures:
 
-1. **OpenZiti service** named `exposed-<share_id>` with role attribute `exposed-services`.
-2. **Intercept config** (`intercept.v1`) matching hostname `exposed-<share_id>.ziti` and TCP port `port`.
+1. **OpenZiti service** named `exposed-<port_id>` with role attribute `exposed-services`.
+2. **Intercept config** (`intercept.v1`) matching hostname `exposed-<port_id>.ziti` and TCP port `port`.
 3. **Host config** (`host.v1`) forwarding to `127.0.0.1:port` inside the agent pod network namespace.
 4. **Bind service policy** granting only the agent's role attribute `agent-<agent_id>` permission to bind the service.
 5. **Dial service policy** granting selected user devices permission to dial the service (see [OpenZiti: Exposed Ports Access Scope](../open-questions.md#openziti-exposed-ports-access-scope)).
 
-### Port Share Flow
+### Exposed Port Flow
 
 ```mermaid
 sequenceDiagram
@@ -185,15 +185,15 @@ sequenceDiagram
 
 ## Removal, Cleanup, and GC
 
-### When port-share services are removed
+### When exposed ports are removed
 
-A port share (and its OpenZiti service/config/policy objects) should be removed when any of the following occurs:
+An exposed port (and its OpenZiti service/config/policy objects) should be removed when any of the following occurs:
 
-1. **Explicit revoke** — user (Console) or agent calls `DeletePort(share_id)`.
-2. **Workload stop** — when an agent workload is terminated, the control plane should revoke any remaining shares for that agent.
-   - Preferred: the **Agents Orchestrator** calls Expose to revoke shares as part of workload stop.
-   - Backstop: Expose GC detects shares whose agent workload no longer exists and deletes them.
-3. **Failed provisioning** — shares stuck in `failed` or `provisioning` beyond a timeout are deleted by GC.
+1. **Explicit revoke** — user (Console) or agent calls `DeletePort(port_id)`.
+2. **Workload stop** — when an agent workload is terminated, the control plane should revoke any remaining exposed ports for that agent.
+   - Preferred: the **Agents Orchestrator** calls Expose to revoke exposed ports as part of workload stop.
+   - Backstop: Expose GC detects exposed ports whose agent workload no longer exists and deletes them.
+3. **Failed provisioning** — ports stuck in `failed` or `provisioning` beyond a timeout are deleted by GC.
 
 Time-based expiry (TTL) is intentionally not specified yet; add it as a follow-up if we want automatic expiration even for long-running workloads.
 
@@ -201,12 +201,12 @@ Time-based expiry (TTL) is intentionally not specified yet; add it as a follow-u
 
 Expose deletes OpenZiti resources using deterministic names. Deletion treats "not found" as success.
 
-Recommended delete sequence for a share `exposed-<share_id>`:
+Recommended delete sequence for an exposed port `exposed-<port_id>`:
 
-1. Delete dial policy `exposed-<share_id>-dial`.
-2. Delete bind policy `exposed-<share_id>-bind`.
-3. Delete service `exposed-<share_id>`.
-4. Delete configs `exposed-<share_id>-intercept-v1` and `exposed-<share_id>-host-v1`.
+1. Delete dial policy `exposed-<port_id>-dial`.
+2. Delete bind policy `exposed-<port_id>-bind`.
+3. Delete service `exposed-<port_id>`.
+4. Delete configs `exposed-<port_id>-intercept-v1` and `exposed-<port_id>-host-v1`.
 
 OpenZiti revocation closes active connections; deleting the service/policies makes the URL stop working.
 
@@ -214,14 +214,14 @@ OpenZiti revocation closes active connections; deleting the service/policies mak
 
 - On delete request, set `status=deleting`.
 - Attempt OpenZiti deletions.
-- On success, delete the `PortShare` record (or mark it deleted/tombstoned; retention is implementation-defined).
+- On success, delete the `ExposedPort` record (or mark it deleted/tombstoned; retention is implementation-defined).
 - On error, keep the record, set `last_error`, and rely on GC to retry.
 
 ### Garbage collection loop
 
 Expose runs a background reconciler that:
 
-- retries deletion for shares stuck in `failed` or `deleting`.
-- deletes shares whose backing workload is no longer running (based on a control-plane workload lookup; implementation-defined).
+- retries deletion for ports stuck in `failed` or `deleting`.
+- deletes exposed ports whose backing workload is no longer running (based on a control-plane workload lookup; implementation-defined).
 
 All deletions are idempotent and may be retried safely.

--- a/architecture/expose.md
+++ b/architecture/expose.md
@@ -1,0 +1,227 @@
+# Expose Service
+
+## Overview
+
+The Expose service provides **temporary access** to TCP ports inside running agent workloads from external user machines.
+
+It is used for workflows like:
+
+- An agent starts a development server inside its container (e.g., Vite on `5173`).
+- The agent requests that port be exposed.
+- The platform returns a URL like `http://exposed-<id>.ziti:5173`.
+- A user with **Ziti Desktop Edge / ziti tunnel** enrolled can open the URL and reach the dev server.
+
+Expose provisions **OpenZiti services, configs, and policies** dynamically (via [Ziti Management](openziti.md#ziti-management-service)).
+
+**User device enrollment** (minting the enrollment token used by Ziti Desktop Edge) is owned by the [Users](users.md#ziti-user-device-enrollment) service.
+
+## Responsibilities
+
+- **Port shares** — create and revoke port exposures ("shares") for agent workloads.
+- **Garbage collection** — reconcile failed provisioning and clean up orphaned shares.
+- **Idempotency** — ensure share provisioning and cleanup are safe to retry.
+
+Non-goals:
+- Not a general internet ingress.
+- Not an HTTP reverse proxy.
+- Access scope policy is TBD (see [Open Questions](../open-questions.md#openziti-exposed-ports-access-scope)).
+
+## API
+
+Expose is an internal gRPC service. Selected methods are exposed externally through the [Gateway](gateway.md).
+
+| Method | Caller | Description |
+|--------|--------|-------------|
+| **AddPort** | Agent | Expose a local TCP port from the agent workload and return a URL (`http://exposed-<id>.ziti:<port>`) |
+| **DeletePort** | Agent, User, GC loop | Revoke an exposed port and delete its OpenZiti resources |
+| **DeletePortsForAgent** | Agents Orchestrator, GC loop | Revoke all ports for a given agent (workload stop cleanup) |
+| **GetPort** | User (Console), internal | Fetch port status and URL |
+
+### AddPort
+
+Creates an exposed port bound to the calling agent.
+
+**Request**
+
+| Field | Type | Description |
+|------|------|-------------|
+| `thread_id` | string (UUID) | Thread the agent is working in |
+| `port` | int32 | Local TCP port inside the agent pod (e.g., `5173`) |
+| `description` | string | Optional display text (e.g., `"Vite dev server"`) |
+
+**Response**
+
+| Field | Type | Description |
+|------|------|-------------|
+| `share_id` | string | 8-character share identifier |
+| `url` | string | URL to open (e.g., `"http://exposed-ab12cd34.ziti:5173"`) |
+| `status` | enum | `active` |
+
+Expose resolves the calling agent identity to `agent_id` and `organization_id` via `Agents.ResolveAgentIdentity`.
+
+### DeletePort
+
+Revokes an exposed port.
+
+**Request**
+
+| Field | Type | Description |
+|------|------|-------------|
+| `share_id` | string | Share identifier |
+
+**Response**
+
+Empty.
+
+Deletion is idempotent: deleting an already-deleted port returns success.
+
+### DeletePortsForAgent
+
+Revokes all exposed ports owned by a given agent.
+
+This is primarily used as part of workload stop cleanup: when the Agents Orchestrator stops an agent workload, it calls `DeletePortsForAgent(agent_id)` so the ports are removed promptly (GC remains the backstop).
+
+**Request**
+
+| Field | Type | Description |
+|------|------|-------------|
+| `agent_id` | string (UUID) | Agent resource UUID |
+
+**Response**
+
+| Field | Type | Description |
+|------|------|-------------|
+| `results` | object[] | Per-port deletion result |
+
+Each `results[]` entry:
+
+| Field | Type | Description |
+|------|------|-------------|
+| `share_id` | string | Share identifier |
+| `status` | enum | `deleted`, `failed` |
+| `error` | string | Present when `status=failed` |
+
+**Behavior**
+
+1. Lookup all shares for `agent_id` in `status in {provisioning, active, failed}`.
+2. For each, run the same deletion sequence as `DeletePort`.
+3. Return per-share results; any failures are retried by GC.
+
+## PortShare Resource
+
+Expose stores each share as a first-class resource.
+
+| Field | Type | Description |
+|------|------|-------------|
+| `share_id` | string | 8-character share identifier |
+| `organization_id` | string (UUID) | Owning organization (derived from agent) |
+| `agent_id` | string (UUID) | Agent resource UUID |
+| `thread_id` | string (UUID) | Thread where the share was created |
+| `port` | int32 | Local TCP port inside the agent pod |
+| `hostname` | string | `exposed-<share_id>.ziti` |
+| `description` | string | Optional display text |
+| `status` | enum | `provisioning`, `active`, `deleting`, `failed` |
+| `last_error` | string | Error message when `status=failed` |
+| `created_at` | timestamp | Creation time |
+| `updated_at` | timestamp | Last update time |
+
+## OpenZiti Provisioning Model
+
+Expose provisions OpenZiti resources through [Ziti Management](openziti.md#ziti-management-service).
+
+### Naming
+
+All created resources use deterministic names derived from `share_id`:
+
+| Resource | Name |
+|----------|------|
+| Service | `exposed-<share_id>` |
+| Intercept hostname | `exposed-<share_id>.ziti` |
+| Intercept config | `exposed-<share_id>-intercept-v1` |
+| Host config | `exposed-<share_id>-host-v1` |
+| Bind policy | `exposed-<share_id>-bind` |
+| Dial policy | `exposed-<share_id>-dial` |
+
+This makes provisioning and cleanup **idempotent**.
+
+### Resources Created per Share
+
+For each share, Expose ensures:
+
+1. **OpenZiti service** named `exposed-<share_id>` with role attribute `exposed-services`.
+2. **Intercept config** (`intercept.v1`) matching hostname `exposed-<share_id>.ziti` and TCP port `port`.
+3. **Host config** (`host.v1`) forwarding to `127.0.0.1:port` inside the agent pod network namespace.
+4. **Bind service policy** granting only the agent's role attribute `agent-<agent_id>` permission to bind the service.
+5. **Dial service policy** granting selected user devices permission to dial the service (see [OpenZiti: Exposed Ports Access Scope](../open-questions.md#openziti-exposed-ports-access-scope)).
+
+### Port Share Flow
+
+```mermaid
+sequenceDiagram
+    participant A as Agent Pod
+    participant GW as Gateway
+    participant EX as Expose
+    participant ZM as Ziti Management
+    participant ZC as OpenZiti Controller
+    participant U as User
+    participant ZDE as Ziti Desktop Edge
+
+    Note over U,ZDE: Prereq: user device enrolled in OpenZiti
+
+    Note over A: Agent starts dev server
+    A->>GW: AddPort(thread_id, port)
+    GW->>EX: AddPort
+    EX->>ZM: Ensure service + configs + policies
+    ZM->>ZC: Create/Update Ziti resources
+    ZC-->>ZM: OK
+    ZM-->>EX: OK
+    EX-->>A: url = http://exposed-<id>.ziti:<port>
+
+    Note over U: User opens link
+    U->>ZDE: Browser connects to exposed-<id>.ziti:<port>
+    ZDE->>A: Dial Ziti service exposed-<id>
+    A->>A: Sidecar forwards to 127.0.0.1:<port>
+```
+
+## Removal, Cleanup, and GC
+
+### When port-share services are removed
+
+A port share (and its OpenZiti service/config/policy objects) should be removed when any of the following occurs:
+
+1. **Explicit revoke** — user (Console) or agent calls `DeletePort(share_id)`.
+2. **Workload stop** — when an agent workload is terminated, the control plane should revoke any remaining shares for that agent.
+   - Preferred: the **Agents Orchestrator** calls Expose to revoke shares as part of workload stop.
+   - Backstop: Expose GC detects shares whose agent workload no longer exists and deletes them.
+3. **Failed provisioning** — shares stuck in `failed` or `provisioning` beyond a timeout are deleted by GC.
+
+Time-based expiry (TTL) is intentionally not specified yet; add it as a follow-up if we want automatic expiration even for long-running workloads.
+
+### How OpenZiti resources are removed (idempotent)
+
+Expose deletes OpenZiti resources using deterministic names. Deletion treats "not found" as success.
+
+Recommended delete sequence for a share `exposed-<share_id>`:
+
+1. Delete dial policy `exposed-<share_id>-dial`.
+2. Delete bind policy `exposed-<share_id>-bind`.
+3. Delete service `exposed-<share_id>`.
+4. Delete configs `exposed-<share_id>-intercept-v1` and `exposed-<share_id>-host-v1`.
+
+OpenZiti revocation closes active connections; deleting the service/policies makes the URL stop working.
+
+### State machine
+
+- On delete request, set `status=deleting`.
+- Attempt OpenZiti deletions.
+- On success, delete the `PortShare` record (or mark it deleted/tombstoned; retention is implementation-defined).
+- On error, keep the record, set `last_error`, and rely on GC to retry.
+
+### Garbage collection loop
+
+Expose runs a background reconciler that:
+
+- retries deletion for shares stuck in `failed` or `deleting`.
+- deletes shares whose backing workload is no longer running (based on a control-plane workload lookup; implementation-defined).
+
+All deletions are idempotent and may be retried safely.

--- a/architecture/openziti.md
+++ b/architecture/openziti.md
@@ -48,7 +48,7 @@ All interactions with the OpenZiti Controller's Edge Management API are encapsul
 | Aspect | Detail |
 |--------|--------|
 | **Plane** | Data — executes operations it is told to perform; runs identity lease GC |
-| **Consumers** | Agents Orchestrator (agent identity lifecycle), Gateway (identity resolution), Orchestrator / Gateway (service identity self-enrollment), Runners Service (runner enrollment), Apps Service (app enrollment), Users Service (user device enrollment), Expose (port shares) |
+| **Consumers** | Agents Orchestrator (agent identity lifecycle), Gateway (identity resolution), Orchestrator / Gateway (service identity self-enrollment), Runners Service (runner enrollment), Apps Service (app enrollment), Users Service (user device enrollment), Expose (exposed ports) |
 | **External dependency** | OpenZiti Edge Management API (`/edge/management/v1/`) via the generated Go client (`openziti/edge-api`, package `rest_management_api_client`) |
 | **Access to Controller** | Via Istio (in-cluster) — avoids circular dependency of using OpenZiti to manage OpenZiti |
 | **Authentication** | Certificate-based auth using a long-lived infrastructure credential provisioned at deployment |
@@ -75,7 +75,7 @@ All interactions with the OpenZiti Controller's Edge Management API are encapsul
 | `CreateAppIdentity` | Apps Service | Create and enroll an OpenZiti identity for an app, return enrolled identity (cert + key). If a previous identity exists for this app, deletes it first |
 | `DeleteAppIdentity` | Apps Service | Delete an app's OpenZiti identity, service, and platform mapping |
 | `CreateUserDeviceIdentity` | Users Service | Create an OpenZiti identity for a user device, return enrollment JWT (Desktop Edge enrolls client-side) |
-| `CreateService` | Runners Service, Apps Service, Expose | Create a per-runner, per-app, or per-share OpenZiti service |
+| `CreateService` | Runners Service, Apps Service, Expose | Create a per-runner, per-app, or per-exposed-port OpenZiti service |
 | `CreateConfig` | Expose | Create an OpenZiti config object (intercept.v1, host.v1) |
 | `DeleteConfig` | Expose | Delete an OpenZiti config object |
 | `CreateServicePolicy` | Expose | Create a service policy (Dial/Bind) |
@@ -281,7 +281,7 @@ Static policies, services, and edge router policies are provisioned by Terraform
 
 In addition to static policies, the platform provisions dynamic services and policies at runtime for ad-hoc connectivity use cases:
 
-- **Exposed ports (dev servers)** — The [Expose service](expose.md) creates a per-share OpenZiti service `exposed-<id>` with intercept hostname `exposed-<id>.ziti` and host forwarding to `127.0.0.1:<port>` in the agent pod. A per-share Bind policy restricts hosting to the requesting agent. Expose also creates a per-share Dial policy; which user devices receive Dial access is defined by the access-scope policy (see the [open question](../open-questions.md#openziti-exposed-ports-access-scope)). On revoke/workload stop, Expose deletes the per-share service/configs/policies.
+- **Exposed ports (dev servers)** — The [Expose service](expose.md) creates a per-exposed-port OpenZiti service `exposed-<id>` with intercept hostname `exposed-<id>.ziti` and host forwarding to `127.0.0.1:<port>` in the agent pod. A per-exposed-port Bind policy restricts hosting to the requesting agent. Expose also creates a per-exposed-port Dial policy; which user devices receive Dial access is defined by the access-scope policy (see the [open question](../open-questions.md#openziti-exposed-ports-access-scope)). On revoke/workload stop, Expose deletes the per-exposed-port service/configs/policies.
 - **Agent-to-agent private networking** — Future capability. Agents expose a port that only specific other agents can connect to.
 
 OpenZiti supports this natively:

--- a/architecture/openziti.md
+++ b/architecture/openziti.md
@@ -16,6 +16,17 @@ This document covers the **implementation** of OpenZiti integration: which servi
 
 **Agent pods** are not in the Istio mesh. They use a **Ziti sidecar container** within the pod that enrolls the agent's OpenZiti identity, runs DNS for OpenZiti service hostnames, and transparently intercepts traffic via iptables TPROXY. This makes hostnames like `gateway.ziti` and `llm-proxy.ziti` reachable as normal network addresses inside the pod. See [Agent Access Scope](#agent-access-scope).
 
+## Public Edge Endpoints (Ingress)
+
+User devices (Ziti Desktop Edge / tunnel) must be able to reach the OpenZiti **Controller client endpoint** and at least one **Edge Router**.
+
+In bootstrap, these endpoints are exposed through Istio on the **same host-exposed ingress port** using **TLS passthrough + SNI routing**:
+
+- Controller client endpoint: `ziti.<base_domain>:<ingress_port>`
+- Edge router endpoint: `ziti-router.<base_domain>:<ingress_port>`
+
+The Edge Management API endpoint (`ziti-mgmt.<base_domain>:<ingress_port>`) is privileged/admin-only. Bootstrap routes it so Terraform (running outside the cluster) can manage the Controller via the OpenZiti Terraform provider; user devices do not require it. In production, restrict it (private network, IP allowlist, separate admin ingress) or avoid exposing it entirely.
+
 The OpenZiti Go SDK implements Go's standard `net.Listener` and `net.Conn` interfaces. A gRPC server accepts connections from an OpenZiti listener the same way it accepts from a TCP listener. A gRPC client dials through an OpenZiti context the same way it dials a TCP address.
 
 | Service | SDK Role | How |
@@ -28,7 +39,7 @@ The OpenZiti Go SDK implements Go's standard `net.Listener` and `net.Conn` inter
 
 Agent pods do not embed the OpenZiti SDK. Instead, a **Ziti sidecar** runs alongside the agent process within the same pod. See [Agent Access Scope](#agent-access-scope).
 
-The Orchestrator, Gateway, and LLM Proxy obtain their OpenZiti identities at runtime via self-enrollment through the [Ziti Management](#ziti-management-service) service. Runners and Apps obtain their identities via the service token enrollment flow — see [Runner Provisioning](#runner-provisioning) and [App Identity Lifecycle](#app-identity-lifecycle). See [Service Identity Self-Enrollment](#service-identity-self-enrollment) and [Authentication](authn.md#enrollment).
+The Orchestrator, Gateway, and LLM Proxy obtain their OpenZiti identities at runtime via self-enrollment through the [Ziti Management](#ziti-management-service) service. Runners and Apps obtain their identities via the service token enrollment flow — see [Runner Provisioning](#runner-provisioning) and [App Identity Lifecycle](#app-identity-lifecycle). Users obtain OpenZiti enrollment tokens for their local machines via the [Users service](users.md#ziti-user-device-enrollment). See [Service Identity Self-Enrollment](#service-identity-self-enrollment) and [Authentication](authn.md#enrollment).
 
 ## Ziti Management Service
 
@@ -37,7 +48,7 @@ All interactions with the OpenZiti Controller's Edge Management API are encapsul
 | Aspect | Detail |
 |--------|--------|
 | **Plane** | Data — executes operations it is told to perform; runs identity lease GC |
-| **Consumers** | Agents Orchestrator (agent identity lifecycle), Gateway (identity resolution), Orchestrator / Gateway (service identity self-enrollment), Runners Service (runner enrollment), Apps Service (app enrollment) |
+| **Consumers** | Agents Orchestrator (agent identity lifecycle), Gateway (identity resolution), Orchestrator / Gateway (service identity self-enrollment), Runners Service (runner enrollment), Apps Service (app enrollment), Users Service (user device enrollment), Expose (port shares) |
 | **External dependency** | OpenZiti Edge Management API (`/edge/management/v1/`) via the generated Go client (`openziti/edge-api`, package `rest_management_api_client`) |
 | **Access to Controller** | Via Istio (in-cluster) — avoids circular dependency of using OpenZiti to manage OpenZiti |
 | **Authentication** | Certificate-based auth using a long-lived infrastructure credential provisioned at deployment |
@@ -50,7 +61,9 @@ All interactions with the OpenZiti Controller's Edge Management API are encapsul
 - If OpenZiti's API changes, only one service changes.
 - Infrastructure services (Orchestrator, Gateway) self-enroll through Ziti Management at startup, keeping all OpenZiti Controller interactions in one place.
 - The Runners Service and Apps Service delegate identity creation to Ziti Management for runners and apps.
-- Future capabilities (user enrollment for CLI, agent-to-agent port sharing) will also route through this service.
+- The Users service delegates user-device identity creation to Ziti Management.
+- Expose delegates dynamic service/config/policy provisioning to Ziti Management for exposed ports.
+- Future capabilities (agent-to-agent port sharing, narrower user scoping) will also route through this service.
 
 ### API Surface
 
@@ -61,7 +74,12 @@ All interactions with the OpenZiti Controller's Edge Management API are encapsul
 | `DeleteRunnerIdentity` | Runners Service | Delete a runner's OpenZiti identity, service, and platform mapping |
 | `CreateAppIdentity` | Apps Service | Create and enroll an OpenZiti identity for an app, return enrolled identity (cert + key). If a previous identity exists for this app, deletes it first |
 | `DeleteAppIdentity` | Apps Service | Delete an app's OpenZiti identity, service, and platform mapping |
-| `CreateService` | Runners Service, Apps Service | Create a per-runner or per-app OpenZiti service |
+| `CreateUserDeviceIdentity` | Users Service | Create an OpenZiti identity for a user device, return enrollment JWT (Desktop Edge enrolls client-side) |
+| `CreateService` | Runners Service, Apps Service, Expose | Create a per-runner, per-app, or per-share OpenZiti service |
+| `CreateConfig` | Expose | Create an OpenZiti config object (intercept.v1, host.v1) |
+| `DeleteConfig` | Expose | Delete an OpenZiti config object |
+| `CreateServicePolicy` | Expose | Create a service policy (Dial/Bind) |
+| `DeleteServicePolicy` | Expose | Delete a service policy |
 | `DeleteIdentity` | Orchestrator | Delete an OpenZiti identity and its platform mapping |
 | `ListManagedIdentities` | Orchestrator | List all identities managed by the platform (for reconciliation) |
 | `ResolveIdentity` | Gateway | Map an OpenZiti identity ID to platform identity (identity_id, identity_type) |
@@ -77,10 +95,12 @@ All interactions with the OpenZiti Controller's Edge Management API are encapsul
 | Delete identity | `DELETE /edge/management/v1/identities/{id}` | Agent stop, identity cleanup, lease GC, runner/app re-enrollment (previous identity cleanup) |
 | List identities | `GET /edge/management/v1/identities?filter=...` | Reconciliation, lease GC |
 | Update role attributes | `PATCH /edge/management/v1/identities/{id}` | Future: dynamic policy changes |
-| Create service | `POST /edge/management/v1/services` | Runner registration, app registration |
-| Delete service | `DELETE /edge/management/v1/services/{id}` | Runner deletion, app deletion |
-| Create service policy | `POST /edge/management/v1/service-policies` | Future: dynamic access grants |
-| Delete service / policy | `DELETE /edge/management/v1/{type}/{id}` | Future: revoke dynamic access |
+| Create config | `POST /edge/management/v1/configs` | Exposed ports provisioning (intercept.v1, host.v1) |
+| Delete config | `DELETE /edge/management/v1/configs/{id}` | Exposed ports cleanup |
+| Create service | `POST /edge/management/v1/services` | Runner registration, app registration, exposed ports provisioning |
+| Delete service | `DELETE /edge/management/v1/services/{id}` | Runner deletion, app deletion, exposed ports cleanup |
+| Create service policy | `POST /edge/management/v1/service-policies` | Exposed ports provisioning (Bind policy), future: dynamic access grants |
+| Delete service / policy | `DELETE /edge/management/v1/{type}/{id}` | Exposed ports cleanup, future: revoke dynamic access |
 
 ### Identity Lease GC
 
@@ -225,6 +245,7 @@ OpenZiti uses an ABAC (Attribute-Based Access Control) model. Service policies m
 
 | Identity Type | Role Attributes |
 |---|---|
+| User device (Ziti Desktop Edge) | `["ziti-users"]` |
 | Agent pod (Ziti sidecar) | `["agents", "agent-<agentId>"]` |
 | Runner | `["runners"]` |
 | Orchestrator | `["orchestrators"]` |
@@ -256,12 +277,12 @@ Edge router policies: `#all` identities → `#all` edge routers (no router-level
 
 Static policies, services, and edge router policies are provisioned by Terraform at bootstrap. Identity provisioning is handled separately via [self-enrollment](#service-identity-self-enrollment) or [service token enrollment](#runner-provisioning) — policies match identities by role attributes, not by specific identity references.
 
-### Dynamic Policies (Future)
+### Dynamic Policies
 
-The static policies above are sufficient for the current architecture. Future capabilities will require dynamic, per-agent or per-user policies managed at runtime by Ziti Management:
+In addition to static policies, the platform provisions dynamic services and policies at runtime for ad-hoc connectivity use cases:
 
-- **User-to-agent direct connection** — A user enrolls their machine via a CLI tool and connects directly to a specific agent over OpenZiti. Requires creating a per-agent service and scoped Dial/Bind policies at runtime.
-- **Agent-to-agent private networking** — An agent exposes a port that only specific other agents can connect to. Requires creating a per-share service and scoped Dial/Bind policies at runtime.
+- **Exposed ports (dev servers)** — The [Expose service](expose.md) creates a per-share OpenZiti service `exposed-<id>` with intercept hostname `exposed-<id>.ziti` and host forwarding to `127.0.0.1:<port>` in the agent pod. A per-share Bind policy restricts hosting to the requesting agent. Expose also creates a per-share Dial policy; which user devices receive Dial access is defined by the access-scope policy (see the [open question](../open-questions.md#openziti-exposed-ports-access-scope)). On revoke/workload stop, Expose deletes the per-share service/configs/policies.
+- **Agent-to-agent private networking** — Future capability. Agents expose a port that only specific other agents can connect to.
 
 OpenZiti supports this natively:
 
@@ -269,7 +290,7 @@ OpenZiti supports this natively:
 - **Policy changes take effect immediately.** New service policies grant (or revoke) access for matching identities in real time.
 - **Revocation closes live connections.** Removing a policy tears down existing connections, not just prevents new ones.
 
-These capabilities mean dynamic policies can be applied to already-running agents without restart. The Ziti Management service API will be extended with RPCs for port sharing and user enrollment when these features are implemented.
+These capabilities mean policies can be applied to already-running endpoints without restart.
 
 ## Gateway Identity Extraction
 

--- a/architecture/system-overview.md
+++ b/architecture/system-overview.md
@@ -18,6 +18,7 @@ graph TB
         RunnersService[Runners]
         AgentsOrch[Agents<br/>Orchestrator]
         Organizations[Organizations]
+        Expose[Expose]
     end
 
     subgraph Data Plane
@@ -55,6 +56,8 @@ graph TB
     ThirdParty <--> TelegramApp
 
     Gateway --> ZitiMgmt
+    Gateway --> Expose
+    Expose --> ZitiMgmt
     Gateway --> Users
     Gateway --> Authorization
     Gateway --> Chat
@@ -73,6 +76,7 @@ graph TB
     Chat --> Users
 
     Users --> Identity
+    Users --> ZitiMgmt
     Agents --> Identity
 
     Threads -->|publish events| Notifications
@@ -109,7 +113,7 @@ graph TB
 | Component | Responsibility |
 |-----------|---------------|
 | **Identity** | Central identity registry. Maps `identity_id` to `identity_type` for all identity types |
-| **Users** | User identity records and profiles. Provisions users on first OIDC login, serves profiles for display |
+| **Users** | User identity records and profiles. Provisions users on first OIDC login, serves profiles for display. Mints OpenZiti user-device enrollment tokens for Ziti Desktop Edge |
 | **Organizations** | Organization lifecycle (CRUD), membership management (invites, direct membership, role assignment), and listing accessible organizations for an identity |
 | **Chat** | Built-in web/mobile app chat experience. Thread lifecycle, unread counts. Built on top of Threads |
 | **Threads** | Generic messaging between participants. Stores messages, tracks participants by ID, provides message acknowledgment. Participant-type-agnostic |
@@ -126,6 +130,7 @@ graph TB
 | **[Runners](runners.md)** | Manages runner registrations and workload runtime state. Central registry of runners (cluster-scoped and org-scoped) and running workloads |
 | **Runner** | Executes workloads. Current implementation: [k8s-runner](k8s-runner.md) |
 | **Gateway** | Exposes platform methods for external usage via [ConnectRPC](gateway.md#connectrpc) (gRPC + HTTP/JSON). Accessible at `gateway.agyn.dev` (subdomain) and `agyn.dev/api/` (path-based, prefix stripped) |
+| **[Expose](expose.md)** | Manages exposed ports (dev server links) over OpenZiti |
 | **Ziti Management** | Manages OpenZiti identities, services, and policies. Encapsulates all OpenZiti Controller API interactions |
 | **[Apps Service](apps-service.md)** | Apps, installations, profiles, and enrollment. Manages the lifecycle of [apps](apps.md) — both apps (owned by organizations) and per-org installations (permissions bridge + configuration) |
 | **[Apps](apps.md)** | Independently deployed services that interact with threads on behalf of external systems or platform capabilities. Includes bidirectional bridges to 3rd-party products ([Telegram Connector](apps/telegram-connector.md)) and platform-provided capabilities ([Reminders](apps/reminders.md)) |

--- a/architecture/users.md
+++ b/architecture/users.md
@@ -16,6 +16,7 @@ User records are system-wide — not scoped to an organization. User-to-organiza
 | **User lookup** | Resolve a user by `identity_id` or by OIDC subject |
 | **Batch profile resolution** | Return profiles for a list of identity IDs |
 | **API token management** | Create, list, revoke, and resolve [API tokens](api-tokens.md) for programmatic access |
+| **Ziti device enrollment** | Mint OpenZiti enrollment tokens for user machines (Ziti Desktop Edge / tunnel) to access [exposed ports](expose.md) |
 
 ## User Model
 
@@ -51,6 +52,45 @@ The Users service exposes a method for the calling user to retrieve their own pr
 | Method | Description |
 |--------|-------------|
 | **GetMe** | Return the calling user's profile and cluster role. Identity is resolved from the request context — no `identity_id` parameter. Returns the same shape as admin `GetUser`: profile fields and `cluster_role` |
+
+## Ziti User Device Enrollment
+
+Users can optionally enroll their local machine into the platform's OpenZiti network to reach agent-exposed dev servers (see [Expose](expose.md) and [Exposed Ports](../product/chat/exposed-ports.md)).
+
+This enrollment is **network-only** and is separate from OIDC authentication used for platform APIs.
+
+### Gateway Interface
+
+Exposed through the Gateway via `UsersGateway`. Requires that the caller is authenticated.
+
+| Method | Description |
+|--------|-------------|
+| **CreateZitiDeviceEnrollment** | Create a Ziti identity for a user device and return an enrollment token (JWT) for Ziti Desktop Edge / tunnel |
+
+#### CreateZitiDeviceEnrollment
+
+**Request**
+
+| Field | Type | Required | Description |
+|------|------|----------|-------------|
+| `label` | string | Yes | Human-readable label for the device (e.g., `"Alice MacBook"`) |
+
+**Response**
+
+| Field | Type | Description |
+|------|------|-------------|
+| `device_id` | string (UUID) | Stable ID for this enrolled device record |
+| `enrollment_jwt` | string | One-time enrollment token consumed by Ziti Desktop Edge / tunnel |
+| `expires_at` | timestamp | Token expiry time |
+
+**Behavior**
+
+1. Create a `user_ziti_devices` record in the Users DB (`device_id`, `user_identity_id`, `label`).
+2. Call Ziti Management `CreateUserDeviceIdentity(external_id=device_id, role_attributes=["ziti-users"])`.
+3. Persist the returned `openziti_identity_id` on the device record.
+4. Return `enrollment_jwt` to the caller (shown once).
+
+If the enrollment JWT expires before being used, the user creates a new device enrollment (a new OpenZiti identity is created).
 
 ## Admin User Management
 

--- a/changes/2026-04-09-exposed-ports.md
+++ b/changes/2026-04-09-exposed-ports.md
@@ -1,0 +1,25 @@
+# Exposed Ports (Dev Server Links)
+
+## Target
+
+- [Product — Exposed Ports](../product/chat/exposed-ports.md)
+- [Architecture — Expose Service](../architecture/expose.md)
+- [OpenZiti Integration — Dynamic Policies](../architecture/openziti.md#dynamic-policies)
+
+## Delta
+
+- There is no Users service + Console workflow for minting Ziti Desktop Edge / tunnel enrollment tokens for user machines.
+- There is no Expose service for managing exposed ports (port shares).
+- Agents cannot request that a local port be exposed over OpenZiti.
+- The platform does not provision per-share OpenZiti services/configs/policies for port exposure.
+
+## Acceptance Signal
+
+- A user can generate an enrollment token in the Console and enroll Ziti Desktop Edge / tunnel.
+- An agent can request a port share and receive a URL `http://exposed-<id>.ziti:<port>`.
+- A user can open the URL and reach the dev server inside the agent pod.
+- Shares are cleaned up when revoked or when the workload stops (with GC as a backstop).
+
+## Notes
+
+- Access scope (which user devices can dial exposed ports) is TBD. Track the decision in [OpenZiti: Exposed Ports Access Scope](../open-questions.md#openziti-exposed-ports-access-scope).

--- a/changes/2026-04-09-exposed-ports.md
+++ b/changes/2026-04-09-exposed-ports.md
@@ -9,16 +9,16 @@
 ## Delta
 
 - There is no Users service + Console workflow for minting Ziti Desktop Edge / tunnel enrollment tokens for user machines.
-- There is no Expose service for managing exposed ports (port shares).
+- There is no Expose service for managing exposed ports.
 - Agents cannot request that a local port be exposed over OpenZiti.
-- The platform does not provision per-share OpenZiti services/configs/policies for port exposure.
+- The platform does not provision per-exposed-port OpenZiti services/configs/policies for port exposure.
 
 ## Acceptance Signal
 
 - A user can generate an enrollment token in the Console and enroll Ziti Desktop Edge / tunnel.
-- An agent can request a port share and receive a URL `http://exposed-<id>.ziti:<port>`.
+- An agent can request an exposed port and receive a URL `http://exposed-<id>.ziti:<port>`.
 - A user can open the URL and reach the dev server inside the agent pod.
-- Shares are cleaned up when revoked or when the workload stops (with GC as a backstop).
+- Exposed ports are cleaned up when revoked or when the workload stops (with GC as a backstop).
 
 ## Notes
 

--- a/maps/product-to-architecture.md
+++ b/maps/product-to-architecture.md
@@ -8,6 +8,7 @@ Cross-links from product surfaces to the architecture docs that support them.
 
 - [Chat](../product/chat/chat.md)
 - [Inline Media](../product/chat/inline-media.md)
+- [Exposed Ports](../product/chat/exposed-ports.md)
 
 ### Architecture docs
 
@@ -17,6 +18,9 @@ Cross-links from product surfaces to the architecture docs that support them.
 - [Media](../architecture/media.md)
 - [Media Proxy](../architecture/media-proxy.md)
 - [Reminders](../architecture/apps/reminders.md)
+- [OpenZiti](../architecture/openziti.md)
+- [Expose](../architecture/expose.md)
+- [Users](../architecture/users.md)
 
 ## Console
 

--- a/open-questions.md
+++ b/open-questions.md
@@ -18,12 +18,23 @@ Unresolved product and architectural decisions requiring discussion.
 
 ## OpenZiti: Agent-to-Agent Private Networking
 
-**Context:** Future capability. Agents should be able to expose a port and share it with specific other agents over a private OpenZiti connection. Other agents must not be able to connect. See [OpenZiti Integration — Dynamic Policies](architecture/openziti.md#dynamic-policies-future).
+**Context:** Future capability. Agents should be able to expose a port and share it with specific other agents over a private OpenZiti connection. Other agents must not be able to connect. See [OpenZiti Integration — Dynamic Policies](architecture/openziti.md#dynamic-policies).
 
 **Questions:**
 - How does the agent request port sharing? (Platform API tool? Agent SDK primitive?)
 - What is the resource model? (Does the platform define "agent networks" as a team resource, or is each share ad-hoc?)
 - Does the binding agent create the OpenZiti service dynamically, or does the Ziti Management service pre-provision it?
+
+---
+
+## OpenZiti: Exposed Ports Access Scope
+
+**Context:** Exposed ports (dev server links) are reachable over OpenZiti at `http://exposed-<id>.ziti:<port>`. We need to decide how dial access to each share is scoped (cluster-wide, org-scoped, thread participants, etc.).
+
+**Questions:**
+- Should dial access be scoped to organization, thread participants, or message author?
+- If scoped to organization: should user device identities carry `org-<orgId>` role attributes, and how are they updated when membership changes?
+- Do exposed ports require per-share dial policies, or can policies be expressed through role attributes alone?
 
 ---
 

--- a/open-questions.md
+++ b/open-questions.md
@@ -22,19 +22,19 @@ Unresolved product and architectural decisions requiring discussion.
 
 **Questions:**
 - How does the agent request port sharing? (Platform API tool? Agent SDK primitive?)
-- What is the resource model? (Does the platform define "agent networks" as a team resource, or is each share ad-hoc?)
+- What is the resource model? (Does the platform define "agent networks" as a team resource, or is each port exposure ad-hoc?)
 - Does the binding agent create the OpenZiti service dynamically, or does the Ziti Management service pre-provision it?
 
 ---
 
 ## OpenZiti: Exposed Ports Access Scope
 
-**Context:** Exposed ports (dev server links) are reachable over OpenZiti at `http://exposed-<id>.ziti:<port>`. We need to decide how dial access to each share is scoped (cluster-wide, org-scoped, thread participants, etc.).
+**Context:** Exposed ports (dev server links) are reachable over OpenZiti at `http://exposed-<id>.ziti:<port>`. We need to decide how dial access to each exposed port is scoped (cluster-wide, org-scoped, thread participants, etc.).
 
 **Questions:**
 - Should dial access be scoped to organization, thread participants, or message author?
 - If scoped to organization: should user device identities carry `org-<orgId>` role attributes, and how are they updated when membership changes?
-- Do exposed ports require per-share dial policies, or can policies be expressed through role attributes alone?
+- Do exposed ports require per-port dial policies, or can policies be expressed through role attributes alone?
 
 ---
 

--- a/product/README.md
+++ b/product/README.md
@@ -5,7 +5,7 @@ Desired product state for the Agyn platform.
 ## Reading paths
 
 - Start here: [Overview](overview.md) -> [Concepts](concepts.md)
-- Chat: [Chat](chat/chat.md) -> [Inline Media](chat/inline-media.md)
+- Chat: [Chat](chat/chat.md) -> [Inline Media](chat/inline-media.md) -> [Exposed Ports](chat/exposed-ports.md)
 - Console: [Console](console/console.md)
 - Tracing: [Run Timeline](tracing/run-timeline.md)
 
@@ -20,6 +20,7 @@ Desired product state for the Agyn platform.
 
 - [Chat](chat/chat.md)
 - [Inline Media](chat/inline-media.md)
+- [Exposed Ports](chat/exposed-ports.md)
 
 ### Console
 

--- a/product/chat/exposed-ports.md
+++ b/product/chat/exposed-ports.md
@@ -1,0 +1,45 @@
+# Exposed Ports (Dev Server Links)
+
+## Purpose
+
+Agents often start local development servers while working (web apps, docs sites, API servers). The platform allows an agent to share a running server with the user as a **clickable link**.
+
+The link is reachable only from machines enrolled in the platform's OpenZiti network.
+
+## Prerequisites
+
+Before opening an exposed port link, the user must:
+
+1. Install **Ziti Desktop Edge** (or another OpenZiti tunnel client).
+2. Enroll their machine using an **enrollment token** generated in the Console.
+
+## User Stories
+
+- As a user, when an agent starts a dev server, I want to receive a link I can open in my browser.
+- As a user, I want exposed links to work from my local machine without SSH, kubectl, or port-forwarding.
+
+## Link Format
+
+Agents share exposed ports using URLs of the form:
+
+```
+http://exposed-<id>.ziti:<port>
+```
+
+Examples:
+
+- `http://exposed-ab12cd34.ziti:5173`
+- `http://exposed-k9x3p2q1.ziti:3000`
+
+## Behavior
+
+1. The user sends a message to an agent in a conversation.
+2. The agent starts and performs work.
+3. If the agent starts a development server, it shares a link in the conversation.
+4. The user opens the link in a browser.
+5. The browser loads the server content over the OpenZiti tunnel.
+
+## Failure Modes
+
+- If the user has not enrolled a Ziti identity on their machine, the link is not reachable.
+- If the agent stops (workload ends) or the server process exits, the link stops working.

--- a/product/concepts.md
+++ b/product/concepts.md
@@ -7,6 +7,7 @@ Domain glossary — canonical definitions of product terms. Both product and arc
 | **Agent** | An AI entity configured with an LLM model, tools, and instructions. Agents receive messages, reason, execute tools, and respond within conversations. |
 | **Chat** | The platform's communication interface. Users create conversations with any combination of users and agents, all managed in a single list-detail view. |
 | **Container** | A running workload (Kubernetes pod) attached to a conversation's agent. Containers provide terminal access for inspection. |
+| **Exposed Port** | A temporary network endpoint that maps a TCP port inside an agent workload to an OpenZiti hostname of the form `exposed-<id>.ziti:<port>`. |
 | **Context** | The set of items (messages, tool results, memory, summaries) assembled into a prompt for an LLM call. Context is paginated and inspectable per LLM event. |
 | **Conversation** | A persistent exchange between participants (users, agents, or both). Conversations have a lifecycle (open → resolved). |
 | **Gateway** | The external API surface of the platform. All client applications communicate with the platform through the Gateway via ConnectRPC. |

--- a/product/console/console.md
+++ b/product/console/console.md
@@ -91,6 +91,7 @@ The dropdown contains:
 | Item | Description |
 |------|-------------|
 | **Profile** | View and edit the user's own profile (name, nickname, photo URL). Read-only fields: OIDC subject |
+| **Devices** | Enroll and manage OpenZiti devices (Ziti Desktop Edge) used to access exposed ports |
 | **API Tokens** | Create, list, and revoke API tokens for programmatic access. Token value is shown once at creation and cannot be retrieved again |
 | **Pending Invites** | List of pending organization invites with accept/decline actions. Badge on the user menu shows the count of pending invites. Accepting an invite adds the organization to the context switcher and switches to it |
 | **Logout** | Ends the session |


### PR DESCRIPTION
Updates architecture + product docs to support remote users reaching agent-container ports over the existing OpenZiti overlay.

Key changes:
- Users service owns Ziti user-device enrollment token issuance
- Expose service is port-only (provision + cleanup), includes removal/GC semantics
- Document public Ziti ingress endpoints and why ziti-mgmt is exposed in bootstrap
- Keep exposed-port access scope as an explicit open question
- Console: add Devices section above API Tokens
- Rename Expose RPCs to AddPort/DeletePort/GetPort/DeletePortsForAgent
