### PR TITLE
arch: Claude Code agent support

### DIFF
--- a/architecture/agent-init.md
+++ b/architecture/agent-init.md
@@ -84,7 +84,7 @@ One init image per supported agent type, each in its own repository:
 | Image | Repository | Contents |
 |-------|------------|----------|
 | `ghcr.io/agynio/agent-init-codex:<version>` | `agynio/agent-init-codex` | `agynd` + `codex` (static musl binary) + `config.json` with `sdk: codex` |
-| `ghcr.io/agynio/agent-init-claude:<version>` | `agynio/agent-init-claude` | `agynd` + `claude` (static musl binary) + `config.json` with `sdk: claude` |
+| `ghcr.io/agynio/agent-init-claude:<version>` | `agynio/agent-init-claude` | `agynd` + `claude` (native `linux-x64-musl` binary) + `libgcc`/`libstdc++` + `config.json` with `sdk: claude` |
 | `ghcr.io/agynio/agent-init-agn:<version>` | `agynio/agent-init-agn` | `agynd` + `agn` (static Go binary) + `config.json` with `sdk: agn` |
 
 #### Repository Structure
@@ -170,7 +170,7 @@ All binaries are statically linked and run on any Linux base image:
 |--------|-------|--------|
 | `agynd` | Go, `CGO_ENABLED=0` | Yes |
 | Codex CLI | Rust, musl target (`codex-x86_64-unknown-linux-musl`) | Yes |
-| Claude Code CLI | musl variant from Anthropic distribution (GCS bucket) | Yes (musl variant only) |
+| Claude Code CLI | Native binary, `linux-x64-musl` variant from Anthropic distribution. Requires `libgcc` and `libstdc++` on Alpine — the init image bundles these alongside the binary | Yes (musl variant; depends on `libgcc`/`libstdc++`) |
 | agn CLI | Go, `CGO_ENABLED=0` | Yes |
 
 #### CI

