### PR TITLE
feat: Port Exposure — user access to agent container ports via OpenZiti

### DIFF
--- a/architecture/README.md
+++ b/architecture/README.md
@@ -72,6 +72,7 @@ Desired architecture state of the platform.
 - [MCP](mcp.md)
 - [files-mcp](files-mcp.md)
 - [OpenZiti](openziti.md)
+- [Expose Service](expose-service.md)
 
 ### Observability
 

--- a/architecture/agent/overview.md
+++ b/architecture/agent/overview.md
@@ -43,7 +43,7 @@ graph TB
 | **Use tools via MCP** | Connect to MCP servers for tool access |
 | **Report tracing** | Optionally emit tracing data |
 
-The agent is primarily a **client** — it connects to the [Gateway](../gateway.md) and the [LLM Proxy](../llm-proxy.md) using OpenZiti service hostnames transparently intercepted by the pod's [Ziti sidecar](../openziti.md#agent-access-scope) and accesses all platform services through them. It does not expose any server or accept inbound connections by default. When the agent exposes a port via `agyn expose add <port>`, the Ziti sidecar binds a new OpenZiti service and forwards inbound traffic to `localhost:<port>` inside the pod. See [Expose Service](../expose-service.md).
+The agent is primarily a **client** — it connects to the [Gateway](../gateway.md) and the [LLM Proxy](../llm-proxy.md) using OpenZiti service hostnames transparently intercepted by the pod's [Ziti sidecar](../openziti.md#agent-access-scope) and accesses all platform services through them. It does not expose any server or accept inbound connections by default. When the agent exposes a port via the platform API, the Ziti sidecar binds a new OpenZiti service and forwards inbound traffic to `localhost:<port>` inside the pod. See [Expose Service](../expose-service.md).
 
 ## Communication Protocol
 

--- a/architecture/agent/overview.md
+++ b/architecture/agent/overview.md
@@ -43,7 +43,7 @@ graph TB
 | **Use tools via MCP** | Connect to MCP servers for tool access |
 | **Report tracing** | Optionally emit tracing data |
 
-The agent is a **pure client** — it connects to the [Gateway](../gateway.md) and the [LLM Proxy](../llm-proxy.md) using OpenZiti service hostnames transparently intercepted by the pod's [Ziti sidecar](../openziti.md#agent-access-scope) and accesses all platform services through them. It does not expose any server or accept inbound connections.
+The agent is primarily a **client** — it connects to the [Gateway](../gateway.md) and the [LLM Proxy](../llm-proxy.md) using OpenZiti service hostnames transparently intercepted by the pod's [Ziti sidecar](../openziti.md#agent-access-scope) and accesses all platform services through them. It does not expose any server or accept inbound connections by default. When the agent exposes a port via `agyn expose add <port>`, the Ziti sidecar binds a new OpenZiti service and forwards inbound traffic to `localhost:<port>` inside the pod. See [Expose Service](../expose-service.md).
 
 ## Communication Protocol
 

--- a/architecture/agents-orchestrator.md
+++ b/architecture/agents-orchestrator.md
@@ -21,7 +21,6 @@ graph TB
     Runners[Runners] -->|workload state| Reconciler
     Reconciler -->|start/stop workloads| Runner
     Reconciler -->|create/delete identities| ZitiMgmt[Ziti Management]
-    Reconciler -->|cleanup exposures| Expose[Expose Service]
 ```
 
 | Dependency | Usage |
@@ -33,7 +32,6 @@ graph TB
 | **[Runners](runners.md)** | Read and write workload runtime state (which workloads are running, on which runner). Query registered runners for [runner selection](runners.md#runner-selection) |
 | **Runner** | Start and stop agent workloads (via OpenZiti SDK — see [Authentication](authn.md#sdk-embedding)) |
 | **Ziti Management** | Create and delete OpenZiti identities for agent containers |
-| **[Expose Service](expose-service.md)** | Clean up port exposures when stopping workloads |
 
 ## Reconciliation
 
@@ -164,13 +162,10 @@ When the orchestrator decides an agent workload should stop (idle timeout exceed
 ```mermaid
 sequenceDiagram
     participant O as Orchestrator
-    participant ES as Expose Service
     participant R as Runner
     participant RS as Runners Service
     participant ZM as Ziti Management
 
-    O->>ES: RemoveExposuresByWorkload(workloadId)
-    ES-->>O: OK
     O->>R: StopWorkload(workloadId)
     R-->>O: OK
     O->>RS: DeleteWorkload(workloadId)
@@ -179,7 +174,7 @@ sequenceDiagram
     ZM-->>O: OK
 ```
 
-The orchestrator calls the [Expose Service](expose-service.md) to clean up any active port exposures before stopping the workload. This ensures OpenZiti resources (services, policies) are removed. See [Expose Service — Workload Cleanup](expose-service.md#workload-cleanup).
+The [Expose Service](expose-service.md) discovers workload stops independently via [Notifications](notifications.md) events and its own reconciliation loop. The Orchestrator does not participate in exposure cleanup. See [Expose Service — Reconciliation](expose-service.md#reconciliation).
 
 ## Leader Election
 

--- a/architecture/agents-orchestrator.md
+++ b/architecture/agents-orchestrator.md
@@ -21,6 +21,7 @@ graph TB
     Runners[Runners] -->|workload state| Reconciler
     Reconciler -->|start/stop workloads| Runner
     Reconciler -->|create/delete identities| ZitiMgmt[Ziti Management]
+    Reconciler -->|cleanup exposures| Expose[Expose Service]
 ```
 
 | Dependency | Usage |