--- a/architecture/agynd-cli.md
+++ b/architecture/agynd-cli.md
@@ -79,6 +79,39 @@ llm:
   endpoint: http://llm-proxy.ziti/v1
 ```
 
+**Claude Code** — `agynd` writes `~/.claude/settings.json` with LLM Proxy configuration and full tool permissions:
+
+```json
+{
+  "env": {
+    "ANTHROPIC_BASE_URL": "http://llm-proxy.ziti/v1",
+    "ANTHROPIC_AUTH_TOKEN": "unused-ziti-mTLS",
+    "DISABLE_AUTOUPDATER": "1",
+    "CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC": "1"
+  },
+  "permissions": {
+    "allow": [
+      "Bash",
+      "Read",
+      "Write",
+      "Edit",
+      "Glob",
+      "Grep",
+      "WebFetch",
+      "WebSearch",
+      "Task",
+      "TodoWrite",
+      "NotebookEdit"
+    ],
+    "deny": []
+  }
+}
+```
+
+`ANTHROPIC_BASE_URL` overrides the API endpoint. `ANTHROPIC_AUTH_TOKEN` sets a custom `Authorization: Bearer` header value — when running with the Ziti sidecar, authentication is handled at the network level, so the value is unused but must be non-empty to suppress Claude Code's authentication prompt. `DISABLE_AUTOUPDATER` prevents background update checks. `CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC` disables telemetry and other non-essential outbound requests.
+
+The `permissions` block grants all built-in tools without interactive confirmation. The platform provides isolation and security at the container level — the agent should be able to perform any filesystem, shell, and network action within its container.
+
 Inside the platform, agents connect to the LLM Proxy using the `llm-proxy.ziti` OpenZiti hostname. The Ziti sidecar resolves the hostname and transparently intercepts connections via DNS + TPROXY, so agent CLI subprocesses connect with standard HTTP clients — no OpenZiti SDK required. When running with the Ziti sidecar, authentication is handled at the network level by the sidecar's mTLS — the `OPENAI_API_KEY` value is unused. Over the public endpoint (development, CI), the token must be a valid platform API token (`agyn_...`).
 
 ### 4. Agent Process Management

--- a/architecture/llm-proxy.md
+++ b/architecture/llm-proxy.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-The LLM Proxy is a standalone HTTP service that exposes LLM API endpoints for agents. It serves two wire protocols: the OpenAI Responses API (`POST /v1/responses`) and the Anthropic Messages API (`POST /v1/messages`). It authenticates callers, resolves the requested model to an LLM provider via the [LLM service](llm.md), and forwards the request to the external provider with injected credentials using the provider's declared wire protocol and auth method. Responses — including streaming — are passed back to the caller.
+The LLM Proxy is a standalone HTTP service that exposes LLM API endpoints for agents. It serves two LLM API protocols: the OpenAI Responses API (`POST /v1/responses`) and the Anthropic Messages API (`POST /v1/messages`). It authenticates callers, resolves the requested model to an LLM provider via the [LLM service](llm.md), and forwards the request to the external provider with injected credentials using the provider's declared protocol and auth method. Responses — including streaming — are passed back to the caller.
 
 Agents point their standard LLM client (OpenAI or Anthropic) at the LLM Proxy and use it like any compatible API. No custom client logic is required.
 
@@ -10,7 +10,7 @@ Agents point their standard LLM client (OpenAI or Anthropic) at the LLM Proxy an
 
 Agents use standard LLM client libraries that expect HTTP REST endpoints — Codex CLI and [`agn`](agn-cli.md) use the OpenAI Responses API (`POST /v1/responses`), Claude Code uses the Anthropic Messages API (`POST /v1/messages`). The platform's internal services communicate over gRPC via [ConnectRPC](gateway.md#connectrpc). Exposing the LLM proxy through the Gateway's ConnectRPC interface would require agents to use a non-standard client, defeating the goal of wrapping unmodified 3rd-party agent CLIs.
 
-The LLM Proxy bridges this gap: it speaks the standard LLM API wire formats externally and gRPC internally.
+The LLM Proxy bridges this gap: it speaks the standard LLM API formats externally and gRPC internally.
 
 ## Responsibilities
 
@@ -21,7 +21,7 @@ The LLM Proxy bridges this gap: it speaks the standard LLM API wire formats exte
 | **Authentication** | Authenticate callers via [OpenZiti](#openziti-identity) network identity or [API token](api-tokens.md) |
 | **Authorization** | Call the [Authorization](authz.md) service to check access before forwarding |
 | **Model resolution** | Call the [LLM service](llm.md) over gRPC to resolve model ID → provider endpoint, token, and remote model name |
-| **Request forwarding** | Forward the request to the external LLM provider with injected credentials (Bearer or x-api-key, per the provider's auth method) and substituted model name, using the provider's declared wire protocol |
+| **Request forwarding** | Forward the request to the external LLM provider with injected credentials (Bearer or x-api-key, per the provider's auth method) and substituted model name, using the provider's declared protocol |
 | **Streaming** | Support SSE streaming (`stream: true`) — stream the provider's response back to the caller without buffering |
 
 ## Classification
@@ -78,18 +78,18 @@ curl -X POST https://llm.agyn.dev/v1/messages \
 
 **Streaming:** When the request includes `"stream": true`, the response is delivered as SSE with `Content-Type: text/event-stream`. Events follow the Anthropic Messages streaming format (e.g., `message_start`, `content_block_delta`, `message_stop`).
 
-The LLM Proxy does not interpret the request or response body beyond extracting the `model` field for resolution and validating the provider's wire protocol. The body is forwarded to the provider as-is (with the `model` field replaced by the remote model name).
+The LLM Proxy does not interpret the request or response body beyond extracting the `model` field for resolution and validating the provider's protocol. The body is forwarded to the provider as-is (with the `model` field replaced by the remote model name).
 
-## Wire API Protocols
+## Protocols
 
-The LLM Proxy supports two wire protocols. The caller-facing endpoint determines which protocol the agent speaks. The provider-facing protocol is determined by the provider's [`wire_api`](providers.md#llm-provider) field returned from model resolution.
+The LLM Proxy supports two LLM API protocols. The caller-facing endpoint determines which protocol the agent speaks. The provider-facing protocol is determined by the provider's [`protocol`](providers.md#llm-provider) field returned from model resolution.
 
-| Caller Endpoint | Agent Protocol | Provider `wire_api` | Provider Endpoint Path |
+| Caller Endpoint | Agent Protocol | Provider `protocol` | Provider Endpoint Path |
 |----------------|----------------|---------------------|----------------------|
 | `POST /v1/responses` | OpenAI Responses API | `responses` | `POST /v1/responses` |
 | `POST /v1/messages` | Anthropic Messages API | `anthropic_messages` | `POST /v1/messages` |
 
-The caller-facing protocol and provider-facing protocol always match: an agent calling `POST /v1/responses` uses a model whose provider has `wire_api: responses`, and an agent calling `POST /v1/messages` uses a model whose provider has `wire_api: anthropic_messages`. The LLM Proxy validates this — if a caller sends a request to `POST /v1/messages` but the resolved provider has `wire_api: responses`, the proxy returns `400 Bad Request`.
+The caller-facing protocol and provider-facing protocol always match: an agent calling `POST /v1/responses` uses a model whose provider has `protocol: responses`, and an agent calling `POST /v1/messages` uses a model whose provider has `protocol: anthropic_messages`. The LLM Proxy validates this — if a caller sends a request to `POST /v1/messages` but the resolved provider has `protocol: responses`, the proxy returns `400 Bad Request`.
 
 ### OpenAI Responses API (`responses`)
 
@@ -148,8 +148,8 @@ sequenceDiagram
     A->>P: POST /v1/responses or /v1/messages (model: platform-model-id)
     P->>P: Authenticate caller (OpenZiti / API token)
     P->>L: ResolveModel(model_id)
-    L-->>P: endpoint, token, remoteName, wire_api, auth_method, organization_id
-    P->>P: Validate caller endpoint matches provider wire_api
+    L-->>P: endpoint, token, remoteName, protocol, auth_method, organization_id
+    P->>P: Validate caller endpoint matches provider protocol
     P->>Auth: Check(identity, can_use, model)
     Auth-->>P: allowed / denied
     P->>E: Forward request (auth per auth_method, model: remoteName)
@@ -159,8 +159,8 @@ sequenceDiagram
 
 1. Agent sends a request to the LLM Proxy (`POST /v1/responses` or `POST /v1/messages`), specifying the platform model ID.
 2. LLM Proxy authenticates the caller — OpenZiti identity resolution via [Ziti Management](openziti.md), or API token hash lookup via [Users](users.md).
-3. LLM Proxy calls the LLM service (`ResolveModel` gRPC method) to get the provider endpoint, token, remote model name, wire protocol, auth method, and organization ID.
-4. LLM Proxy validates that the caller's endpoint matches the provider's wire protocol (e.g., `POST /v1/messages` requires `wire_api: anthropic_messages`). If mismatched, returns `400 Bad Request`.
+3. LLM Proxy calls the LLM service (`ResolveModel` gRPC method) to get the provider endpoint, token, remote model name, protocol, auth method, and organization ID.
+4. LLM Proxy validates that the caller's endpoint matches the provider's protocol (e.g., `POST /v1/messages` requires `protocol: anthropic_messages`). If mismatched, returns `400 Bad Request`.
 5. LLM Proxy calls the [Authorization](authz.md) service to check whether the caller has access. If denied, returns `403 Forbidden`.
 6. LLM Proxy forwards the request to the provider's endpoint, replacing the `model` field with the remote model name and injecting the provider's token using the provider's auth method (`bearer` → `Authorization: Bearer`, `x_api_key` → `x-api-key`).
 7. The provider's response is returned to the agent. For streaming requests, SSE events are forwarded without buffering.

--- a/architecture/llm-proxy.md
+++ b/architecture/llm-proxy.md
@@ -2,25 +2,26 @@
 
 ## Overview
 
-The LLM Proxy is a standalone HTTP service that exposes an OpenAI-compatible Responses API endpoint for agents. It authenticates callers, resolves the requested model to an LLM provider via the [LLM service](llm.md), and forwards the request to the external provider with injected credentials. Responses — including streaming — are passed back to the caller.
+The LLM Proxy is a standalone HTTP service that exposes LLM API endpoints for agents. It serves two wire protocols: the OpenAI Responses API (`POST /v1/responses`) and the Anthropic Messages API (`POST /v1/messages`). It authenticates callers, resolves the requested model to an LLM provider via the [LLM service](llm.md), and forwards the request to the external provider with injected credentials using the provider's declared wire protocol and auth method. Responses — including streaming — are passed back to the caller.
 
-Agents point a standard OpenAI client at the LLM Proxy and use it like any OpenAI-compatible API. No custom client logic is required.
+Agents point their standard LLM client (OpenAI or Anthropic) at the LLM Proxy and use it like any compatible API. No custom client logic is required.
 
 ## Motivation
 
-Agents (Codex CLI, Claude Code, [`agn`](agn-cli.md)) use standard OpenAI client libraries that expect an HTTP REST endpoint (`POST /v1/responses`) with Bearer token authentication. The platform's internal services communicate over gRPC via [ConnectRPC](gateway.md#connectrpc). Exposing the LLM proxy through the Gateway's ConnectRPC interface would require agents to use a non-standard client, defeating the goal of wrapping unmodified 3rd-party agent CLIs.
+Agents use standard LLM client libraries that expect HTTP REST endpoints — Codex CLI and [`agn`](agn-cli.md) use the OpenAI Responses API (`POST /v1/responses`), Claude Code uses the Anthropic Messages API (`POST /v1/messages`). The platform's internal services communicate over gRPC via [ConnectRPC](gateway.md#connectrpc). Exposing the LLM proxy through the Gateway's ConnectRPC interface would require agents to use a non-standard client, defeating the goal of wrapping unmodified 3rd-party agent CLIs.
 
-The LLM Proxy bridges this gap: it speaks the OpenAI Responses API wire format externally and gRPC internally.
+The LLM Proxy bridges this gap: it speaks the standard LLM API wire formats externally and gRPC internally.
 
 ## Responsibilities
 
 | Responsibility | Description |
 |---------------|-------------|
 | **Responses API endpoint** | Serve `POST /v1/responses` with the OpenAI Responses API request/response format |
+| **Messages API endpoint** | Serve `POST /v1/messages` with the Anthropic Messages API request/response format |
 | **Authentication** | Authenticate callers via [OpenZiti](#openziti-identity) network identity or [API token](api-tokens.md) |
 | **Authorization** | Call the [Authorization](authz.md) service to check access before forwarding |
 | **Model resolution** | Call the [LLM service](llm.md) over gRPC to resolve model ID → provider endpoint, token, and remote model name |
-| **Request forwarding** | Forward the request to the external LLM provider with injected Bearer credentials and substituted model name |
+| **Request forwarding** | Forward the request to the external LLM provider with injected credentials (Bearer or x-api-key, per the provider's auth method) and substituted model name, using the provider's declared wire protocol |
 | **Streaming** | Support SSE streaming (`stream: true`) — stream the provider's response back to the caller without buffering |
 
 ## Classification
@@ -51,6 +52,89 @@ curl -X POST https://llm.agyn.dev/v1/responses \
 
 The LLM Proxy does not interpret the request or response body beyond extracting the `model` field for resolution. The body is forwarded to the provider as-is (with the `model` field replaced by the remote model name).
 
+### `POST /v1/messages`
+
+Accepts an [Anthropic Messages API](https://docs.anthropic.com/en/api/messages) request. The `model` field contains the platform's internal model ID (not the provider's model name).
+
+**Authentication:** Same as `POST /v1/responses` — the LLM Proxy checks both `Authorization: Bearer` and `x-api-key` headers, plus OpenZiti mTLS.
+
+**Required header:** `anthropic-version` (e.g., `2023-06-01`). Forwarded to the provider as-is.
+
+**Non-streaming request example:**
+
+```bash
+curl -X POST https://llm.agyn.dev/v1/messages \
+  -H "Content-Type: application/json" \
+  -H "x-api-key: agyn_..." \
+  -H "anthropic-version: 2023-06-01" \
+  -d '{
+    "model": "<platform-model-uuid>",
+    "max_tokens": 4096,
+    "messages": [
+      {"role": "user", "content": "Hello, Claude"}
+    ]
+  }'
+```
+
+**Streaming:** When the request includes `"stream": true`, the response is delivered as SSE with `Content-Type: text/event-stream`. Events follow the Anthropic Messages streaming format (e.g., `message_start`, `content_block_delta`, `message_stop`).
+
+The LLM Proxy does not interpret the request or response body beyond extracting the `model` field for resolution and validating the provider's wire protocol. The body is forwarded to the provider as-is (with the `model` field replaced by the remote model name).
+
+## Wire API Protocols
+
+The LLM Proxy supports two wire protocols. The caller-facing endpoint determines which protocol the agent speaks. The provider-facing protocol is determined by the provider's [`wire_api`](providers.md#llm-provider) field returned from model resolution.
+
+| Caller Endpoint | Agent Protocol | Provider `wire_api` | Provider Endpoint Path |
+|----------------|----------------|---------------------|----------------------|
+| `POST /v1/responses` | OpenAI Responses API | `responses` | `POST /v1/responses` |
+| `POST /v1/messages` | Anthropic Messages API | `anthropic_messages` | `POST /v1/messages` |
+
+The caller-facing protocol and provider-facing protocol always match: an agent calling `POST /v1/responses` uses a model whose provider has `wire_api: responses`, and an agent calling `POST /v1/messages` uses a model whose provider has `wire_api: anthropic_messages`. The LLM Proxy validates this — if a caller sends a request to `POST /v1/messages` but the resolved provider has `wire_api: responses`, the proxy returns `400 Bad Request`.
+
+### OpenAI Responses API (`responses`)
+
+The existing protocol. Request and response format follows the [OpenAI Responses API specification](https://platform.openai.com/docs/api-reference/responses/create). Streaming uses SSE with event types `response.created`, `response.output_text.delta`, `response.completed`, etc.
+
+The LLM Proxy forwards the request body as-is (replacing the `model` field) and injects auth per the provider's `authMethod`.
+
+### Anthropic Messages API (`anthropic_messages`)
+
+Request and response format follows the [Anthropic Messages API specification](https://docs.anthropic.com/en/api/messages).
+
+**Caller-facing endpoint:**
+
+```bash
+curl -X POST https://llm.agyn.dev/v1/messages \
+  -H "Content-Type: application/json" \
+  -H "x-api-key: agyn_..." \
+  -H "anthropic-version: 2023-06-01" \
+  -d '{
+    "model": "<platform-model-uuid>",
+    "max_tokens": 4096,
+    "messages": [
+      {"role": "user", "content": "Hello, Claude"}
+    ]
+  }'
+```
+
+**Authentication on the caller side:** The LLM Proxy accepts auth from agents via the `x-api-key` header (for API token `agyn_...` authentication) or via OpenZiti mTLS (for agents inside the platform). This is the same authentication as `POST /v1/responses` — the LLM Proxy checks both `Authorization: Bearer` and `x-api-key` headers on all endpoints.
+
+**Provider-side forwarding:** The proxy forwards the request body as-is (replacing the `model` field with the remote model name) and injects auth per the provider's `authMethod` (`bearer` → `Authorization: Bearer <token>`, `x_api_key` → `x-api-key: <token>`). The `anthropic-version` header from the caller is forwarded to the provider.
+
+**Streaming:** When the request includes `"stream": true`, the response is delivered as SSE. Events follow the Anthropic streaming format:
+
+| SSE Event Type | Description |
+|---------------|-------------|
+| `message_start` | Start of the response message with metadata and usage |
+| `content_block_start` | Start of a content block (text, tool_use, thinking) |
+| `content_block_delta` | Incremental content update (text delta, input JSON delta, thinking delta) |
+| `content_block_stop` | End of a content block |
+| `message_delta` | Message-level metadata update (stop_reason, usage) |
+| `message_stop` | End of the response message |
+| `ping` | Keepalive |
+
+The LLM Proxy does not interpret message content, tool definitions, thinking blocks, or any other request/response fields beyond extracting the `model` field for resolution. The body is forwarded to the provider as-is.
+
 ## Request Flow
 
 ```mermaid
@@ -61,23 +145,25 @@ sequenceDiagram
     participant L as LLM Service (gRPC)
     participant E as LLM Provider (external)
 
-    A->>P: POST /v1/responses (model: platform-model-id) [via llm-proxy.ziti (intercepted by sidecar)]
+    A->>P: POST /v1/responses or /v1/messages (model: platform-model-id)
     P->>P: Authenticate caller (OpenZiti / API token)
     P->>L: ResolveModel(model_id)
-    L-->>P: endpoint, token, remoteName, organization_id
+    L-->>P: endpoint, token, remoteName, wire_api, auth_method, organization_id
+    P->>P: Validate caller endpoint matches provider wire_api
     P->>Auth: Check(identity, can_use, model)
     Auth-->>P: allowed / denied
-    P->>E: Forward request (Bearer token, model: remoteName)
+    P->>E: Forward request (auth per auth_method, model: remoteName)
     E-->>P: Response (or SSE stream)
     P-->>A: Response (or SSE stream)
 ```
 
-1. Agent sends an OpenAI Responses API request to the LLM Proxy, specifying the platform model ID.
+1. Agent sends a request to the LLM Proxy (`POST /v1/responses` or `POST /v1/messages`), specifying the platform model ID.
 2. LLM Proxy authenticates the caller — OpenZiti identity resolution via [Ziti Management](openziti.md), or API token hash lookup via [Users](users.md).
-3. LLM Proxy calls the LLM service (`ResolveModel` gRPC method) to get the provider endpoint, token, remote model name, and organization ID.
-4. LLM Proxy calls the [Authorization](authz.md) service to check whether the caller has access. If denied, returns `403 Forbidden`.
-5. LLM Proxy forwards the request to the provider's endpoint, replacing the `model` field with the remote model name and injecting the provider's token as a `Bearer` authorization header.
-6. The provider's response is returned to the agent. For streaming requests, SSE events are forwarded without buffering.
+3. LLM Proxy calls the LLM service (`ResolveModel` gRPC method) to get the provider endpoint, token, remote model name, wire protocol, auth method, and organization ID.
+4. LLM Proxy validates that the caller's endpoint matches the provider's wire protocol (e.g., `POST /v1/messages` requires `wire_api: anthropic_messages`). If mismatched, returns `400 Bad Request`.
+5. LLM Proxy calls the [Authorization](authz.md) service to check whether the caller has access. If denied, returns `403 Forbidden`.
+6. LLM Proxy forwards the request to the provider's endpoint, replacing the `model` field with the remote model name and injecting the provider's token using the provider's auth method (`bearer` → `Authorization: Bearer`, `x_api_key` → `x-api-key`).
+7. The provider's response is returned to the agent. For streaming requests, SSE events are forwarded without buffering.
 
 ## Authentication
 

--- a/architecture/llm.md
+++ b/architecture/llm.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-The LLM service manages LLM providers and models as internal resources, and provides model resolution for the [LLM Proxy](llm-proxy.md). It is the single source of truth for provider credentials, wire protocol selection, and model-to-provider mappings.
+The LLM service manages LLM providers and models as internal resources, and provides model resolution for the [LLM Proxy](llm-proxy.md). It is the single source of truth for provider credentials, protocol selection, and model-to-provider mappings.
 
 Agents do not interact with the LLM service directly. They call the [LLM Proxy](llm-proxy.md), which resolves models through this service.
 
@@ -37,7 +37,7 @@ The `ResolveModel` method returns everything the [LLM Proxy](llm-proxy.md) needs
 | `endpoint` | string | Provider base URL (e.g., `https://api.openai.com`) |
 | `token` | string | Provider authentication token |
 | `remote_name` | string | Model identifier on the provider's side (e.g., `gpt-5`, `claude-sonnet-4-20250514`) |