@@ -32,6 +33,7 @@ graph TB
 | **[Runners](runners.md)** | Read and write workload runtime state (which workloads are running, on which runner). Query registered runners for [runner selection](runners.md#runner-selection) |
 | **Runner** | Start and stop agent workloads (via OpenZiti SDK — see [Authentication](authn.md#sdk-embedding)) |
 | **Ziti Management** | Create and delete OpenZiti identities for agent containers |
+| **[Expose Service](expose-service.md)** | Clean up port exposures when stopping workloads |
 
 ## Reconciliation
 
@@ -162,10 +164,13 @@ When the orchestrator decides an agent workload should stop (idle timeout exceed
 ```mermaid
 sequenceDiagram
     participant O as Orchestrator
+    participant ES as Expose Service
     participant R as Runner
     participant RS as Runners Service
     participant ZM as Ziti Management
 
+    O->>ES: RemoveExposuresByWorkload(workloadId)
+    ES-->>O: OK
     O->>R: StopWorkload(workloadId)
     R-->>O: OK
     O->>RS: DeleteWorkload(workloadId)
@@ -173,6 +178,8 @@ sequenceDiagram
     O->>ZM: DeleteIdentity(openZitiIdentityId)
     ZM-->>O: OK
 ```
+
+The orchestrator calls the [Expose Service](expose-service.md) to clean up any active port exposures before stopping the workload. This ensures OpenZiti resources (services, policies) are removed. See [Expose Service — Workload Cleanup](expose-service.md#workload-cleanup).
 
 ## Leader Election
 

--- a/architecture/agents-orchestrator.md
+++ b/architecture/agents-orchestrator.md
@@ -174,7 +174,6 @@ sequenceDiagram
     ZM-->>O: OK
 ```
 
-The [Expose Service](expose-service.md) discovers workload stops independently via [Notifications](notifications.md) events and its own reconciliation loop. The Orchestrator does not participate in exposure cleanup. See [Expose Service — Reconciliation](expose-service.md#reconciliation).
 
 ## Leader Election
 

--- a/architecture/agyn-cli.md
+++ b/architecture/agyn-cli.md
@@ -26,6 +26,11 @@ agyn agents list
 # Messaging
 agyn messages send --thread <thread-id> "Hello"
 
+# Port exposure (inside agent containers)
+agyn expose add 3000
+agyn expose remove 3000
+agyn expose list
+
 # Any Gateway API operation
 agyn <resource> <verb> [flags]
 ```
@@ -36,9 +41,21 @@ agyn <resource> <verb> [flags]
 |------|---------|---------|
 | **Administrators** | Manage platform resources from a terminal | `agyn agents create`, `agyn agents list` |
 | **Developers** | Interact with the platform during development | `agyn messages send`, `agyn threads list` |
-| **Agents** | Invoke platform operations from within an agent runtime (e.g., update memory, add agents) | `agyn agents create`, `agyn messages send` |
+| **Agents** | Invoke platform operations from within an agent runtime (e.g., update memory, add agents, expose ports) | `agyn agents create`, `agyn messages send`, `agyn expose add 3000` |
 
 All users interact with the same Gateway API. [Authorization](authz.md) determines what each identity is permitted to do.
+
+## Port Exposure Commands
+
+Agents use the `expose` command group to make ports inside their container accessible to users over the OpenZiti network. See [Expose Service](expose-service.md) for the architecture.
+
+| Command | Description |
+|---------|-------------|
+| `agyn expose add <port>` | Expose a port. Returns the access URL (`http://exposed-<id>.ziti:<port>`) |
+| `agyn expose remove <port>` | Un-expose a port |
+| `agyn expose list` | List active exposures for the current workload |
+
+These commands call the [Gateway](gateway.md) → [Expose Service](expose-service.md). The agent's workload context is resolved from the authenticated identity.
 
 ## Authentication
 

--- a/architecture/console.md
+++ b/architecture/console.md
@@ -19,7 +19,6 @@ graph LR
     LLMService[LLM]
     Secrets[Secrets]
     Apps[Apps Service]
-    Expose[Expose Service]
 
     Console -->|ConnectRPC / HTTP JSON| Gateway
     Gateway --> Users
@@ -29,7 +28,6 @@ graph LR
     Gateway --> LLMService
     Gateway --> Secrets
     Gateway --> Apps
-    Gateway --> Expose
 ```
 
 The Console is a static SPA served by its own Kubernetes deployment with no backend.
@@ -64,7 +62,7 @@ The Console displays:
 | `LLMGateway` | `CreateProvider`, `GetProvider`, `ListProviders`, `UpdateProvider`, `DeleteProvider`, `CreateModel`, `GetModel`, `ListModels`, `UpdateModel`, `DeleteModel` | Org owner or cluster admin | LLM Providers, Models |
 | `SecretsGateway` | `CreateSecretProvider`, `GetSecretProvider`, `ListSecretProviders`, `UpdateSecretProvider`, `DeleteSecretProvider`, `CreateSecret`, `GetSecret`, `ListSecrets`, `UpdateSecret`, `DeleteSecret` | Org owner or cluster admin | Secret Providers, Secrets |
 | `AppsGateway` | `CreateApp`, `GetApp`, `GetAppBySlug`, `ListApps`, `UpdateApp`, `DeleteApp`, `InstallApp`, `GetInstallation`, `GetInstallationBySlug`, `ListInstallations`, `UpdateInstallation`, `UninstallApp` | Org owner or cluster admin | Apps (Published Apps, Installed Apps) |
-| `ExposeGateway` | `CreateDevice`, `ListDevices`, `DeleteDevice` | Any authenticated user (own devices) | Devices (User Menu) |
+| `UsersGateway` | `CreateDevice`, `ListDevices`, `DeleteDevice` | Any authenticated user (own devices) | Devices (User Menu) |
 
 ## Deployment
 

--- a/architecture/console.md
+++ b/architecture/console.md
@@ -19,6 +19,7 @@ graph LR
     LLMService[LLM]
     Secrets[Secrets]
     Apps[Apps Service]
+    Expose[Expose Service]
 
     Console -->|ConnectRPC / HTTP JSON| Gateway
     Gateway --> Users
@@ -28,6 +29,7 @@ graph LR
     Gateway --> LLMService
     Gateway --> Secrets
     Gateway --> Apps
+    Gateway --> Expose
 ```
 
 The Console is a static SPA served by its own Kubernetes deployment with no backend.
@@ -62,6 +64,7 @@ The Console displays:
 | `LLMGateway` | `CreateProvider`, `GetProvider`, `ListProviders`, `UpdateProvider`, `DeleteProvider`, `CreateModel`, `GetModel`, `ListModels`, `UpdateModel`, `DeleteModel` | Org owner or cluster admin | LLM Providers, Models |
 | `SecretsGateway` | `CreateSecretProvider`, `GetSecretProvider`, `ListSecretProviders`, `UpdateSecretProvider`, `DeleteSecretProvider`, `CreateSecret`, `GetSecret`, `ListSecrets`, `UpdateSecret`, `DeleteSecret` | Org owner or cluster admin | Secret Providers, Secrets |
 | `AppsGateway` | `CreateApp`, `GetApp`, `GetAppBySlug`, `ListApps`, `UpdateApp`, `DeleteApp`, `InstallApp`, `GetInstallation`, `GetInstallationBySlug`, `ListInstallations`, `UpdateInstallation`, `UninstallApp` | Org owner or cluster admin | Apps (Published Apps, Installed Apps) |
+| `ExposeGateway` | `CreateDevice`, `ListDevices`, `DeleteDevice` | Any authenticated user (own devices) | Devices (User Menu) |
 
 ## Deployment
 

--- a/architecture/expose-service.md
+++ b/architecture/expose-service.md
@@ -4,6 +4,8 @@
 
 The Expose service manages the lifecycle of port exposures — making ports inside agent containers accessible to users over the [OpenZiti](openziti.md) network. When an agent exposes a port, the Expose service creates the required OpenZiti resources (service, policies) so that enrolled user devices can reach the port. When the exposure is removed or the agent stops, the service cleans up all associated resources.
 
+The Expose service runs its own [reconciliation loop](#reconciliation) to converge actual state toward desired state. It is decoupled from the [Agents Orchestrator](agents-orchestrator.md) — it discovers workload lifecycle changes through [Notifications](notifications.md) events and the [Runners](runners.md) service, following the standard platform [pull + notifications](notifications.md#consumer-sync-protocol) pattern.
+
 ## Interface
 
 | Method | Description |
@@ -11,10 +13,6 @@ The Expose service manages the lifecycle of port exposures — making ports insi
 | **AddExposure** | Expose a port on an agent workload. Creates OpenZiti resources and returns the exposure record (including the access URL) |
 | **RemoveExposure** | Un-expose a port on an agent workload. Deletes the OpenZiti resources and the exposure record |
 | **ListExposures** | List active exposures for an agent workload |
-| **RemoveExposuresByWorkload** | Remove all exposures for a workload. Called during workload cleanup |
-| **CreateDevice** | Register a user device. Creates an OpenZiti identity and returns the enrollment JWT |
-| **ListDevices** | List devices for a user |
-| **DeleteDevice** | Delete a device and its OpenZiti identity |
 
 ## Exposure Resource
 
@@ -33,42 +31,35 @@ The Expose service manages the lifecycle of port exposures — making ports insi
 
 The `status` field tracks the provisioning state of OpenZiti resources. See [Provisioning and Cleanup](#provisioning-and-cleanup).
 
-## Device Resource
-
-| Field | Type | Description |
-|-------|------|-------------|
-| `id` | string (UUID) | Unique device identifier |
-| `user_identity_id` | string (UUID) | Owning user's identity ID |
-| `name` | string | User-provided device name |
-| `openziti_identity_id` | string | OpenZiti identity ID for this device |
-| `enrollment_jwt` | string (nullable) | Enrollment JWT. Stored until enrollment completes, then cleared |
-| `status` | enum | `pending`, `enrolled` |
-| `created_at` | timestamp | Creation time |
-
 ## Dependencies
 
 ```mermaid
 graph TB
     subgraph "Expose Service"
         API[gRPC API]
+        Reconciler[Reconciliation Loop]
     end
 
     ZM[Ziti Management] -->|OpenZiti resource lifecycle| API
+    ZM -->|cleanup| Reconciler
     API -->|resolve workload → agent identity| RS[Runners Service]
+    Reconciler -->|query workload status| RS
+    N[Notifications] -->|workload.status_changed| Reconciler
 ```
 
 | Dependency | Usage |
 |-----------|-------|
-| **[Ziti Management](openziti.md)** | Create and delete OpenZiti services, service policies, and device identities |
-| **[Runners](runners.md)** | Resolve workload to agent identity (for Bind policy targeting) |
+| **[Ziti Management](openziti.md)** | Create and delete OpenZiti services and service policies |
+| **[Runners](runners.md)** | Resolve workload to agent identity (for Bind policy targeting). Query workload existence during reconciliation |
+| **[Notifications](notifications.md)** | Subscribe to `workload.status_changed` events for fast reactivity on workload stop |
 
 ## Add Exposure Flow
 
-When an agent calls `agyn expose add <port>`:
+When an agent requests a port exposure via the platform API:
 
 ```mermaid
 sequenceDiagram
-    participant A as Agent (agyn CLI)
+    participant A as Agent
     participant GW as Gateway
     participant ES as Expose Service
     participant RS as Runners Service
@@ -116,12 +107,10 @@ The agent's Ziti sidecar must host the exposed service. When the OpenZiti servic
 |-----|--------|-------------|
 | `CreateExposureResources` | Expose Service | Create an OpenZiti service + Bind policy + Dial policy for a port exposure. Returns all three resource IDs |
 | `DeleteExposureResources` | Expose Service | Delete the OpenZiti service + Bind policy + Dial policy by their IDs |
-| `CreateDeviceIdentity` | Expose Service | Create an OpenZiti identity for a user device with `roleAttributes: ["devices"]` and `enrollment.ott: true`. Returns the identity ID and enrollment JWT |
-| `DeleteDeviceIdentity` | Expose Service | Delete a device's OpenZiti identity |
 
 ## Remove Exposure Flow
 
-When an agent calls `agyn expose remove <port>`, or when a workload is stopped:
+When an agent requests removal of a port exposure via the platform API:
 
 ```mermaid
 sequenceDiagram
@@ -140,29 +129,58 @@ sequenceDiagram
 
 Deletion order: Dial policy → Bind policy → Service. Policies reference the service, so they are deleted first.
 
-## Workload Cleanup
+## Reconciliation
 
-When the [Agents Orchestrator](agents-orchestrator.md) stops a workload, it calls `RemoveExposuresByWorkload` on the Expose service before stopping the workload on the Runner. This removes all active exposures and their OpenZiti resources.
+The Expose service runs its own reconciliation loop — it does not depend on the [Agents Orchestrator](agents-orchestrator.md) to trigger cleanup. It follows the standard platform [pull + notifications](notifications.md#consumer-sync-protocol) pattern.
+
+### Triggers
+
+| Trigger | Source | Latency |
+|---------|--------|---------|
+| `workload.status_changed` event | [Notifications](notifications.md) subscription on `workload:{id}` rooms | Real-time (fast path) |
+| Periodic reconciliation poll | Timer-based | Configurable interval (catch-all) |
+
+On startup, the Expose service subscribes to `workload:{id}` rooms for all workloads that have active exposures. When new exposures are created, the service subscribes to the corresponding workload room. Notifications provide fast reactivity; the periodic poll is the catch-all for missed events.
+
+### Reconciliation Logic
+
+Each reconciliation pass:
+
+1. **Orphaned exposures:** For each `active` exposure, query [Runners](runners.md) to check if the workload still exists. If the workload is gone, transition the exposure to `removing` and delete its OpenZiti resources.
+2. **Failed provisioning:** For each `failed` exposure, attempt to delete any remaining OpenZiti resources via `DeleteExposureResources`. On success, delete the exposure record. On failure, leave for the next pass.
+3. **Stuck removals:** For each `removing` exposure, retry `DeleteExposureResources`. On success, delete the exposure record.
+
+This ensures eventual cleanup of all OpenZiti resources regardless of transient failures or missed events.
+
+### Workload Stop Sequence
+
+When the Orchestrator stops a workload, the Expose service discovers this independently:
 
 ```mermaid
 sequenceDiagram
     participant O as Orchestrator
-    participant ES as Expose Service
     participant R as Runner
     participant RS as Runners Service
+    participant N as Notifications
+    participant ES as Expose Service
     participant ZM as Ziti Management
 
-    O->>ES: RemoveExposuresByWorkload(workload_id)
+    O->>R: StopWorkload(workloadId)
+    R-->>O: OK
+    R->>N: Publish(workload.status_changed, workload:{id})
+    O->>RS: DeleteWorkload(workloadId)
+    O->>ZM: DeleteIdentity(openZitiIdentityId)
+    N-->>ES: workload.status_changed
+    ES->>RS: GetWorkload(workloadId)
+    RS-->>ES: not found
     ES->>ES: List exposures for workload
     loop For each exposure
         ES->>ZM: DeleteExposureResources(...)
         ES->>ES: Delete exposure record
     end
-    ES-->>O: OK
-    O->>R: StopWorkload(workloadId)
-    O->>RS: DeleteWorkload(workloadId)
-    O->>ZM: DeleteIdentity(openZitiIdentityId)
 ```
+
+The Orchestrator and Expose service are fully decoupled. The Orchestrator does not know about exposures. The Expose service reacts to workload lifecycle changes via events and reconciliation.
 
 ## Provisioning and Cleanup
 
@@ -175,7 +193,7 @@ If `CreateExposureResources` fails partway through (e.g., service created but Bi
 1. Ziti Management attempts to delete any resources that were successfully created in the current request.
 2. If cleanup within the same request also fails, Ziti Management returns the IDs of the resources that were created but not cleaned up.
 3. The Expose service stores the exposure record with `status: failed` and the IDs of any created resources.
-4. A background reconciliation loop in the Expose service periodically scans for `failed` exposures and retries cleanup via `DeleteExposureResources`.
+4. The [reconciliation loop](#reconciliation) retries cleanup on the next pass.
 
 ### Removal Failure
 
@@ -183,55 +201,7 @@ If `DeleteExposureResources` fails partway through (e.g., Dial policy deleted bu
 
 1. Ziti Management returns which resources were deleted and which remain.
 2. The Expose service updates the exposure record with the remaining resource IDs and sets `status: failed`.
-3. The background reconciliation loop retries cleanup.
-
-### Reconciliation Loop
-
-The Expose service runs a background loop that handles stuck or failed exposures:
-
-1. Query for exposures with `status: failed` or `status: removing`.
-2. For each, attempt to delete remaining OpenZiti resources via `DeleteExposureResources`.
-3. On success, delete the exposure record.
-4. On failure, leave the record for the next pass.
-
-This ensures eventual cleanup of all OpenZiti resources regardless of transient failures.
-
-## Device Enrollment Flow
-
-```mermaid
-sequenceDiagram
-    participant U as User (Console)
-    participant GW as Gateway
-    participant ES as Expose Service
-    participant ZM as Ziti Management
-    participant ZC as OpenZiti Controller
-
-    U->>GW: CreateDevice(name)
-    GW->>ES: CreateDevice(user_identity_id, name)
-    ES->>ZM: CreateDeviceIdentity(user_identity_id, name, roleAttributes: ["devices"])
-    ZM->>ZC: POST /identities (type: Device, roleAttributes: ["devices"], enrollment.ott)
-    ZC-->>ZM: Identity ID + enrollment JWT
-    ZM-->>ES: (openziti_identity_id, enrollment_jwt)
-    ES->>ES: Store device record (status: pending)
-    ES-->>GW: Device record + enrollment JWT
-    GW-->>U: Device record + enrollment JWT (shown once)
-```
-
-The user copies the JWT and uses it in their Ziti tunnel client. The OpenZiti Controller handles enrollment directly — when the user's tunnel enrolls with the JWT, the Controller issues an x509 certificate. The Expose service does not participate in the enrollment step.
-
-Device status transitions from `pending` to `enrolled` when the Ziti tunnel enrolls. The Expose service queries the OpenZiti Controller (via Ziti Management) to check enrollment status — this can be done on `ListDevices` calls or via a background check.
-
-## Device Identity
-
-| Field | Value |
-|-------|-------|
-| `name` | `device-<deviceId>` |
-| `type` | `Device` |
-| `roleAttributes` | `["devices"]` |
-| `externalId` | `<user_identity_id>` |
-| `enrollment` | `{ "ott": true }` |
-
-The `devices` role attribute is used by Dial policies on exposed services. All enrolled devices can access all exposed services — scoped access control is not implemented in this version.
+3. The [reconciliation loop](#reconciliation) retries cleanup on the next pass.
 
 ## Static Policies
 
@@ -247,15 +217,13 @@ One additional static policy is required at infrastructure provisioning:
 
 | Gateway Proto Service | Methods |
 |----------------------|---------|
-| `ExposeGateway` | `AddExposure`, `RemoveExposure`, `ListExposures`, `CreateDevice`, `ListDevices`, `DeleteDevice` |
+| `ExposeGateway` | `AddExposure`, `RemoveExposure`, `ListExposures` |
 
-`AddExposure`, `RemoveExposure`, and `ListExposures` are called by agents via `agyn` CLI. `CreateDevice`, `ListDevices`, and `DeleteDevice` are called by users via the Console.
-
-The Gateway resolves the agent's `workload_id` from request context for exposure methods. For device methods, the Gateway passes the authenticated user's `identity_id`.
+Called by agents via the platform API. The Gateway resolves the agent's `workload_id` from request context.
 
 ## Data Store
 
-PostgreSQL. The Expose service owns its database with `exposures` and `devices` tables.
+PostgreSQL. The Expose service owns its database with an `exposures` table.
 
 ## Classification
 
@@ -264,4 +232,4 @@ PostgreSQL. The Expose service owns its database with `exposures` and `devices` 
 | **Plane** | Data — on the path for port exposure operations |
 | **API** | gRPC (internal) + Gateway (external via ConnectRPC) |
 | **State** | PostgreSQL |
-| **Dependencies** | Ziti Management, Runners Service |
+| **Dependencies** | Ziti Management, Runners Service, Notifications |

--- a/architecture/expose-service.md
+++ b/architecture/expose-service.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-The Expose service manages the lifecycle of port exposures — making ports inside agent containers accessible to users over the [OpenZiti](openziti.md) network. When an agent exposes a port, the Expose service creates the required OpenZiti resources (service, policies) so that enrolled user devices can reach the port. When the exposure is removed or the agent stops, the service cleans up all associated resources.
+The Expose service manages the lifecycle of port exposures — making ports inside agent containers accessible over the [OpenZiti](openziti.md) network. When an agent exposes a port, the Expose service creates the required OpenZiti resources (service, policies) so that any identity on the OpenZiti network can reach the port. When the exposure is removed or the agent stops, the service cleans up all associated resources.
 
 The Expose service runs its own [reconciliation loop](#reconciliation) to converge actual state toward desired state. It is decoupled from the [Agents Orchestrator](agents-orchestrator.md) — it discovers workload lifecycle changes through [Notifications](notifications.md) events and the [Runners](runners.md) service, following the standard platform [pull + notifications](notifications.md#consumer-sync-protocol) pattern.
 
@@ -72,14 +72,22 @@ sequenceDiagram
     ES->>ES: Store exposure record (status: provisioning)
     ES->>RS: GetWorkload(workload_id)
     RS-->>ES: Workload (agent_id, runner_id, containers)
-    ES->>ZM: CreateExposureResources(exposure_id, port, agent_identity_attribute)
-    ZM->>ZC: POST /services (name: "exposed-<id>", roleAttributes: ["exposed-services"])
+
+    ES->>ZM: CreateService(name: "exposed-<id>", roleAttributes: ["exposed-services"])
+    ZM->>ZC: POST /services
     ZC-->>ZM: Service ID
-    ZM->>ZC: POST /service-policies (Bind, identity: #agent-<agentId>, service: @exposed-<id>)
+    ZM-->>ES: Service ID
+
+    ES->>ZM: CreateServicePolicy(type: Bind, identityRoles: ["#agent-<agentId>"], serviceRoles: ["@exposed-<id>"])
+    ZM->>ZC: POST /service-policies
     ZC-->>ZM: Bind policy ID
-    ZM->>ZC: POST /service-policies (Dial, identity: #devices, service: @exposed-<id>)
+    ZM-->>ES: Bind policy ID
+
+    ES->>ZM: CreateServicePolicy(type: Dial, identityRoles: ["#all"], serviceRoles: ["@exposed-<id>"])
+    ZM->>ZC: POST /service-policies
     ZC-->>ZM: Dial policy ID
-    ZM-->>ES: (service_id, bind_policy_id, dial_policy_id)
+    ZM-->>ES: Dial policy ID
+
     ES->>ES: Update exposure (status: active, store OpenZiti resource IDs)
     ES-->>GW: Exposure record (url: http://exposed-<id>.ziti:<port>)
     GW-->>A: Exposure record
@@ -87,26 +95,21 @@ sequenceDiagram
 
 ### OpenZiti Resources Created
 
-For each port exposure, the Expose service creates three OpenZiti resources via [Ziti Management](openziti.md):
+For each port exposure, the Expose service creates three OpenZiti resources via [Ziti Management](openziti.md), calling each API individually:
 
-| Resource | Details |
-|----------|---------|
-| **Service** | Name: `exposed-<id>`. Role attributes: `["exposed-services"]` |
-| **Bind policy** | Type: Bind. Identity roles: `#agent-<agentId>`. Service roles: `@exposed-<id>`. Grants the agent's Ziti sidecar permission to host this service |
-| **Dial policy** | Type: Dial. Identity roles: `#devices`. Service roles: `@exposed-<id>`. Grants all enrolled devices permission to connect |
+| Resource | Ziti Management RPC | Details |
+|----------|---------------------|---------|
+| **Service** | `CreateService` | Name: `exposed-<id>`. Role attributes: `["exposed-services"]` |
+| **Bind policy** | `CreateServicePolicy` | Type: Bind. Identity roles: `#agent-<agentId>`. Service roles: `@exposed-<id>`. Grants the agent's Ziti sidecar permission to host this service |
+| **Dial policy** | `CreateServicePolicy` | Type: Dial. Identity roles: `#all`. Service roles: `@exposed-<id>`. Grants all identities on the OpenZiti network permission to connect |
 
-The Bind policy uses the `agent-<agentId>` role attribute that is already assigned to agent identities at creation time (see [OpenZiti — Identity Creation Request](openziti.md#identity-creation-request)). The Dial policy uses a `#devices` role attribute assigned to all device identities.
+The Bind policy uses the `agent-<agentId>` role attribute that is already assigned to agent identities at creation time (see [OpenZiti — Identity Creation Request](openziti.md#identity-creation-request)). The Dial policy uses `#all` — any identity connected to the OpenZiti network can access exposed services.
+
+The Expose service manages the orchestration of these three calls. Ziti Management provides generic `CreateService`, `CreateServicePolicy`, `DeleteService`, and `DeleteServicePolicy` RPCs — it has no knowledge of the exposure concept.
 
 ### Agent-Side Hosting
 
 The agent's Ziti sidecar must host the exposed service. When the OpenZiti service and Bind policy are created, the sidecar — which is already enrolled and connected — receives the service update from the OpenZiti Controller. The sidecar is configured to host services matching its role attributes by forwarding traffic to `localhost:<port>` inside the pod. The agent process listens on the port in the shared network namespace.
-
-### Ziti Management API Additions
-
-| RPC | Caller | Description |
-|-----|--------|-------------|
-| `CreateExposureResources` | Expose Service | Create an OpenZiti service + Bind policy + Dial policy for a port exposure. Returns all three resource IDs |
-| `DeleteExposureResources` | Expose Service | Delete the OpenZiti service + Bind policy + Dial policy by their IDs |
 
 ## Remove Exposure Flow
 
@@ -119,9 +122,13 @@ sequenceDiagram
     participant ZC as OpenZiti Controller
 
     ES->>ES: Update exposure (status: removing)
-    ES->>ZM: DeleteExposureResources(service_id, bind_policy_id, dial_policy_id)
+    ES->>ZM: DeleteServicePolicy(dial_policy_id)
     ZM->>ZC: DELETE /service-policies/{dial_policy_id}
+    ZM-->>ES: OK
+    ES->>ZM: DeleteServicePolicy(bind_policy_id)
     ZM->>ZC: DELETE /service-policies/{bind_policy_id}
+    ZM-->>ES: OK
+    ES->>ZM: DeleteService(service_id)
     ZM->>ZC: DELETE /services/{service_id}
     ZM-->>ES: OK
     ES->>ES: Delete exposure record
@@ -147,8 +154,8 @@ On startup, the Expose service subscribes to `workload:{id}` rooms for all workl
 Each reconciliation pass:
 
 1. **Orphaned exposures:** For each `active` exposure, query [Runners](runners.md) to check if the workload still exists. If the workload is gone, transition the exposure to `removing` and delete its OpenZiti resources.
-2. **Failed provisioning:** For each `failed` exposure, attempt to delete any remaining OpenZiti resources via `DeleteExposureResources`. On success, delete the exposure record. On failure, leave for the next pass.
-3. **Stuck removals:** For each `removing` exposure, retry `DeleteExposureResources`. On success, delete the exposure record.
+2. **Failed provisioning:** For each `failed` exposure, attempt to delete any remaining OpenZiti resources via individual `DeleteService` / `DeleteServicePolicy` calls. On success, delete the exposure record. On failure, leave for the next pass.
+3. **Stuck removals:** For each `removing` exposure, retry deletion of remaining OpenZiti resources. On success, delete the exposure record.
 
 This ensures eventual cleanup of all OpenZiti resources regardless of transient failures or missed events.
 
@@ -175,7 +182,9 @@ sequenceDiagram
     RS-->>ES: not found
     ES->>ES: List exposures for workload
     loop For each exposure
-        ES->>ZM: DeleteExposureResources(...)
+        ES->>ZM: DeleteServicePolicy(dial_policy_id)
+        ES->>ZM: DeleteServicePolicy(bind_policy_id)
+        ES->>ZM: DeleteService(service_id)
         ES->>ES: Delete exposure record
     end
 ```
@@ -188,20 +197,18 @@ Port exposure involves creating multiple OpenZiti resources (service, Bind polic
 
 ### Provisioning Failure
 
-If `CreateExposureResources` fails partway through (e.g., service created but Bind policy creation fails):
+If any step in the provisioning sequence fails (e.g., service created but Bind policy creation fails):
 
-1. Ziti Management attempts to delete any resources that were successfully created in the current request.
-2. If cleanup within the same request also fails, Ziti Management returns the IDs of the resources that were created but not cleaned up.
-3. The Expose service stores the exposure record with `status: failed` and the IDs of any created resources.
-4. The [reconciliation loop](#reconciliation) retries cleanup on the next pass.
+1. The Expose service attempts to delete any resources that were successfully created in the current request (in reverse order).
+2. If cleanup also fails, the Expose service stores the exposure record with `status: failed` and the IDs of any created resources.
+3. The [reconciliation loop](#reconciliation) retries cleanup on the next pass.
 
 ### Removal Failure
 
-If `DeleteExposureResources` fails partway through (e.g., Dial policy deleted but service deletion fails):
+If any step in the removal sequence fails (e.g., Dial policy deleted but service deletion fails):
 
-1. Ziti Management returns which resources were deleted and which remain.
-2. The Expose service updates the exposure record with the remaining resource IDs and sets `status: failed`.
-3. The [reconciliation loop](#reconciliation) retries cleanup on the next pass.
+1. The Expose service updates the exposure record with the remaining resource IDs and sets `status: failed`.
+2. The [reconciliation loop](#reconciliation) retries cleanup on the next pass.
 
 ## Static Policies
 

--- a/architecture/expose-service.md
+++ b/architecture/expose-service.md
@@ -1,0 +1,267 @@
+# Expose Service
+
+## Overview
+
+The Expose service manages the lifecycle of port exposures — making ports inside agent containers accessible to users over the [OpenZiti](openziti.md) network. When an agent exposes a port, the Expose service creates the required OpenZiti resources (service, policies) so that enrolled user devices can reach the port. When the exposure is removed or the agent stops, the service cleans up all associated resources.
+
+## Interface
+
+| Method | Description |
+|--------|-------------|
+| **AddExposure** | Expose a port on an agent workload. Creates OpenZiti resources and returns the exposure record (including the access URL) |
+| **RemoveExposure** | Un-expose a port on an agent workload. Deletes the OpenZiti resources and the exposure record |
+| **ListExposures** | List active exposures for an agent workload |
+| **RemoveExposuresByWorkload** | Remove all exposures for a workload. Called during workload cleanup |
+| **CreateDevice** | Register a user device. Creates an OpenZiti identity and returns the enrollment JWT |
+| **ListDevices** | List devices for a user |
+| **DeleteDevice** | Delete a device and its OpenZiti identity |
+
+## Exposure Resource
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `id` | string (UUID) | Unique exposure identifier |
+| `workload_id` | string (UUID) | Workload hosting the exposed port |
+| `agent_id` | string (UUID) | Agent that owns the workload |
+| `port` | integer | Port number inside the agent container |
+| `openziti_service_id` | string | OpenZiti service ID created for this exposure |
+| `openziti_bind_policy_id` | string | OpenZiti Bind service policy ID |
+| `openziti_dial_policy_id` | string | OpenZiti Dial service policy ID |
+| `url` | string | Access URL: `http://exposed-<id>.ziti:<port>` |
+| `status` | enum | `provisioning`, `active`, `failed`, `removing` |
+| `created_at` | timestamp | Creation time |
+
+The `status` field tracks the provisioning state of OpenZiti resources. See [Provisioning and Cleanup](#provisioning-and-cleanup).
+
+## Device Resource
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `id` | string (UUID) | Unique device identifier |
+| `user_identity_id` | string (UUID) | Owning user's identity ID |
+| `name` | string | User-provided device name |
+| `openziti_identity_id` | string | OpenZiti identity ID for this device |
+| `enrollment_jwt` | string (nullable) | Enrollment JWT. Stored until enrollment completes, then cleared |
+| `status` | enum | `pending`, `enrolled` |
+| `created_at` | timestamp | Creation time |
+
+## Dependencies
+
+```mermaid
+graph TB
+    subgraph "Expose Service"
+        API[gRPC API]
+    end
+
+    ZM[Ziti Management] -->|OpenZiti resource lifecycle| API
+    API -->|resolve workload → agent identity| RS[Runners Service]
+```
+
+| Dependency | Usage |
+|-----------|-------|
+| **[Ziti Management](openziti.md)** | Create and delete OpenZiti services, service policies, and device identities |
+| **[Runners](runners.md)** | Resolve workload to agent identity (for Bind policy targeting) |
+
+## Add Exposure Flow
+
+When an agent calls `agyn expose add <port>`:
+
+```mermaid
+sequenceDiagram
+    participant A as Agent (agyn CLI)
+    participant GW as Gateway
+    participant ES as Expose Service
+    participant RS as Runners Service
+    participant ZM as Ziti Management
+    participant ZC as OpenZiti Controller
+
+    A->>GW: AddExposure(workload_id, port)
+    GW->>ES: AddExposure(workload_id, port, agent_id)
+    ES->>ES: Generate exposure ID
+    ES->>ES: Store exposure record (status: provisioning)
+    ES->>RS: GetWorkload(workload_id)
+    RS-->>ES: Workload (agent_id, runner_id, containers)
+    ES->>ZM: CreateExposureResources(exposure_id, port, agent_identity_attribute)
+    ZM->>ZC: POST /services (name: "exposed-<id>", roleAttributes: ["exposed-services"])
+    ZC-->>ZM: Service ID
+    ZM->>ZC: POST /service-policies (Bind, identity: #agent-<agentId>, service: @exposed-<id>)
+    ZC-->>ZM: Bind policy ID
+    ZM->>ZC: POST /service-policies (Dial, identity: #devices, service: @exposed-<id>)
+    ZC-->>ZM: Dial policy ID
+    ZM-->>ES: (service_id, bind_policy_id, dial_policy_id)
+    ES->>ES: Update exposure (status: active, store OpenZiti resource IDs)
+    ES-->>GW: Exposure record (url: http://exposed-<id>.ziti:<port>)
+    GW-->>A: Exposure record
+```
+
+### OpenZiti Resources Created
+
+For each port exposure, the Expose service creates three OpenZiti resources via [Ziti Management](openziti.md):
+
+| Resource | Details |
+|----------|---------|
+| **Service** | Name: `exposed-<id>`. Role attributes: `["exposed-services"]` |
+| **Bind policy** | Type: Bind. Identity roles: `#agent-<agentId>`. Service roles: `@exposed-<id>`. Grants the agent's Ziti sidecar permission to host this service |
+| **Dial policy** | Type: Dial. Identity roles: `#devices`. Service roles: `@exposed-<id>`. Grants all enrolled devices permission to connect |
+
+The Bind policy uses the `agent-<agentId>` role attribute that is already assigned to agent identities at creation time (see [OpenZiti — Identity Creation Request](openziti.md#identity-creation-request)). The Dial policy uses a `#devices` role attribute assigned to all device identities.
+
+### Agent-Side Hosting
+
+The agent's Ziti sidecar must host the exposed service. When the OpenZiti service and Bind policy are created, the sidecar — which is already enrolled and connected — receives the service update from the OpenZiti Controller. The sidecar is configured to host services matching its role attributes by forwarding traffic to `localhost:<port>` inside the pod. The agent process listens on the port in the shared network namespace.
+
+### Ziti Management API Additions
+
+| RPC | Caller | Description |
+|-----|--------|-------------|
+| `CreateExposureResources` | Expose Service | Create an OpenZiti service + Bind policy + Dial policy for a port exposure. Returns all three resource IDs |
+| `DeleteExposureResources` | Expose Service | Delete the OpenZiti service + Bind policy + Dial policy by their IDs |
+| `CreateDeviceIdentity` | Expose Service | Create an OpenZiti identity for a user device with `roleAttributes: ["devices"]` and `enrollment.ott: true`. Returns the identity ID and enrollment JWT |
+| `DeleteDeviceIdentity` | Expose Service | Delete a device's OpenZiti identity |
+
+## Remove Exposure Flow
+
+When an agent calls `agyn expose remove <port>`, or when a workload is stopped:
+
+```mermaid
+sequenceDiagram
+    participant ES as Expose Service
+    participant ZM as Ziti Management
+    participant ZC as OpenZiti Controller
+
+    ES->>ES: Update exposure (status: removing)
+    ES->>ZM: DeleteExposureResources(service_id, bind_policy_id, dial_policy_id)
+    ZM->>ZC: DELETE /service-policies/{dial_policy_id}
+    ZM->>ZC: DELETE /service-policies/{bind_policy_id}
+    ZM->>ZC: DELETE /services/{service_id}
+    ZM-->>ES: OK
+    ES->>ES: Delete exposure record
+```
+
+Deletion order: Dial policy → Bind policy → Service. Policies reference the service, so they are deleted first.
+
+## Workload Cleanup
+
+When the [Agents Orchestrator](agents-orchestrator.md) stops a workload, it calls `RemoveExposuresByWorkload` on the Expose service before stopping the workload on the Runner. This removes all active exposures and their OpenZiti resources.
+
+```mermaid
+sequenceDiagram
+    participant O as Orchestrator
+    participant ES as Expose Service
+    participant R as Runner
+    participant RS as Runners Service
+    participant ZM as Ziti Management
+
+    O->>ES: RemoveExposuresByWorkload(workload_id)
+    ES->>ES: List exposures for workload
+    loop For each exposure
+        ES->>ZM: DeleteExposureResources(...)
+        ES->>ES: Delete exposure record
+    end
+    ES-->>O: OK
+    O->>R: StopWorkload(workloadId)
+    O->>RS: DeleteWorkload(workloadId)
+    O->>ZM: DeleteIdentity(openZitiIdentityId)
+```
+
+## Provisioning and Cleanup
+
+Port exposure involves creating multiple OpenZiti resources (service, Bind policy, Dial policy). If any step fails, the system must not leave orphaned resources.
+
+### Provisioning Failure
+
+If `CreateExposureResources` fails partway through (e.g., service created but Bind policy creation fails):
+
+1. Ziti Management attempts to delete any resources that were successfully created in the current request.
+2. If cleanup within the same request also fails, Ziti Management returns the IDs of the resources that were created but not cleaned up.
+3. The Expose service stores the exposure record with `status: failed` and the IDs of any created resources.
+4. A background reconciliation loop in the Expose service periodically scans for `failed` exposures and retries cleanup via `DeleteExposureResources`.
+
+### Removal Failure
+
+If `DeleteExposureResources` fails partway through (e.g., Dial policy deleted but service deletion fails):
+
+1. Ziti Management returns which resources were deleted and which remain.
+2. The Expose service updates the exposure record with the remaining resource IDs and sets `status: failed`.
+3. The background reconciliation loop retries cleanup.
+
+### Reconciliation Loop
+
+The Expose service runs a background loop that handles stuck or failed exposures:
+
+1. Query for exposures with `status: failed` or `status: removing`.
+2. For each, attempt to delete remaining OpenZiti resources via `DeleteExposureResources`.
+3. On success, delete the exposure record.
+4. On failure, leave the record for the next pass.
+
+This ensures eventual cleanup of all OpenZiti resources regardless of transient failures.
+
+## Device Enrollment Flow
+
+```mermaid
+sequenceDiagram
+    participant U as User (Console)
+    participant GW as Gateway
+    participant ES as Expose Service
+    participant ZM as Ziti Management
+    participant ZC as OpenZiti Controller
+
+    U->>GW: CreateDevice(name)
+    GW->>ES: CreateDevice(user_identity_id, name)
+    ES->>ZM: CreateDeviceIdentity(user_identity_id, name, roleAttributes: ["devices"])
+    ZM->>ZC: POST /identities (type: Device, roleAttributes: ["devices"], enrollment.ott)
+    ZC-->>ZM: Identity ID + enrollment JWT
+    ZM-->>ES: (openziti_identity_id, enrollment_jwt)
+    ES->>ES: Store device record (status: pending)
+    ES-->>GW: Device record + enrollment JWT
+    GW-->>U: Device record + enrollment JWT (shown once)
+```
+
+The user copies the JWT and uses it in their Ziti tunnel client. The OpenZiti Controller handles enrollment directly — when the user's tunnel enrolls with the JWT, the Controller issues an x509 certificate. The Expose service does not participate in the enrollment step.
+
+Device status transitions from `pending` to `enrolled` when the Ziti tunnel enrolls. The Expose service queries the OpenZiti Controller (via Ziti Management) to check enrollment status — this can be done on `ListDevices` calls or via a background check.
+
+## Device Identity
+
+| Field | Value |
+|-------|-------|
+| `name` | `device-<deviceId>` |
+| `type` | `Device` |
+| `roleAttributes` | `["devices"]` |
+| `externalId` | `<user_identity_id>` |
+| `enrollment` | `{ "ott": true }` |
+
+The `devices` role attribute is used by Dial policies on exposed services. All enrolled devices can access all exposed services — scoped access control is not implemented in this version.
+
+## Static Policies
+
+One additional static policy is required at infrastructure provisioning:
+
+| Policy | Type | Identity Roles | Service Roles | Purpose |
+|--------|------|---------------|---------------|---------|
+| `agents-host-exposed` | Host | `#agents` | `#exposed-services` | All agents can host exposed services (traffic forwarded to localhost by sidecar) |
+
+**Note:** The per-exposure Bind policy uses identity role `#agent-<agentId>` to scope hosting to the specific agent. The `agents-host-exposed` Host policy is a broader fallback — it allows the Ziti sidecar to intercept exposed service traffic. The per-exposure Bind policy is the primary access control mechanism.
+
+## Gateway Exposure
+
+| Gateway Proto Service | Methods |
+|----------------------|---------|
+| `ExposeGateway` | `AddExposure`, `RemoveExposure`, `ListExposures`, `CreateDevice`, `ListDevices`, `DeleteDevice` |
+
+`AddExposure`, `RemoveExposure`, and `ListExposures` are called by agents via `agyn` CLI. `CreateDevice`, `ListDevices`, and `DeleteDevice` are called by users via the Console.
+
+The Gateway resolves the agent's `workload_id` from request context for exposure methods. For device methods, the Gateway passes the authenticated user's `identity_id`.
+
+## Data Store
+
+PostgreSQL. The Expose service owns its database with `exposures` and `devices` tables.
+
+## Classification
+
+| Aspect | Detail |
+|--------|--------|
+| **Plane** | Data — on the path for port exposure operations |
+| **API** | gRPC (internal) + Gateway (external via ConnectRPC) |
+| **State** | PostgreSQL |
+| **Dependencies** | Ziti Management, Runners Service |

--- a/architecture/expose-service.md
+++ b/architecture/expose-service.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-The Expose service manages the lifecycle of port exposures — making ports inside agent containers accessible over the [OpenZiti](openziti.md) network. When an agent exposes a port, the Expose service creates the required OpenZiti resources (service, policies) so that any identity on the OpenZiti network can reach the port. When the exposure is removed or the agent stops, the service cleans up all associated resources.
+The Expose service manages the lifecycle of port exposures — making ports inside agent containers accessible over the [OpenZiti](openziti.md) network. When an agent exposes a port, the Expose service creates the required OpenZiti resources (service, configs, policies) so that any identity on the OpenZiti network can reach the port. When the exposure is removed or the agent stops, the service cleans up all associated resources.
 
 The Expose service runs its own [reconciliation loop](#reconciliation) to converge actual state toward desired state. It is decoupled from the [Agents Orchestrator](agents-orchestrator.md) — it discovers workload lifecycle changes through [Notifications](notifications.md) events and the [Runners](runners.md) service, following the standard platform [pull + notifications](notifications.md#consumer-sync-protocol) pattern.
 
@@ -49,7 +49,7 @@ graph TB
 
 | Dependency | Usage |
 |-----------|-------|
-| **[Ziti Management](openziti.md)** | Create and delete OpenZiti services and service policies |
+| **[Ziti Management](openziti.md)** | Create and delete OpenZiti services, configs, and service policies |
 | **[Runners](runners.md)** | Resolve workload to agent identity (for Bind policy targeting). Query workload existence during reconciliation |
 | **[Notifications](notifications.md)** | Subscribe to `workload.status_changed` events for fast reactivity on workload stop |
 
@@ -73,8 +73,10 @@ sequenceDiagram
     ES->>RS: GetWorkload(workload_id)
     RS-->>ES: Workload (agent_id, runner_id, containers)
 
-    ES->>ZM: CreateService(name: "exposed-<id>", roleAttributes: ["exposed-services"])
-    ZM->>ZC: POST /services
+    ES->>ZM: CreateService(name: "exposed-<id>", roleAttributes: ["exposed-services"], configs: [host.v1, intercept.v1])
+    ZM->>ZC: POST /configs (host.v1: localhost:<port>)
+    ZM->>ZC: POST /configs (intercept.v1: exposed-<id>.ziti:<port>)
+    ZM->>ZC: POST /services (with config IDs)
     ZC-->>ZM: Service ID
     ZM-->>ES: Service ID
 
@@ -99,17 +101,49 @@ For each port exposure, the Expose service creates three OpenZiti resources via 
 
 | Resource | Ziti Management RPC | Details |
 |----------|---------------------|---------|
-| **Service** | `CreateService` | Name: `exposed-<id>`. Role attributes: `["exposed-services"]` |
+| **Service** | `CreateService` | Name: `exposed-<id>`. Role attributes: `["exposed-services"]`. Attached configs: `host.v1` and `intercept.v1` (see [Service Configs](#service-configs)) |
 | **Bind policy** | `CreateServicePolicy` | Type: Bind. Identity roles: `#agent-<agentId>`. Service roles: `@exposed-<id>`. Grants the agent's Ziti sidecar permission to host this service |
 | **Dial policy** | `CreateServicePolicy` | Type: Dial. Identity roles: `#all`. Service roles: `@exposed-<id>`. Grants all identities on the OpenZiti network permission to connect |
 
 The Bind policy uses the `agent-<agentId>` role attribute that is already assigned to agent identities at creation time (see [OpenZiti — Identity Creation Request](openziti.md#identity-creation-request)). The Dial policy uses `#all` — any identity connected to the OpenZiti network can access exposed services.
 
-The Expose service manages the orchestration of these three calls. Ziti Management provides generic `CreateService`, `CreateServicePolicy`, `DeleteService`, and `DeleteServicePolicy` RPCs — it has no knowledge of the exposure concept.
+The Expose service manages the orchestration of these calls. Ziti Management provides generic `CreateService`, `CreateServicePolicy`, `DeleteService`, and `DeleteServicePolicy` RPCs — it has no knowledge of the exposure concept.
+
+### Service Configs
+
+Each exposed service is created with two OpenZiti config objects attached. These configs tell tunnelers how to handle traffic for the service — no dynamic configuration file updates are needed.
+
+**`host.v1`** — tells the agent's Ziti sidecar where to forward incoming traffic:
+
+```json
+{
+  "protocol": "tcp",
+  "address": "localhost",
+  "port": <port>
+}
+```
+
+The sidecar forwards connections to `localhost:<port>` inside the pod, where the agent's dev server is listening.
+
+**`intercept.v1`** — tells dialing tunnelers (user devices) which address to intercept:
+
+```json
+{
+  "protocols": ["tcp"],
+  "addresses": ["exposed-<id>.ziti"],
+  "portRanges": [{ "low": <port>, "high": <port> }]
+}
+```
+
+The user's Ziti tunnel resolves `exposed-<id>.ziti` via its built-in DNS and intercepts connections to that address, routing them over the OpenZiti network to the hosting sidecar.
+
+Ziti Management creates both config objects on the OpenZiti Controller (`POST /configs`) and attaches them to the service at creation time. Config objects are deleted when the service is deleted.
 
 ### Agent-Side Hosting
 
-The agent's Ziti sidecar must host the exposed service. When the OpenZiti service and Bind policy are created, the sidecar — which is already enrolled and connected — receives the service update from the OpenZiti Controller. The sidecar is configured to host services matching its role attributes by forwarding traffic to `localhost:<port>` inside the pod. The agent process listens on the port in the shared network namespace.
+The agent pod's Ziti sidecar runs `ziti-edge-tunnel run`, which provides both intercepting (dial-side, for `gateway.ziti`, `llm-proxy.ziti`, etc.) and hosting (bind-side, for exposed services). When the Expose service creates the OpenZiti service with its `host.v1` config and the Bind policy, the sidecar automatically discovers the new service on its next poll of the Controller (default interval: 10 seconds, configurable via `--refresh`). No notification, restart, or configuration file update is needed — the sidecar begins hosting the service as soon as it detects the matching Bind policy and reads the `host.v1` config to learn where to forward traffic (`localhost:<port>`).
+
+The agent process listens on the port in the shared network namespace. The sidecar forwards incoming Ziti connections to `localhost:<port>` inside the pod.
 
 ## Remove Exposure Flow
 
@@ -134,7 +168,7 @@ sequenceDiagram
     ES->>ES: Delete exposure record
 ```
 
-Deletion order: Dial policy → Bind policy → Service. Policies reference the service, so they are deleted first.
+Deletion order: Dial policy → Bind policy → Service. Policies reference the service, so they are deleted first. Deleting the service also deletes its attached config objects.
 
 ## Reconciliation
 

--- a/architecture/gateway.md
+++ b/architecture/gateway.md
@@ -72,7 +72,7 @@ Only methods intended for external use appear in gateway proto services. Interna
 | `FilesGateway` | [Files](media.md) | UploadFile (client-streaming), GetFileMetadata, GetDownloadURL, GetFileContent (server-streaming) |
 | `TracingGateway` | [Tracing](tracing.md) | Ingest, Query |
 | `SecretsGateway` | [Secrets](secrets.md) | ResolveSecretValue, CreateSecretProvider, GetSecretProvider, ListSecretProviders, UpdateSecretProvider, DeleteSecretProvider, CreateSecret, GetSecret, ListSecrets, UpdateSecret, DeleteSecret |
-| `UsersGateway` | [Users](users.md) | GetMe, CreateAPIToken, ListAPITokens, RevokeAPIToken, CreateUser, GetUser, GetUserByOIDCSubject, ListUsers, UpdateUser, DeleteUser |
+| `UsersGateway` | [Users](users.md) | GetMe, CreateAPIToken, ListAPITokens, RevokeAPIToken, CreateUser, GetUser, GetUserByOIDCSubject, ListUsers, UpdateUser, DeleteUser, CreateDevice, ListDevices, DeleteDevice |
 | `RunnersGateway` | [Runners](runners.md) | RegisterRunner, GetRunner, ListRunners, UpdateRunner, DeleteRunner, EnrollRunner, ListWorkloads, ListWorkloadsByThread, GetWorkload, TouchWorkload |
 | `OrganizationsGateway` | [Organizations](organizations.md) | CreateOrganization, GetOrganization, ListOrganizations, UpdateOrganization, DeleteOrganization, CreateMembership, AcceptMembership, DeclineMembership, RemoveMembership, UpdateMembershipRole, ListMembers, ListMyMemberships |
 | `LLMGateway` | [LLM](llm.md) | CreateProvider, GetProvider, ListProviders, UpdateProvider, DeleteProvider, CreateModel, GetModel, ListModels, UpdateModel, DeleteModel |
@@ -189,5 +189,5 @@ The `GetInstallationBySlug` lookup is cached in-memory with a short TTL. Install
 | Gateway Proto Service | Internal Service | Methods |
 |-----------------------|-----------------|---------|
 | `AppsGateway` | [Apps Service](apps-service.md) | CreateApp, GetApp, GetAppBySlug, ListApps, UpdateApp, DeleteApp, InstallApp, GetInstallation, GetInstallationBySlug, ListInstallations, UpdateInstallation, UninstallApp |
-| `ExposeGateway` | [Expose Service](expose-service.md) | AddExposure, RemoveExposure, ListExposures, CreateDevice, ListDevices, DeleteDevice |
+| `ExposeGateway` | [Expose Service](expose-service.md) | AddExposure, RemoveExposure, ListExposures |
 | *(app proxy)* | *per-app via OpenZiti* | *pass-through* |

--- a/architecture/gateway.md
+++ b/architecture/gateway.md
@@ -189,4 +189,5 @@ The `GetInstallationBySlug` lookup is cached in-memory with a short TTL. Install
 | Gateway Proto Service | Internal Service | Methods |
 |-----------------------|-----------------|---------|
 | `AppsGateway` | [Apps Service](apps-service.md) | CreateApp, GetApp, GetAppBySlug, ListApps, UpdateApp, DeleteApp, InstallApp, GetInstallation, GetInstallationBySlug, ListInstallations, UpdateInstallation, UninstallApp |
+| `ExposeGateway` | [Expose Service](expose-service.md) | AddExposure, RemoveExposure, ListExposures, CreateDevice, ListDevices, DeleteDevice |
 | *(app proxy)* | *per-app via OpenZiti* | *pass-through* |

--- a/architecture/openziti.md
+++ b/architecture/openziti.md
@@ -61,7 +61,7 @@ All interactions with the OpenZiti Controller's Edge Management API are encapsul
 | `DeleteRunnerIdentity` | Runners Service | Delete a runner's OpenZiti identity, service, and platform mapping |
 | `CreateAppIdentity` | Apps Service | Create and enroll an OpenZiti identity for an app, return enrolled identity (cert + key). If a previous identity exists for this app, deletes it first |
 | `DeleteAppIdentity` | Apps Service | Delete an app's OpenZiti identity, service, and platform mapping |
-| `CreateService` | Runners Service, Apps Service, Expose Service | Create an OpenZiti service (per-runner, per-app, or per-exposure) |
+| `CreateService` | Runners Service, Apps Service, Expose Service | Create an OpenZiti service (per-runner, per-app, or per-exposure). Optionally creates and attaches config objects (`host.v1`, `intercept.v1`) |
 | `DeleteIdentity` | Orchestrator | Delete an OpenZiti identity and its platform mapping |
 | `ListManagedIdentities` | Orchestrator | List all identities managed by the platform (for reconciliation) |
 | `ResolveIdentity` | Gateway | Map an OpenZiti identity ID to platform identity (identity_id, identity_type) |
@@ -82,8 +82,9 @@ All interactions with the OpenZiti Controller's Edge Management API are encapsul
 | Delete identity | `DELETE /edge/management/v1/identities/{id}` | Agent stop, identity cleanup, lease GC, runner/app re-enrollment (previous identity cleanup) |
 | List identities | `GET /edge/management/v1/identities?filter=...` | Reconciliation, lease GC |
 | Update role attributes | `PATCH /edge/management/v1/identities/{id}` | Future: dynamic policy changes |
-| Create service | `POST /edge/management/v1/services` | Runner registration, app registration, port exposure |
-| Delete service | `DELETE /edge/management/v1/services/{id}` | Runner deletion, app deletion, port exposure cleanup |
+| Create config | `POST /edge/management/v1/configs` | Port exposure (`host.v1` and `intercept.v1` configs per exposed service) |
+| Create service | `POST /edge/management/v1/services` | Runner registration, app registration, port exposure (with attached configs) |
+| Delete service | `DELETE /edge/management/v1/services/{id}` | Runner deletion, app deletion, port exposure cleanup (also deletes attached configs) |
 | Create service policy | `POST /edge/management/v1/service-policies` | Port exposure (per-exposure Bind and Dial policies) |
 | Delete service policy | `DELETE /edge/management/v1/service-policies/{id}` | Port exposure cleanup |
 
@@ -501,7 +502,7 @@ This follows the same pattern as [runner enrollment](#runner-provisioning). The 
 |-----|--------|-------------|
 | `CreateAppIdentity` | Apps Service | Create and enroll an OpenZiti identity for an app, return enrolled identity (cert + key). If a previous identity exists for this app, deletes it first |
 | `DeleteAppIdentity` | Apps Service | Delete an app's OpenZiti identity, service, and platform mapping |
-| `CreateService` | Runners Service, Apps Service, Expose Service | Create an OpenZiti service (per-runner, per-app, or per-exposure) |
+| `CreateService` | Runners Service, Apps Service, Expose Service | Create an OpenZiti service (per-runner, per-app, or per-exposure). Optionally creates and attaches config objects (`host.v1`, `intercept.v1`) |
 
 This follows the same pattern as runner enrollment — Ziti Management creates the identity, enrolls it on behalf of the caller, and returns the enrolled credentials.
 

--- a/architecture/openziti.md
+++ b/architecture/openziti.md
@@ -67,6 +67,10 @@ All interactions with the OpenZiti Controller's Edge Management API are encapsul
 | `ResolveIdentity` | Gateway | Map an OpenZiti identity ID to platform identity (identity_id, identity_type) |
 | `RequestServiceIdentity` | Orchestrator, Gateway | Create and enroll an OpenZiti identity for the calling service, return enrolled identity (cert + key) |
 | `ExtendIdentityLease` | Orchestrator, Gateway | Extend the lease on a service identity |
+| `CreateExposureResources` | Expose Service | Create an OpenZiti service + Bind policy + Dial policy for a port exposure. Returns all three resource IDs |
+| `DeleteExposureResources` | Expose Service | Delete the OpenZiti service + Bind policy + Dial policy by their IDs |
+| `CreateDeviceIdentity` | Expose Service | Create an OpenZiti identity for a user device with `roleAttributes: ["devices"]`, return identity ID + enrollment JWT |
+| `DeleteDeviceIdentity` | Expose Service | Delete a device's OpenZiti identity |
 
 ### OpenZiti Controller Operations
 
@@ -231,8 +235,9 @@ OpenZiti uses an ABAC (Attribute-Based Access Control) model. Service policies m
 | App | `["apps"]` |
 | LLM Proxy | `["llm-proxy-hosts"]` |
 | Tracing | `["tracing-hosts"]` |
+| Device (user) | `["devices"]` |
 
-The `agent-<agentId>` attribute is assigned at creation time for future use in per-agent policies. It has no effect until matching service policies are created.
+The `agent-<agentId>` attribute is assigned at creation time and used by per-exposure Bind policies (see [Expose Service](expose-service.md)) to scope hosting to the specific agent. The `devices` attribute is assigned to user device identities enrolled via the Console.
 
 ### Static Policies
 
@@ -251,17 +256,20 @@ Defined once at infrastructure provisioning (Terraform / bootstrap scripts). The
 | `apps-dial-gateway` | Dial | `#apps` | `@gateway` | Apps can reach Gateway |
 | `apps-bind` | Bind | `#apps` | `#app-services` | Apps host their own services |
 | `gateway-dial-apps` | Dial | `#gateway-hosts` | `#app-services` | Gateway can reach apps |
+| `agents-host-exposed` | Host | `#agents` | `#exposed-services` | Agent sidecars can host exposed services (traffic forwarded to localhost) |
 
 Edge router policies: `#all` identities → `#all` edge routers (no router-level segmentation needed).
 
 Static policies, services, and edge router policies are provisioned by Terraform at bootstrap. Identity provisioning is handled separately via [self-enrollment](#service-identity-self-enrollment) or [service token enrollment](#runner-provisioning) — policies match identities by role attributes, not by specific identity references.
 
-### Dynamic Policies (Future)
+### Dynamic Policies
 
-The static policies above are sufficient for the current architecture. Future capabilities will require dynamic, per-agent or per-user policies managed at runtime by Ziti Management:
+The [Expose Service](expose-service.md) creates per-exposure OpenZiti service policies at runtime when an agent exposes a port. These policies are dynamic — created and deleted with each exposure lifecycle. See [Expose Service — Add Exposure Flow](expose-service.md#add-exposure-flow) for the full flow.
 
-- **User-to-agent direct connection** — A user enrolls their machine via a CLI tool and connects directly to a specific agent over OpenZiti. Requires creating a per-agent service and scoped Dial/Bind policies at runtime.
-- **Agent-to-agent private networking** — An agent exposes a port that only specific other agents can connect to. Requires creating a per-share service and scoped Dial/Bind policies at runtime.
+| Policy | Type | Identity Roles | Service Roles | Lifecycle |
+|--------|------|---------------|---------------|-----------|
+| Per-exposure Bind | Bind | `#agent-<agentId>` | `@exposed-<id>` | Created on `AddExposure`, deleted on `RemoveExposure` or workload stop |
+| Per-exposure Dial | Dial | `#devices` | `@exposed-<id>` | Created on `AddExposure`, deleted on `RemoveExposure` or workload stop |
 
 OpenZiti supports this natively:
 
@@ -269,7 +277,11 @@ OpenZiti supports this natively:
 - **Policy changes take effect immediately.** New service policies grant (or revoke) access for matching identities in real time.
 - **Revocation closes live connections.** Removing a policy tears down existing connections, not just prevents new ones.
 
-These capabilities mean dynamic policies can be applied to already-running agents without restart. The Ziti Management service API will be extended with RPCs for port sharing and user enrollment when these features are implemented.
+These capabilities mean dynamic policies can be applied to already-running agents without restart.
+
+#### Future: Agent-to-Agent Private Networking
+
+Agent-to-agent private networking (an agent exposes a port that only specific other agents can connect to) is not yet designed. It will follow the same pattern — dynamic services and policies managed by the Expose Service or a similar mechanism.
 
 ## Gateway Identity Extraction
 
@@ -423,6 +435,7 @@ The Gateway routes agent requests to internal services (Threads, Files, etc.) vi
 | Gateway | Ephemeral (per pod) | Self-enrollment via Ziti Management | — (binds `gateway` service) |
 | LLM Proxy | Ephemeral (per pod) | Self-enrollment via Ziti Management | — (binds `llm-proxy` service) |
 | Tracing | Ephemeral (per pod) | Self-enrollment via Ziti Management | — (binds `tracing` service) |
+| Device (user) | Persistent (enrolled via JWT from Console) | User creates device in Console → Expose Service via Ziti Management | Exposed services (dial) |
 
 ## App Identity Lifecycle
 
@@ -509,9 +522,11 @@ Each app binds its own OpenZiti service (named `app-{slug}`). The service is cre
 | Orchestrator | `["orchestrators"]` |
 | App | `["apps"]` |
 | Tracing | `["tracing-hosts"]` |
+| Device (user) | `["devices"]` |
 
 ### Updated Identities Summary
 
 | Identity | Lifecycle | Provisioning | Calls via OpenZiti |
 |----------|-----------|--------------|--------------------|
 | App | Persistent (enrolled via service token) | Apps Service via Ziti Management | Gateway (dial) + own service (bind) |
+| Device (user) | Persistent (enrolled via JWT from Console) | Expose Service via Ziti Management | Exposed services (dial) |

--- a/architecture/openziti.md
+++ b/architecture/openziti.md
@@ -37,7 +37,7 @@ All interactions with the OpenZiti Controller's Edge Management API are encapsul
 | Aspect | Detail |
 |--------|--------|
 | **Plane** | Data — executes operations it is told to perform; runs identity lease GC |
-| **Consumers** | Agents Orchestrator (agent identity lifecycle), Gateway (identity resolution), Orchestrator / Gateway (service identity self-enrollment), Runners Service (runner enrollment), Apps Service (app enrollment) |
+| **Consumers** | Agents Orchestrator (agent identity lifecycle), Gateway (identity resolution), Orchestrator / Gateway (service identity self-enrollment), Runners Service (runner enrollment), Apps Service (app enrollment), Expose Service (port exposure resources), Users Service (device identities) |
 | **External dependency** | OpenZiti Edge Management API (`/edge/management/v1/`) via the generated Go client (`openziti/edge-api`, package `rest_management_api_client`) |
 | **Access to Controller** | Via Istio (in-cluster) — avoids circular dependency of using OpenZiti to manage OpenZiti |
 | **Authentication** | Certificate-based auth using a long-lived infrastructure credential provisioned at deployment |
@@ -61,14 +61,15 @@ All interactions with the OpenZiti Controller's Edge Management API are encapsul
 | `DeleteRunnerIdentity` | Runners Service | Delete a runner's OpenZiti identity, service, and platform mapping |
 | `CreateAppIdentity` | Apps Service | Create and enroll an OpenZiti identity for an app, return enrolled identity (cert + key). If a previous identity exists for this app, deletes it first |
 | `DeleteAppIdentity` | Apps Service | Delete an app's OpenZiti identity, service, and platform mapping |
-| `CreateService` | Runners Service, Apps Service | Create a per-runner or per-app OpenZiti service |
+| `CreateService` | Runners Service, Apps Service, Expose Service | Create an OpenZiti service (per-runner, per-app, or per-exposure) |
 | `DeleteIdentity` | Orchestrator | Delete an OpenZiti identity and its platform mapping |
 | `ListManagedIdentities` | Orchestrator | List all identities managed by the platform (for reconciliation) |
 | `ResolveIdentity` | Gateway | Map an OpenZiti identity ID to platform identity (identity_id, identity_type) |
 | `RequestServiceIdentity` | Orchestrator, Gateway | Create and enroll an OpenZiti identity for the calling service, return enrolled identity (cert + key) |
 | `ExtendIdentityLease` | Orchestrator, Gateway | Extend the lease on a service identity |
-| `CreateExposureResources` | Expose Service | Create an OpenZiti service + Bind policy + Dial policy for a port exposure. Returns all three resource IDs |
-| `DeleteExposureResources` | Expose Service | Delete the OpenZiti service + Bind policy + Dial policy by their IDs |
+| `CreateServicePolicy` | Expose Service | Create a single OpenZiti service policy (Bind or Dial). Returns the policy ID |
+| `DeleteServicePolicy` | Expose Service | Delete an OpenZiti service policy by ID |
+| `DeleteService` | Expose Service | Delete an OpenZiti service by ID |
 | `CreateDeviceIdentity` | Users Service | Create an OpenZiti identity for a user device with `roleAttributes: ["devices"]`, return identity ID + enrollment JWT |
 | `DeleteDeviceIdentity` | Users Service | Delete a device's OpenZiti identity |
 
@@ -81,10 +82,10 @@ All interactions with the OpenZiti Controller's Edge Management API are encapsul
 | Delete identity | `DELETE /edge/management/v1/identities/{id}` | Agent stop, identity cleanup, lease GC, runner/app re-enrollment (previous identity cleanup) |
 | List identities | `GET /edge/management/v1/identities?filter=...` | Reconciliation, lease GC |
 | Update role attributes | `PATCH /edge/management/v1/identities/{id}` | Future: dynamic policy changes |
-| Create service | `POST /edge/management/v1/services` | Runner registration, app registration |
-| Delete service | `DELETE /edge/management/v1/services/{id}` | Runner deletion, app deletion |
-| Create service policy | `POST /edge/management/v1/service-policies` | Future: dynamic access grants |
-| Delete service / policy | `DELETE /edge/management/v1/{type}/{id}` | Future: revoke dynamic access |
+| Create service | `POST /edge/management/v1/services` | Runner registration, app registration, port exposure |
+| Delete service | `DELETE /edge/management/v1/services/{id}` | Runner deletion, app deletion, port exposure cleanup |
+| Create service policy | `POST /edge/management/v1/service-policies` | Port exposure (per-exposure Bind and Dial policies) |
+| Delete service policy | `DELETE /edge/management/v1/service-policies/{id}` | Port exposure cleanup |
 
 ### Identity Lease GC
 
@@ -269,7 +270,7 @@ The [Expose Service](expose-service.md) creates per-exposure OpenZiti service po
 | Policy | Type | Identity Roles | Service Roles | Lifecycle |
 |--------|------|---------------|---------------|-----------|
 | Per-exposure Bind | Bind | `#agent-<agentId>` | `@exposed-<id>` | Created on `AddExposure`, deleted on `RemoveExposure` or workload stop |
-| Per-exposure Dial | Dial | `#devices` | `@exposed-<id>` | Created on `AddExposure`, deleted on `RemoveExposure` or workload stop |
+| Per-exposure Dial | Dial | `#all` | `@exposed-<id>` | Created on `AddExposure`, deleted on `RemoveExposure` or workload stop |
 
 OpenZiti supports this natively:
 
@@ -435,7 +436,7 @@ The Gateway routes agent requests to internal services (Threads, Files, etc.) vi
 | Gateway | Ephemeral (per pod) | Self-enrollment via Ziti Management | — (binds `gateway` service) |
 | LLM Proxy | Ephemeral (per pod) | Self-enrollment via Ziti Management | — (binds `llm-proxy` service) |
 | Tracing | Ephemeral (per pod) | Self-enrollment via Ziti Management | — (binds `tracing` service) |
-| Device (user) | Persistent (enrolled via JWT from Console) | User creates device in Console → Expose Service via Ziti Management | Exposed services (dial) |
+| Device (user) | Persistent (enrolled via JWT from Console) | User creates device in Console → Users Service via Ziti Management | Exposed services (dial) |
 
 ## App Identity Lifecycle
 
@@ -500,7 +501,7 @@ This follows the same pattern as [runner enrollment](#runner-provisioning). The 
 |-----|--------|-------------|
 | `CreateAppIdentity` | Apps Service | Create and enroll an OpenZiti identity for an app, return enrolled identity (cert + key). If a previous identity exists for this app, deletes it first |
 | `DeleteAppIdentity` | Apps Service | Delete an app's OpenZiti identity, service, and platform mapping |
-| `CreateService` | Runners Service, Apps Service | Create a per-runner or per-app OpenZiti service |
+| `CreateService` | Runners Service, Apps Service, Expose Service | Create an OpenZiti service (per-runner, per-app, or per-exposure) |
 
 This follows the same pattern as runner enrollment — Ziti Management creates the identity, enrolls it on behalf of the caller, and returns the enrolled credentials.
 
@@ -529,4 +530,4 @@ Each app binds its own OpenZiti service (named `app-{slug}`). The service is cre
 | Identity | Lifecycle | Provisioning | Calls via OpenZiti |
 |----------|-----------|--------------|--------------------|
 | App | Persistent (enrolled via service token) | Apps Service via Ziti Management | Gateway (dial) + own service (bind) |
-| Device (user) | Persistent (enrolled via JWT from Console) | Expose Service via Ziti Management | Exposed services (dial) |
+| Device (user) | Persistent (enrolled via JWT from Console) | Users Service via Ziti Management | Exposed services (dial) |

--- a/architecture/openziti.md
+++ b/architecture/openziti.md
@@ -69,8 +69,8 @@ All interactions with the OpenZiti Controller's Edge Management API are encapsul
 | `ExtendIdentityLease` | Orchestrator, Gateway | Extend the lease on a service identity |
 | `CreateExposureResources` | Expose Service | Create an OpenZiti service + Bind policy + Dial policy for a port exposure. Returns all three resource IDs |
 | `DeleteExposureResources` | Expose Service | Delete the OpenZiti service + Bind policy + Dial policy by their IDs |
-| `CreateDeviceIdentity` | Expose Service | Create an OpenZiti identity for a user device with `roleAttributes: ["devices"]`, return identity ID + enrollment JWT |
-| `DeleteDeviceIdentity` | Expose Service | Delete a device's OpenZiti identity |
+| `CreateDeviceIdentity` | Users Service | Create an OpenZiti identity for a user device with `roleAttributes: ["devices"]`, return identity ID + enrollment JWT |
+| `DeleteDeviceIdentity` | Users Service | Delete a device's OpenZiti identity |
 
 ### OpenZiti Controller Operations
 

--- a/architecture/users.md
+++ b/architecture/users.md
@@ -177,12 +177,82 @@ Initial profile fields (name, email, picture) are populated from the IdP UserInf
 |----------|-------|
 | **Gateway** | Resolve OIDC subject → `identity_id` on every request (`ResolveUser`). Provision new users on first login (`ProvisionUser`). Resolve [API tokens](api-tokens.md) → `identity_id` (`ResolveAPIToken`) |
 | **Chat** | Resolve user profiles for message display (sender name, photo) |
-| **[Console](console.md)** | Current user context via `GetMe` (profile, cluster admin status). User management (CRUD) for cluster admins |
+| **[Console](console.md)** | Current user context via `GetMe` (profile, cluster admin status). User management (CRUD) for cluster admins. Device management (create, list, delete) |
 | **[Terraform Provider](operations/terraform-provider.md)** | `agyn_user` resource — create and manage users as code. `data.agyn_user` data source — look up existing users by OIDC subject |
+
+## Devices
+
+Users register devices to access [exposed agent ports](expose-service.md) from their machines. Device management is part of the Users service because devices are user-scoped identity resources — similar to API tokens.
+
+### Device Model
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `id` | string (UUID) | Unique device identifier |
+| `user_identity_id` | string (UUID) | Owning user's identity ID |
+| `name` | string | User-provided device name |
+| `openziti_identity_id` | string | OpenZiti identity ID for this device |
+| `enrollment_jwt` | string (nullable) | Enrollment JWT. Stored until enrollment completes, then cleared |
+| `status` | enum | `pending` (JWT generated, not yet enrolled) or `enrolled` |
+| `created_at` | timestamp | Creation time |
+
+### Device Interface
+
+| Method | Description |
+|--------|-------------|
+| **CreateDevice** | Register a device. Creates an OpenZiti identity via [Ziti Management](openziti.md) and returns the device record with enrollment JWT |
+| **ListDevices** | List devices for the calling user |
+| **DeleteDevice** | Delete a device and its OpenZiti identity. Caller must own the device |
+
+### Device Enrollment Flow
+
+```mermaid
+sequenceDiagram
+    participant U as User (Console)
+    participant GW as Gateway
+    participant US as Users Service
+    participant ZM as Ziti Management
+    participant ZC as OpenZiti Controller
+
+    U->>GW: CreateDevice(name)
+    GW->>US: CreateDevice(user_identity_id, name)
+    US->>ZM: CreateDeviceIdentity(user_identity_id, name, roleAttributes: [devices])
+    ZM->>ZC: POST /identities (type: Device, roleAttributes: [devices], enrollment.ott)
+    ZC-->>ZM: Identity ID + enrollment JWT
+    ZM-->>US: (openziti_identity_id, enrollment_jwt)
+    US->>US: Store device record (status: pending)
+    US-->>GW: Device record + enrollment JWT
+    GW-->>U: Device record + enrollment JWT (shown once)
+```
+
+The user copies the JWT and uses it in their Ziti tunnel client (Ziti Desktop Edge or `ziti-edge-tunnel`). The OpenZiti Controller handles enrollment directly — when the user's tunnel enrolls with the JWT, the Controller issues an x509 certificate. The Users service does not participate in the enrollment step.
+
+Device status transitions from `pending` to `enrolled` when the Ziti tunnel enrolls. The Users service queries the OpenZiti Controller (via Ziti Management) to check enrollment status — this can be done on `ListDevices` calls or via a background check.
+
+### Device OpenZiti Identity
+
+| Field | Value |
+|-------|-------|
+| `name` | `device-<deviceId>` |
+| `type` | `Device` |
+| `roleAttributes` | `[devices]` |
+| `externalId` | `<user_identity_id>` |
+| `enrollment` | `{ ott: true }` |
+
+The `devices` role attribute is used by Dial policies on exposed services. All enrolled devices can access all exposed services — scoped access control is not implemented in this version.
+
+The enrollment JWT is shown once at creation time and cannot be retrieved again. If the user loses the JWT before enrolling, they must delete the device and create a new one.
+
+### Ziti Management API Additions
+
+| RPC | Caller | Description |
+|-----|--------|-------------|
+| `CreateDeviceIdentity` | Users Service | Create an OpenZiti identity for a user device with `roleAttributes: [devices]` and `enrollment.ott: true`. Returns the identity ID and enrollment JWT |
+| `DeleteDeviceIdentity` | Users Service | Delete a device's OpenZiti identity |
 
 ## Data Store
 
-PostgreSQL. System-wide `users` and `user_api_tokens` tables. See [API Tokens](api-tokens.md) for the token model.
+PostgreSQL. System-wide `users`, `user_api_tokens`, and `user_devices` tables. See [API Tokens](api-tokens.md) for the token model.
 
 ## Classification
 

--- a/changes/2025-07-25-port-exposure.md
+++ b/changes/2025-07-25-port-exposure.md
@@ -6,6 +6,7 @@
 
 - [Product: Port Exposure](../product/port-exposure/port-exposure.md)
 - [Architecture: Expose Service](../architecture/expose-service.md)
+- [Architecture: Users (Devices)](../architecture/users.md#devices)
 - [Architecture: OpenZiti Integration](../architecture/openziti.md)
 - [Architecture: Console](../architecture/console.md)
 - [Product: Console](../product/console/console.md)
@@ -14,13 +15,15 @@
 
 Port exposure does not exist yet. The following are not implemented:
 
-- Expose service (`agynio/expose`)
+- Expose service (`agynio/expose`) with own reconciliation loop
 - Expose service proto definitions in `agynio/api`
-- Ziti Management: `CreateExposureResources`, `DeleteExposureResources`, `CreateDeviceIdentity`, `DeleteDeviceIdentity` RPCs
-- Gateway: `ExposeGateway` proto service
+- Ziti Management: `CreateExposureResources`, `DeleteExposureResources` RPCs
+- Gateway: `ExposeGateway` proto service (`AddExposure`, `RemoveExposure`, `ListExposures`)
 - `agyn` CLI: `agyn expose add <port>`, `agyn expose remove <port>`, `agyn expose list`
+- Users service: `CreateDevice`, `ListDevices`, `DeleteDevice` methods and `user_devices` table
+- Ziti Management: `CreateDeviceIdentity`, `DeleteDeviceIdentity` RPCs
+- Gateway: extended `UsersGateway` (`CreateDevice`, `ListDevices`, `DeleteDevice`)
 - Console: Devices section in user menu
-- Agents Orchestrator: call `RemoveExposuresByWorkload` during workload stop flow
 - Ziti sidecar: configuration to host exposed services (forward to localhost)
 - OpenZiti static policy: `agents-host-exposed`
 
@@ -29,10 +32,12 @@ Port exposure does not exist yet. The following are not implemented:
 - Agent can expose a port via `agyn expose add <port>` and receive an access URL.
 - Agent can un-expose a port via `agyn expose remove <port>`.
 - User can enroll a device via Console and access the exposed URL from their browser.
-- All OpenZiti resources are cleaned up when the agent workload stops.
+- All OpenZiti resources are cleaned up when the agent workload stops (via Expose service reconciliation).
 - Failed or partial provisioning is eventually cleaned up by the reconciliation loop.
 
 ## Notes
 
+- The Expose service is decoupled from the Agents Orchestrator — it discovers workload lifecycle changes via Notifications events and its own reconciliation loop.
+- Device management lives in the Users service (user-scoped identity, similar to API tokens).
 - Device enrollment uses the OpenZiti one-time-token (OTT) flow. The user's Ziti tunnel client handles enrollment directly with the OpenZiti Controller.
 - Access control for exposed ports is broad (all enrolled devices can access all exposed services). Scoped access control is deferred.

--- a/changes/2025-07-25-port-exposure.md
+++ b/changes/2025-07-25-port-exposure.md
@@ -17,7 +17,7 @@ Port exposure does not exist yet. The following are not implemented:
 
 - Expose service (`agynio/expose`) with own reconciliation loop
 - Expose service proto definitions in `agynio/api`
-- Ziti Management: `CreateExposureResources`, `DeleteExposureResources` RPCs
+- Ziti Management: `CreateServicePolicy`, `DeleteServicePolicy`, `DeleteService` RPCs
 - Gateway: `ExposeGateway` proto service (`AddExposure`, `RemoveExposure`, `ListExposures`)
 - `agyn` CLI: `agyn expose add <port>`, `agyn expose remove <port>`, `agyn expose list`
 - Users service: `CreateDevice`, `ListDevices`, `DeleteDevice` methods and `user_devices` table
@@ -32,6 +32,7 @@ Port exposure does not exist yet. The following are not implemented:
 - Agent can expose a port via `agyn expose add <port>` and receive an access URL.
 - Agent can un-expose a port via `agyn expose remove <port>`.
 - User can enroll a device via Console and access the exposed URL from their browser.
+- Any identity on the OpenZiti network can access exposed services.
 - All OpenZiti resources are cleaned up when the agent workload stops (via Expose service reconciliation).
 - Failed or partial provisioning is eventually cleaned up by the reconciliation loop.
 
@@ -40,4 +41,6 @@ Port exposure does not exist yet. The following are not implemented:
 - The Expose service is decoupled from the Agents Orchestrator — it discovers workload lifecycle changes via Notifications events and its own reconciliation loop.
 - Device management lives in the Users service (user-scoped identity, similar to API tokens).
 - Device enrollment uses the OpenZiti one-time-token (OTT) flow. The user's Ziti tunnel client handles enrollment directly with the OpenZiti Controller.
-- Access control for exposed ports is broad (all enrolled devices can access all exposed services). Scoped access control is deferred.
+- Access control for exposed ports is broad — all identities on the OpenZiti network can access all exposed services (Dial policy uses `#all`).
+- Ziti Management provides generic service and policy RPCs (`CreateService`, `CreateServicePolicy`, `DeleteService`, `DeleteServicePolicy`). The Expose service orchestrates creating the three OpenZiti resources (service, Bind policy, Dial policy) per exposure.
+- The platform does not automatically share the exposure link — the agent decides when and how to share the URL with the user.

--- a/changes/2025-07-25-port-exposure.md
+++ b/changes/2025-07-25-port-exposure.md
@@ -24,7 +24,7 @@ Port exposure does not exist yet. The following are not implemented:
 - Ziti Management: `CreateDeviceIdentity`, `DeleteDeviceIdentity` RPCs
 - Gateway: extended `UsersGateway` (`CreateDevice`, `ListDevices`, `DeleteDevice`)
 - Console: Devices section in user menu
-- Ziti sidecar: configuration to host exposed services (forward to localhost)
+- Ziti sidecar: `host.v1` and `intercept.v1` configs per exposed service (created by Ziti Management, auto-discovered by sidecar)
 - OpenZiti static policy: `agents-host-exposed`
 
 ## Acceptance Signal

--- a/changes/2025-07-25-port-exposure.md
+++ b/changes/2025-07-25-port-exposure.md
@@ -1,0 +1,38 @@
+# Port Exposure — User Access to Agent Ports
+
+**Date:** 2025-07-25
+
+## Target
+
+- [Product: Port Exposure](../product/port-exposure/port-exposure.md)
+- [Architecture: Expose Service](../architecture/expose-service.md)
+- [Architecture: OpenZiti Integration](../architecture/openziti.md)
+- [Architecture: Console](../architecture/console.md)
+- [Product: Console](../product/console/console.md)
+
+## Delta
+
+Port exposure does not exist yet. The following are not implemented:
+
+- Expose service (`agynio/expose`)
+- Expose service proto definitions in `agynio/api`
+- Ziti Management: `CreateExposureResources`, `DeleteExposureResources`, `CreateDeviceIdentity`, `DeleteDeviceIdentity` RPCs
+- Gateway: `ExposeGateway` proto service
+- `agyn` CLI: `agyn expose add <port>`, `agyn expose remove <port>`, `agyn expose list`
+- Console: Devices section in user menu
+- Agents Orchestrator: call `RemoveExposuresByWorkload` during workload stop flow
+- Ziti sidecar: configuration to host exposed services (forward to localhost)
+- OpenZiti static policy: `agents-host-exposed`
+
+## Acceptance Signal
+
+- Agent can expose a port via `agyn expose add <port>` and receive an access URL.
+- Agent can un-expose a port via `agyn expose remove <port>`.
+- User can enroll a device via Console and access the exposed URL from their browser.
+- All OpenZiti resources are cleaned up when the agent workload stops.
+- Failed or partial provisioning is eventually cleaned up by the reconciliation loop.
+
+## Notes
+
+- Device enrollment uses the OpenZiti one-time-token (OTT) flow. The user's Ziti tunnel client handles enrollment directly with the OpenZiti Controller.
+- Access control for exposed ports is broad (all enrolled devices can access all exposed services). Scoped access control is deferred.

--- a/maps/product-to-architecture.md
+++ b/maps/product-to-architecture.md
@@ -37,6 +37,21 @@ Cross-links from product surfaces to the architecture docs that support them.
 - [Apps](../architecture/apps.md)
 - [Apps Service](../architecture/apps-service.md)
 
+## Port Exposure
+
+### Product docs
+
+- [Port Exposure](../product/port-exposure/port-exposure.md)
+
+### Architecture docs
+
+- [Expose Service](../architecture/expose-service.md)
+- [OpenZiti Integration](../architecture/openziti.md)
+- [Console](../architecture/console.md)
+- [Gateway](../architecture/gateway.md)
+- [Agents Orchestrator](../architecture/agents-orchestrator.md)
+- [agyn-cli](../architecture/agyn-cli.md)
+
 ## Tracing
 
 ### Product docs

--- a/maps/product-to-architecture.md
+++ b/maps/product-to-architecture.md
@@ -46,10 +46,10 @@ Cross-links from product surfaces to the architecture docs that support them.
 ### Architecture docs
 
 - [Expose Service](../architecture/expose-service.md)
+- [Users (Devices)](../architecture/users.md#devices)
 - [OpenZiti Integration](../architecture/openziti.md)
 - [Console](../architecture/console.md)
 - [Gateway](../architecture/gateway.md)
-- [Agents Orchestrator](../architecture/agents-orchestrator.md)
 - [agyn-cli](../architecture/agyn-cli.md)
 
 ## Tracing

--- a/open-questions.md
+++ b/open-questions.md
@@ -119,7 +119,7 @@ Ziti v2.0.0-pre9 introduced `GetDialerIdentityId()` — the edge router now inje
 
 ## Port Exposure: Scoped Access Control
 
-**Context:** The current [Expose Service](architecture/expose-service.md) design grants all enrolled devices access to all exposed services via the `#devices` role attribute on Dial policies. This is intentionally broad for the initial implementation.
+**Context:** The current [Expose Service](architecture/expose-service.md) design grants all identities on the OpenZiti network access to all exposed services via `#all` on Dial policies. This is intentionally broad for the initial implementation.
 
 **Questions:**
 - Should exposed ports be scoped to specific users? (e.g., only the user who started the conversation can access the exposed port)

--- a/open-questions.md
+++ b/open-questions.md
@@ -137,14 +137,3 @@ Ziti v2.0.0-pre9 introduced `GetDialerIdentityId()` — the edge router now inje
 - Should the platform provide an option for agents to serve TLS-terminated services (agent provides its own cert)?
 - Would a local HTTPS proxy in the Ziti tunnel client be feasible?
 
----
-
-## Port Exposure: Sidecar Hosting Configuration
-
-**Context:** The agent's Ziti sidecar must host (bind) dynamically created OpenZiti services and forward traffic to `localhost:<port>` inside the pod. The sidecar needs to be configured to watch for new services matching its role attributes and automatically set up the local forwarding.
-
-**Questions:**
-- What is the specific `ziti-edge-tunnel` or SDK configuration for dynamic service hosting?
-- Does the sidecar need to be notified of new services, or does the Ziti SDK automatically pick up new services when matching policies are created?
-- Is there a configuration file format (e.g., `host.v1` config) that needs to be dynamically updated, or can the sidecar use a wildcard/attribute-based hosting config?
-

--- a/open-questions.md
+++ b/open-questions.md
@@ -18,7 +18,7 @@ Unresolved product and architectural decisions requiring discussion.
 
 ## OpenZiti: Agent-to-Agent Private Networking
 
-**Context:** Future capability. Agents should be able to expose a port and share it with specific other agents over a private OpenZiti connection. Other agents must not be able to connect. See [OpenZiti Integration — Dynamic Policies](architecture/openziti.md#dynamic-policies-future).
+**Context:** Future capability. Agents should be able to expose a port and share it with specific other agents over a private OpenZiti connection. Other agents must not be able to connect. See [OpenZiti Integration — Dynamic Policies](architecture/openziti.md#dynamic-policies). User-to-agent port exposure has been designed (see [Expose Service](architecture/expose-service.md)); this question is about the agent-to-agent variant.
 
 **Questions:**
 - How does the agent request port sharing? (Platform API tool? Agent SDK primitive?)
@@ -114,3 +114,37 @@ Ziti v2.0.0-pre9 introduced `GetDialerIdentityId()` — the edge router now inje
 - What is the migration plan for upgrading Ziti controller and routers from v1.7.2 to v2.0.0+? The v2.x line introduces OIDC-based authentication, router data model changes, and removal of `xgress_edge_tunnel` v1 — this is a breaking upgrade.
 - Once on v2.0.0+, should the `SourceIdentifier()` fallback be removed immediately, or kept behind a feature flag for rollback safety?
 - Are there other services (Gateway, Tracing) that rely on `SourceIdentifier()` and would need the same update?
+
+---
+
+## Port Exposure: Scoped Access Control
+
+**Context:** The current [Expose Service](architecture/expose-service.md) design grants all enrolled devices access to all exposed services via the `#devices` role attribute on Dial policies. This is intentionally broad for the initial implementation.
+
+**Questions:**
+- Should exposed ports be scoped to specific users? (e.g., only the user who started the conversation can access the exposed port)
+- If scoped, should per-user role attributes (`user-<userId>`) be assigned to device identities, and per-exposure Dial policies target specific users?
+- How does multi-user thread access (shared threads, teams) interact with exposure scoping?
+
+---
+
+## Port Exposure: TLS for Exposed Services
+
+**Context:** Exposed services are accessed over `http://exposed-<id>.ziti:<port>`. The OpenZiti overlay provides encryption in transit (mTLS between Ziti endpoints), but the user's browser connects to the local Ziti tunnel via plain HTTP on `localhost`.
+
+**Questions:**
+- Is the lack of browser-visible HTTPS acceptable for the initial version?
+- Should the platform provide an option for agents to serve TLS-terminated services (agent provides its own cert)?
+- Would a local HTTPS proxy in the Ziti tunnel client be feasible?
+
+---
+
+## Port Exposure: Sidecar Hosting Configuration
+
+**Context:** The agent's Ziti sidecar must host (bind) dynamically created OpenZiti services and forward traffic to `localhost:<port>` inside the pod. The sidecar needs to be configured to watch for new services matching its role attributes and automatically set up the local forwarding.
+
+**Questions:**
+- What is the specific `ziti-edge-tunnel` or SDK configuration for dynamic service hosting?
+- Does the sidecar need to be notified of new services, or does the Ziti SDK automatically pick up new services when matching policies are created?
+- Is there a configuration file format (e.g., `host.v1` config) that needs to be dynamically updated, or can the sidecar use a wildcard/attribute-based hosting config?
+

--- a/product/README.md
+++ b/product/README.md
@@ -7,6 +7,7 @@ Desired product state for the Agyn platform.
 - Start here: [Overview](overview.md) -> [Concepts](concepts.md)
 - Chat: [Chat](chat/chat.md) -> [Inline Media](chat/inline-media.md)
 - Console: [Console](console/console.md)
+- Port Exposure: [Port Exposure](port-exposure/port-exposure.md)
 - Tracing: [Run Timeline](tracing/run-timeline.md)
 
 ## By domain
@@ -24,6 +25,10 @@ Desired product state for the Agyn platform.
 ### Console
 
 - [Console](console/console.md)
+
+### Port Exposure
+
+- [Port Exposure](port-exposure/port-exposure.md)
 
 ### Tracing
 

--- a/product/console/console.md
+++ b/product/console/console.md
@@ -91,6 +91,7 @@ The dropdown contains:
 | Item | Description |
 |------|-------------|
 | **Profile** | View and edit the user's own profile (name, nickname, photo URL). Read-only fields: OIDC subject |
+| **Devices** | Register and manage devices enrolled in the platform network for accessing [exposed agent ports](../port-exposure/port-exposure.md). Each device has a name, enrollment status, and a one-time enrollment JWT. See [Port Exposure — Devices](../port-exposure/port-exposure.md#devices) |
 | **API Tokens** | Create, list, and revoke API tokens for programmatic access. Token value is shown once at creation and cannot be retrieved again |
 | **Pending Invites** | List of pending organization invites with accept/decline actions. Badge on the user menu shows the count of pending invites. Accepting an invite adds the organization to the context switcher and switches to it |
 | **Logout** | Ends the session |

--- a/product/port-exposure/port-exposure.md
+++ b/product/port-exposure/port-exposure.md
@@ -2,17 +2,17 @@
 
 ## Purpose
 
-Port Exposure allows users to access development servers and other network services running inside agent containers directly from their own machines. An agent starts a service (e.g., a dev server on port 3000), exposes it through the platform, and shares a link in the conversation. The user opens the link in their browser and interacts with the service as if it were running locally.
+Port Exposure allows users to access development servers and other network services running inside agent containers directly from their own machines. An agent starts a service (e.g., a dev server on port 3000), exposes it through the platform, and shares a link. The user opens the link in their browser and interacts with the service as if it were running locally.
 
 ## User Stories
 
 - As a user, I want to enroll my device into the platform network so I can access services exposed by agents.
-- As a user, I want to receive a link in the conversation when an agent exposes a port so I can open the service in my browser.
+- As an agent, I want to expose a port and receive an access URL so I can share it with the user.
 - As a user, I want the exposed service to be cleaned up automatically when the agent stops so I don't have stale connections.
 
 ## Prerequisites
 
-The user must install a Ziti tunnel client on their machine and enroll it using a JWT token generated from the Console. See [Devices](#devices) for the enrollment flow.
+The user must install a Ziti tunnel client on their machine and enroll it using a JWT token generated from the Console. See [Devices](#devices) for the enrollment flow. Once enrolled, the device is part of the OpenZiti network and can access any exposed service.
 
 ## Flow
 
@@ -21,8 +21,10 @@ The user must install a Ziti tunnel client on their machine and enroll it using 
 3. The platform starts the agent.
 4. The agent executes work and starts a dev server (e.g., on port 3000).
 5. The agent exposes the port via `agyn expose add 3000`.
-6. The agent posts a link to the conversation: `http://exposed-<id>.ziti:3000`.
+6. The agent receives the access URL (`http://exposed-<id>.ziti:3000`) and shares it with the user (e.g., posts it to the conversation).
 7. The user opens the link in their browser. The Ziti tunnel on the user's machine resolves the hostname and routes traffic to the agent container over the OpenZiti network.
+
+The platform does not automatically post the link — the agent decides when and how to share it.
 
 ## Link Format
 
@@ -70,7 +72,7 @@ The enrollment JWT is shown once at creation time and cannot be retrieved again.
 ## Constraints
 
 - The user must have a Ziti tunnel client installed and running on their machine.
-- Exposed services are accessible only to devices enrolled in the platform network.
+- Exposed services are accessible to any identity connected to the OpenZiti network (enrolled devices, agents, runners, etc.).
 - The link uses HTTP (not HTTPS) — TLS termination is not provided by the platform for exposed ports.
 
 ## Related Architecture

--- a/product/port-exposure/port-exposure.md
+++ b/product/port-exposure/port-exposure.md
@@ -1,0 +1,80 @@
+# Port Exposure
+
+## Purpose
+
+Port Exposure allows users to access development servers and other network services running inside agent containers directly from their own machines. An agent starts a service (e.g., a dev server on port 3000), exposes it through the platform, and shares a link in the conversation. The user opens the link in their browser and interacts with the service as if it were running locally.
+
+## User Stories
+
+- As a user, I want to enroll my device into the platform network so I can access services exposed by agents.
+- As a user, I want to receive a link in the conversation when an agent exposes a port so I can open the service in my browser.
+- As a user, I want the exposed service to be cleaned up automatically when the agent stops so I don't have stale connections.
+
+## Prerequisites
+
+The user must install a Ziti tunnel client on their machine and enroll it using a JWT token generated from the Console. See [Devices](#devices) for the enrollment flow.
+
+## Flow
+
+1. The user enrolls their device into the platform network via the Console (one-time setup).
+2. The user sends a message to a conversation with an agent.
+3. The platform starts the agent.
+4. The agent executes work and starts a dev server (e.g., on port 3000).
+5. The agent exposes the port via `agyn expose add 3000`.
+6. The agent posts a link to the conversation: `http://exposed-<id>.ziti:3000`.
+7. The user opens the link in their browser. The Ziti tunnel on the user's machine resolves the hostname and routes traffic to the agent container over the OpenZiti network.
+
+## Link Format
+
+Exposed services are reachable at:
+
+```
+http://exposed-<id>.ziti:<port>
+```
+
+Where `<id>` is the unique identifier of the exposure and `<port>` is the exposed port number. The `.ziti` suffix is resolved by the user's Ziti tunnel — it is not a public DNS name.
+
+## Lifecycle
+
+- Ports are exposed on demand by the agent during execution.
+- Ports can be explicitly un-exposed by the agent via `agyn expose remove 3000`.
+- All exposed ports are automatically cleaned up when the agent workload is stopped (idle timeout, conversation resolved, or manual stop).
+
+## Devices
+
+Users enroll their machines into the platform network through the Console. The Devices section is in the user menu (above API Tokens).
+
+### Enrollment Flow
+
+1. User opens the Console and navigates to Devices in the user menu.
+2. User clicks "Add Device" and provides a device name (e.g., "Work Laptop").
+3. The platform generates an enrollment JWT token.
+4. The user copies the JWT and uses it in their Ziti tunnel client (Ziti Desktop Edge or `ziti-edge-tunnel`) to enroll the device.
+5. Once enrolled, the device appears as "Enrolled" in the Devices list.
+
+### Device Management
+
+The Devices section shows all registered devices for the user:
+
+| Column | Description |
+|--------|-------------|
+| Name | User-provided device name |
+| Status | `pending` (JWT generated, not yet enrolled) or `enrolled` |
+| Created | When the device was registered |
+
+Actions:
+- **Delete** — removes the device and revokes its network identity. Requires confirmation.
+
+The enrollment JWT is shown once at creation time and cannot be retrieved again. If the user loses the JWT before enrolling, they must delete the device and create a new one.
+
+## Constraints
+
+- The user must have a Ziti tunnel client installed and running on their machine.
+- Exposed services are accessible only to devices enrolled in the platform network.
+- The link uses HTTP (not HTTPS) — TLS termination is not provided by the platform for exposed ports.
+
+## Related Architecture
+
+- [Expose Service](../../architecture/expose-service.md)
+- [OpenZiti Integration](../../architecture/openziti.md)
+- [Console](../../architecture/console.md)

--- a/product/port-exposure/port-exposure.md
+++ b/product/port-exposure/port-exposure.md
@@ -76,5 +76,6 @@ The enrollment JWT is shown once at creation time and cannot be retrieved again.
 ## Related Architecture
 
 - [Expose Service](../../architecture/expose-service.md)
+- [Users — Devices](../../architecture/users.md#devices)
 - [OpenZiti Integration](../../architecture/openziti.md)
 - [Console](../../architecture/console.md)


### PR DESCRIPTION
## Summary

Adds product and architecture documentation for **Port Exposure** — a feature that allows users to access development servers and other network services running inside agent containers directly from their machines via the OpenZiti network.

## New Files

| File | Description |
|------|-------------|
| `product/port-exposure/port-exposure.md` | Product doc: user stories, end-to-end flow, device enrollment, lifecycle, constraints |
| `architecture/expose-service.md` | Architecture doc: new Expose service with full API, resource model, Ziti resource lifecycle, provisioning/cleanup, device management |
| `changes/2025-07-25-port-exposure.md` | Change file: delta between desired and current state |

## Updated Files

| File | What Changed |
|------|--------------|
| `architecture/openziti.md` | Dynamic Policies section (was "Future", now designed); device identity type; 4 new Ziti Management RPCs; `agents-host-exposed` static policy; role attribute + identity summary tables |
| `architecture/agents-orchestrator.md` | Stop flow now calls `RemoveExposuresByWorkload` before stopping workload; Expose Service added as dependency |
| `architecture/agent/overview.md` | Agent is no longer "pure client" — notes port exposure binding |
| `architecture/agyn-cli.md` | `expose` command group (`add`, `remove`, `list`) |
| `architecture/gateway.md` | `ExposeGateway` proto service added |
| `architecture/console.md` | Devices section added; Expose Service in dependency diagram |
| `product/console/console.md` | Devices row in user menu table |
| `product/README.md` | Port Exposure in reading paths and by-domain sections |
| `architecture/README.md` | Expose Service in MCP and networking section |
| `maps/product-to-architecture.md` | Port Exposure cross-links |
| `open-questions.md` | 3 new questions (scoped access control, TLS, sidecar hosting config); updated agent-to-agent context |

## Key Design Decisions

1. **New Expose service** rather than extending Orchestrator or Ziti Management — clean separation of concerns
2. **Per-exposure OpenZiti resources** (service + Bind policy + Dial policy) created dynamically, cleaned up on removal/stop
3. **Reconciliation loop** for eventual cleanup of failed/partial provisioning
4. **Devices owned by Expose service** — user device enrollment via Console, OTT flow with OpenZiti Controller
5. **Broad access control** for v1 — all enrolled devices can access all exposed services; scoped access deferred (open question added)
6. **Orchestrator calls Expose Service** during workload stop flow — ensures cleanup before pod termination