-| `wire_api` | string | Wire protocol — `responses` or `anthropic_messages`. From the provider's [`wire_api`](providers.md#llm-provider) field |
+| `protocol` | string | LLM API protocol — `responses` or `anthropic_messages`. From the provider's [`protocol`](providers.md#llm-provider) field |
 | `auth_method` | string | Authentication method — `bearer` or `x_api_key`. From the provider's [`authMethod`](providers.md#llm-provider) field |
 | `organization_id` | string (UUID) | Organization that owns the model |
 

--- a/architecture/llm.md
+++ b/architecture/llm.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-The LLM service manages LLM providers and models as internal resources, and provides model resolution for the [LLM Proxy](llm-proxy.md). It is the single source of truth for provider credentials and model-to-provider mappings.
+The LLM service manages LLM providers and models as internal resources, and provides model resolution for the [LLM Proxy](llm-proxy.md). It is the single source of truth for provider credentials, wire protocol selection, and model-to-provider mappings.
 
 Agents do not interact with the LLM service directly. They call the [LLM Proxy](llm-proxy.md), which resolves models through this service.
 
@@ -36,7 +36,9 @@ The `ResolveModel` method returns everything the [LLM Proxy](llm-proxy.md) needs
 |-------|------|-------------|
 | `endpoint` | string | Provider base URL (e.g., `https://api.openai.com`) |
 | `token` | string | Provider authentication token |
-| `remote_name` | string | Model identifier on the provider's side (e.g., `gpt-5`, `anthropic/claude-sonnet-4-20250514`) |
+| `remote_name` | string | Model identifier on the provider's side (e.g., `gpt-5`, `claude-sonnet-4-20250514`) |
+| `wire_api` | string | Wire protocol — `responses` or `anthropic_messages`. From the provider's [`wire_api`](providers.md#llm-provider) field |
+| `auth_method` | string | Authentication method — `bearer` or `x_api_key`. From the provider's [`authMethod`](providers.md#llm-provider) field |
 | `organization_id` | string (UUID) | Organization that owns the model |
 
 ### Resolution Chain

--- a/architecture/providers.md
+++ b/architecture/providers.md
@@ -2,17 +2,27 @@
 
 ## LLM Provider
 
-An LLM provider represents a connection to an external LLM service. All LLM providers expose an OpenAI-compatible Responses API. The [LLM Proxy](llm-proxy.md) uses the same client for every provider — only the endpoint and auth differ.
+An LLM provider represents a connection to an external LLM service. Each provider declares which wire protocol it speaks — OpenAI Responses API or Anthropic Messages API. The [LLM Proxy](llm-proxy.md) uses the matching protocol when forwarding requests.
 
 ### Resource Definition
 
 | Field | Type | Description |
 |-------|------|-------------|
 | `endpoint` | string | Base URL of the provider API (e.g., `https://api.openai.com`, a litellm proxy URL, an OpenRouter URL) |
-| `authMethod` | enum | Authentication method. Supported: `bearer` |
-| `token` | string | Authentication token (used as Bearer token) |
+| `wire_api` | enum | Wire protocol the provider speaks. Supported: `responses` (OpenAI Responses API), `anthropic_messages` (Anthropic Messages API) |
+| `authMethod` | enum | Authentication method. Supported: `bearer`, `x_api_key` |
+| `token` | string | Authentication token |
 
-`authMethod` is `bearer` for now. The field exists so other methods (API key header, mTLS, etc.) can be added without schema changes.
+`wire_api` determines how the [LLM Proxy](llm-proxy.md) communicates with the provider — which HTTP endpoint path, request/response format, and streaming event protocol to use. See [LLM Proxy — Wire API Protocols](llm-proxy.md#wire-api-protocols) for the details of each protocol.
+
+`authMethod` determines how the LLM Proxy authenticates with the provider:
+
+| Value | Header | Format |
+|-------|--------|--------|
+| `bearer` | `Authorization` | `Bearer <token>` |
+| `x_api_key` | `x-api-key` | `<token>` |
+
+The auth method is independent of the wire API. An Anthropic-protocol provider typically uses `x_api_key`, but a proxy (e.g., litellm) may expose the Anthropic Messages API with `bearer` auth.
 
 ### Provisioning Flow
 

--- a/architecture/providers.md
+++ b/architecture/providers.md
@@ -2,18 +2,18 @@
 
 ## LLM Provider
 
-An LLM provider represents a connection to an external LLM service. Each provider declares which wire protocol it speaks — OpenAI Responses API or Anthropic Messages API. The [LLM Proxy](llm-proxy.md) uses the matching protocol when forwarding requests.
+An LLM provider represents a connection to an external LLM service. Each provider declares which LLM API protocol it speaks — OpenAI Responses API or Anthropic Messages API. The [LLM Proxy](llm-proxy.md) uses the matching protocol when forwarding requests.
 
 ### Resource Definition
 
 | Field | Type | Description |
 |-------|------|-------------|
 | `endpoint` | string | Base URL of the provider API (e.g., `https://api.openai.com`, a litellm proxy URL, an OpenRouter URL) |
-| `wire_api` | enum | Wire protocol the provider speaks. Supported: `responses` (OpenAI Responses API), `anthropic_messages` (Anthropic Messages API) |
+| `protocol` | enum | LLM API protocol the provider speaks. Supported: `responses` (OpenAI Responses API), `anthropic_messages` (Anthropic Messages API) |
 | `authMethod` | enum | Authentication method. Supported: `bearer`, `x_api_key` |
 | `token` | string | Authentication token |
 
-`wire_api` determines how the [LLM Proxy](llm-proxy.md) communicates with the provider — which HTTP endpoint path, request/response format, and streaming event protocol to use. See [LLM Proxy — Wire API Protocols](llm-proxy.md#wire-api-protocols) for the details of each protocol.
+`protocol` determines how the [LLM Proxy](llm-proxy.md) communicates with the provider — which HTTP endpoint path, request/response format, and streaming event protocol to use. See [LLM Proxy — Protocols](llm-proxy.md#protocols) for the details of each protocol.
 
 `authMethod` determines how the LLM Proxy authenticates with the provider:
 
@@ -22,7 +22,7 @@ An LLM provider represents a connection to an external LLM service. Each provide
 | `bearer` | `Authorization` | `Bearer <token>` |
 | `x_api_key` | `x-api-key` | `<token>` |
 
-The auth method is independent of the wire API. An Anthropic-protocol provider typically uses `x_api_key`, but a proxy (e.g., litellm) may expose the Anthropic Messages API with `bearer` auth.
+The auth method is independent of the protocol. An Anthropic-protocol provider typically uses `x_api_key`, but a proxy (e.g., litellm) may expose the Anthropic Messages API with `bearer` auth.
 
 ### Provisioning Flow
 

--- a/changes/2026-08-25-claude-code-agent-support.md
+++ b/changes/2026-08-25-claude-code-agent-support.md
@@ -1,0 +1,78 @@
+# Claude Code Agent Support
+
+## Target
+
+- [Architecture: LLM Proxy](../architecture/llm-proxy.md)
+- [Architecture: LLM Service](../architecture/llm.md)
+- [Architecture: Providers, Models, and Secrets — LLM Provider](../architecture/providers.md#llm-provider)
+- [Architecture: agynd-cli — LLM Endpoint Configuration](../architecture/agynd-cli.md#llm-endpoint-configuration)
+- [Architecture: agynd-cli — Agent Communication Protocol](../architecture/agynd-cli.md#agent-communication-protocol)
+- [Architecture: Agent Init Container](../architecture/agent-init.md)
+
+## Delta
+
+Claude Code cannot run as an agent on the platform. The following are not implemented:
+
+### LLM Proxy — Anthropic Messages API endpoint
+
+- `POST /v1/messages` endpoint does not exist. The LLM Proxy only serves `POST /v1/responses` (OpenAI Responses API).
+- Anthropic Messages API request/response forwarding is not implemented (different request schema, different SSE streaming event types, `anthropic-version` header forwarding).
+- Caller authentication via `x-api-key` header is not implemented (the proxy only reads `Authorization: Bearer`).
+- Wire protocol validation (caller endpoint must match provider `wire_api`) is not implemented.
+
+### LLM Service — Protocol-aware model resolution
+
+- `ResolveModel` does not return `wire_api` or `auth_method`. It returns `endpoint`, `token`, `remote_name`, `organization_id` only.
+- The LLM proto (`agynio/api`) does not have `wire_api` or `auth_method` fields on the `ResolveModelResponse` message.
+
+### LLM Provider — `wire_api` and `authMethod` extension
+
+- The LLM Provider resource has no `wire_api` field. All providers are assumed to speak OpenAI Responses API.
+- The `authMethod` enum only supports `bearer`. `x_api_key` (for Anthropic's `x-api-key` header) is not supported.
+- The LLM Provider proto (`agynio/api`) does not have a `wire_api` field on the `LLMProvider` message.
+- The Agents service (`agynio/agents`) does not store or validate `wire_api` on LLM Provider resources.
+- The Terraform provider (`agynio/terraform-provider-agyn`) does not expose `wire_api` on the `agyn_llm_provider` resource.
+
+### agynd — Claude Code environment preparation
+
+- `agynd` does not write `~/.claude/settings.json`. Claude Code LLM endpoint configuration (via `ANTHROPIC_BASE_URL`, `ANTHROPIC_AUTH_TOKEN` in the `env` block) is not implemented.
+- `agynd` does not configure Claude Code permissions (the `permissions` block granting all built-in tools).
+- `agynd` does not set `DISABLE_AUTOUPDATER` or `CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC` for Claude Code.
+- Skills placement for Claude Code (filesystem path conventions for `CLAUDE.md` or equivalent) is not implemented.
+- MCP server configuration for Claude Code (writing `~/.claude/settings.json` `mcpServers` block, or using `--mcp-config` flag) is not implemented.
+
+### agynd — `claude-sdk-go` integration
+
+- The `claude-sdk-go` repository (`agynio/claude-sdk-go`) does not exist.
+- `agynd` returns `unsupported` at runtime when `sdk: claude` is specified in `config.json`.
+- The Claude Code JSONL subprocess protocol (spawn `claude --output-format stream-json --input-format stream-json --verbose`, parse NDJSON messages discriminated by `type` field) is not implemented in any Go module.
+
+### Agent init container — `agent-init-claude`
+
+- The `agynio/agent-init-claude` repository does not exist.
+- The init container image `ghcr.io/agynio/agent-init-claude:<version>` is not built or published.
+- Claude Code native binary (`linux-x64-musl` variant) download and packaging in the Dockerfile is not implemented.
+- `libgcc`/`libstdc++` bundling for the Claude Code binary on Alpine-based user images is not implemented.
+- `config.json` with `{ "sdk": "claude", "bin": "/agyn-bin/claude" }` does not exist.
+- `versions.env` pinning `AGYND_VERSION` and `CLAUDE_VERSION` does not exist.
+- CI workflow for building and publishing the image does not exist.
+
+## Acceptance Signal
+
+- An agent with `init_image: ghcr.io/agynio/agent-init-claude:<version>` starts successfully.
+- Claude Code inside the agent container connects to the LLM Proxy via `POST /v1/messages` and receives streaming responses.
+- An LLM Provider with `wire_api: anthropic_messages` and `authMethod: x_api_key` can be created and used to resolve models.
+- Claude Code has full tool permissions (no interactive prompts) via `settings.json` permissions block.
+- Claude Code has auto-updater and non-essential traffic disabled.
+- `claude-sdk-go` spawns the Claude Code subprocess, sends user messages, and receives NDJSON responses.
+- `agynd` writes `~/.claude/settings.json` with the correct `env` and `permissions` blocks before spawning Claude Code.
+- MCP tool servers are accessible to Claude Code via MCP configuration.
+- The `agyn_llm_provider` Terraform resource supports the `wire_api` field.
+
+## Notes
+
+- `claude-sdk-go` protocol spec lives in the `agynio/claude-sdk-go` repository, not in architecture docs. The protocol is reverse-engineered from Anthropic's Python and TypeScript SDK sources and has no formal specification.
+- Token counting changes are out of scope. Claude Code handles its own token counting internally.
+- The LLM Proxy does not translate between wire protocols. A `POST /v1/messages` request is only valid when the resolved provider has `wire_api: anthropic_messages`.
+- Claude Code's native binary (`linux-x64-musl`) is not fully static — it dynamically links `libgcc` and `libstdc++`. The init container image must bundle these libraries (from Alpine's `libgcc` and `libstdc++` packages) and ensure they are available at `/agyn-bin/lib/` or equivalent for the binary to find at runtime.
+- Claude Code permission management uses `settings.json` `permissions.allow` block to grant all tool permissions. The platform provides security isolation at the container level, so the agent can perform any action.

--- a/changes/2026-08-25-claude-code-agent-support.md
+++ b/changes/2026-08-25-claude-code-agent-support.md
@@ -18,20 +18,20 @@ Claude Code cannot run as an agent on the platform. The following are not implem
 - `POST /v1/messages` endpoint does not exist. The LLM Proxy only serves `POST /v1/responses` (OpenAI Responses API).
 - Anthropic Messages API request/response forwarding is not implemented (different request schema, different SSE streaming event types, `anthropic-version` header forwarding).
 - Caller authentication via `x-api-key` header is not implemented (the proxy only reads `Authorization: Bearer`).
-- Wire protocol validation (caller endpoint must match provider `wire_api`) is not implemented.
+- Wire protocol validation (caller endpoint must match provider `protocol`) is not implemented.
 
 ### LLM Service — Protocol-aware model resolution
 
-- `ResolveModel` does not return `wire_api` or `auth_method`. It returns `endpoint`, `token`, `remote_name`, `organization_id` only.
-- The LLM proto (`agynio/api`) does not have `wire_api` or `auth_method` fields on the `ResolveModelResponse` message.
+- `ResolveModel` does not return `protocol` or `auth_method`. It returns `endpoint`, `token`, `remote_name`, `organization_id` only.
+- The LLM proto (`agynio/api`) does not have `protocol` or `auth_method` fields on the `ResolveModelResponse` message.
 
-### LLM Provider — `wire_api` and `authMethod` extension
+### LLM Provider — `protocol` and `authMethod` extension
 
-- The LLM Provider resource has no `wire_api` field. All providers are assumed to speak OpenAI Responses API.
+- The LLM Provider resource has no `protocol` field. All providers are assumed to speak OpenAI Responses API.
 - The `authMethod` enum only supports `bearer`. `x_api_key` (for Anthropic's `x-api-key` header) is not supported.
-- The LLM Provider proto (`agynio/api`) does not have a `wire_api` field on the `LLMProvider` message.
-- The Agents service (`agynio/agents`) does not store or validate `wire_api` on LLM Provider resources.
-- The Terraform provider (`agynio/terraform-provider-agyn`) does not expose `wire_api` on the `agyn_llm_provider` resource.
+- The LLM Provider proto (`agynio/api`) does not have a `protocol` field on the `LLMProvider` message.
+- The Agents service (`agynio/agents`) does not store or validate `protocol` on LLM Provider resources.
+- The Terraform provider (`agynio/terraform-provider-agyn`) does not expose `protocol` on the `agyn_llm_provider` resource.
 
 ### agynd — Claude Code environment preparation
 
@@ -61,18 +61,18 @@ Claude Code cannot run as an agent on the platform. The following are not implem
 
 - An agent with `init_image: ghcr.io/agynio/agent-init-claude:<version>` starts successfully.
 - Claude Code inside the agent container connects to the LLM Proxy via `POST /v1/messages` and receives streaming responses.
-- An LLM Provider with `wire_api: anthropic_messages` and `authMethod: x_api_key` can be created and used to resolve models.
+- An LLM Provider with `protocol: anthropic_messages` and `authMethod: x_api_key` can be created and used to resolve models.
 - Claude Code has full tool permissions (no interactive prompts) via `settings.json` permissions block.
 - Claude Code has auto-updater and non-essential traffic disabled.
 - `claude-sdk-go` spawns the Claude Code subprocess, sends user messages, and receives NDJSON responses.
 - `agynd` writes `~/.claude/settings.json` with the correct `env` and `permissions` blocks before spawning Claude Code.
 - MCP tool servers are accessible to Claude Code via MCP configuration.
-- The `agyn_llm_provider` Terraform resource supports the `wire_api` field.
+- The `agyn_llm_provider` Terraform resource supports the `protocol` field.
 
 ## Notes
 
 - `claude-sdk-go` protocol spec lives in the `agynio/claude-sdk-go` repository, not in architecture docs. The protocol is reverse-engineered from Anthropic's Python and TypeScript SDK sources and has no formal specification.
 - Token counting changes are out of scope. Claude Code handles its own token counting internally.
-- The LLM Proxy does not translate between wire protocols. A `POST /v1/messages` request is only valid when the resolved provider has `wire_api: anthropic_messages`.
+- The LLM Proxy does not translate between protocols. A `POST /v1/messages` request is only valid when the resolved provider has `protocol: anthropic_messages`.
 - Claude Code's native binary (`linux-x64-musl`) is not fully static — it dynamically links `libgcc` and `libstdc++`. The init container image must bundle these libraries (from Alpine's `libgcc` and `libstdc++` packages) and ensure they are available at `/agyn-bin/lib/` or equivalent for the binary to find at runtime.
 - Claude Code permission management uses `settings.json` `permissions.allow` block to grant all tool permissions. The platform provides security isolation at the container level, so the agent can perform any action.


### PR DESCRIPTION
## Summary

Architecture updates and changes file for Claude Code agent support. This covers the full vertical: LLM Proxy → LLM Service → Provider → agynd → agent-init.

## Architecture Updates

### `providers.md` — LLM Provider resource
- Added `wire_api` enum field (`responses` | `anthropic_messages`) to declare which wire protocol the provider speaks
- Extended `authMethod` enum with `x_api_key` (Anthropic's `x-api-key` header format)
- Auth method is independent of wire API — a proxy could expose Anthropic Messages API with Bearer auth

### `llm.md` — LLM Service
- `ResolveModel` response now includes `wire_api` and `auth_method` (from the provider's fields)
- LLM Proxy uses these to select the correct forwarding protocol and auth header

### `llm-proxy.md` — LLM Proxy
- Added `POST /v1/messages` endpoint (Anthropic Messages API)
- Added `Wire API Protocols` section documenting both protocols side-by-side
- Caller auth now checks both `Authorization: Bearer` and `x-api-key` headers on all endpoints
- Wire protocol validation: caller endpoint must match provider's `wire_api` (400 on mismatch)
- Documented Anthropic SSE streaming event types
- `anthropic-version` header forwarded to provider

### `agynd-cli.md` — agynd
- Added Claude Code LLM endpoint configuration via `~/.claude/settings.json`
- `env` block: `ANTHROPIC_BASE_URL`, `ANTHROPIC_AUTH_TOKEN`, `DISABLE_AUTOUPDATER`, `CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC`
- `permissions` block: grants all built-in tools (Bash, Read, Write, Edit, Glob, Grep, etc.) — security is at the container level

### `agent-init.md` — Agent Init Container
- Clarified Claude Code binary is `linux-x64-musl` variant (not fully static)
- Documents `libgcc`/`libstdc++` dependency bundling in init image

## Changes File

`changes/2026-08-25-claude-code-agent-support.md` — full delta covering:
- LLM Proxy (POST /v1/messages, x-api-key auth, wire_api validation)
- LLM Service (wire_api/auth_method in ResolveModel)
- LLM Provider (wire_api field, x_api_key auth method)
- agynd (Claude Code settings.json, permissions, MCP config, skills)
- claude-sdk-go (new repo, JSONL protocol)
- agent-init-claude (new repo, Dockerfile, binary packaging)

## Decisions

- `wire_api` lives on the **Provider** (not Model) — all models from a provider use the same protocol
- Claude Code permissions: grant **all** tools — isolation at container level
- Claude Code config: via `~/.claude/settings.json` (not env vars) — consistent with Codex `config.toml` pattern
- Token counting: **out of scope** — Claude Code handles its own
- `claude-sdk-go` spec: lives in its own repo, not architecture docs