### PR TITLE
docs: enrollment invariants, updated re-enrollment delta, migration policy

### DIFF
--- a/architecture/README.md
+++ b/architecture/README.md
@@ -12,6 +12,7 @@ Desired architecture state of the platform.
   - [Terraform Provider](operations/terraform-provider.md)
   - [New Service Development](operations/new-service.md)
   - [E2E Testing](operations/e2e-testing.md)
+  - [Database Migrations](operations/database-migrations.md)
 
 ## By domain
 
@@ -87,3 +88,4 @@ Desired architecture state of the platform.
 - [Terraform Provider](operations/terraform-provider.md)
 - [New Service Development](operations/new-service.md)
 - [E2E Testing](operations/e2e-testing.md)
+- [Database Migrations](operations/database-migrations.md)

--- a/architecture/openziti.md
+++ b/architecture/openziti.md
@@ -401,6 +401,16 @@ The enrollment response includes the service name (`runner-{runnerId}`) that the
 1. Deletes the runner's current OpenZiti identity (if any) and the per-runner OpenZiti service (`runner-{runnerId}`) via Ziti Management `DeleteRunnerIdentity`.
 2. Removes the runner record from the Runners service database.
 
+### Enrollment Invariants
+
+These invariants apply to both runner enrollment (`CreateRunnerIdentity`) and app enrollment (`CreateAppIdentity`). They ensure that bootstrap re-apply, pod restart, and manual re-enrollment succeed without manual cleanup.
+
+1. **Idempotent by externalId.** Before creating a new OpenZiti identity, Ziti Management queries `GET /identities?filter=externalId="<platformId>"` and deletes any matching identities. This prevents the OpenZiti Controller's unique index on `externalId` from rejecting the new identity.
+2. **Managed identity record cleanup.** Before inserting the new `managed_identities` row, the server deletes any existing row for the same `identity_id`. The unique index on `identity_id` requires this — a stale row from a previous enrollment must not block the insert.
+3. **No service creation during enrollment.** Enrollment creates only the OpenZiti identity and the `managed_identities` mapping. The per-runner/per-app OpenZiti service is created during registration (`RegisterRunner` / `RegisterApp`), not enrollment. Re-enrollment must not attempt to re-create the service.
+4. **Enrollment is the only credential source.** Each enrollment produces a fresh x509 certificate and private key. Previous credentials are invalidated when the old identity is deleted. There is no certificate rotation without re-enrollment.
+5. **Atomic cleanup.** The delete-previous → create-new → insert-mapping sequence must leave no orphaned state. If identity creation fails after deleting the previous identity, the runner is left unenrolled (no identity) and can retry. If the mapping insert fails after identity creation, the newly created identity is deleted as cleanup.
+
 ### Addressing
 
 The Orchestrator and Terminal Proxy reach a specific runner by dialing its per-runner OpenZiti service:
@@ -479,7 +489,7 @@ sequenceDiagram
     App->>App: Dial Gateway for platform APIs
 ```
 
-This follows the same pattern as [runner enrollment](#runner-provisioning). The service token is long-lived — if the app restarts, it re-enrolls and receives a new OpenZiti identity. `CreateAppIdentity` is idempotent — if a previous identity exists for this app, Ziti Management deletes it before creating the new one.
+This follows the same pattern as [runner enrollment](#runner-provisioning). The service token is long-lived — if the app restarts, it re-enrolls and receives a new OpenZiti identity. `CreateAppIdentity` is idempotent — if a previous identity exists for this app, Ziti Management deletes it before creating the new one. The same [enrollment invariants](#enrollment-invariants) apply.
 
 ### Identity Creation Request
 

--- a/architecture/operations/database-migrations.md
+++ b/architecture/operations/database-migrations.md
@@ -1,0 +1,62 @@
+# Database Migrations
+
+Rules for SQL migration files across all services that use the filename-based migration runner (`internal/db/migrate.go`).
+
+## Migration Runner
+
+Each service embeds its SQL migrations in a `migrations/` directory. The runner applies files in lexicographic order, tracking each applied file by **filename** in a `schema_migrations` table:
+
+```sql
+CREATE TABLE IF NOT EXISTS schema_migrations (
+    version    TEXT PRIMARY KEY,
+    applied_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+```
+
+The runner has no content hashing — it uses the filename as the sole version key.
+
+## Rules
+
+### 1. Migrations Are Immutable
+
+Once a migration file is committed to `main`, its **filename and contents must never change**. Any schema change — including corrections to a previous migration — must be a new file with a new sequence number.
+
+Renaming a file (e.g., `0003_add_nickname.sql` → `0003_add_email.sql`) creates a new version key. Databases that applied the old filename will see the renamed file as unapplied and attempt to re-execute its contents, causing failures.
+
+### 2. Migrations Must Be Idempotent
+
+Every migration must succeed when applied to a database that already has the described state. Use defensive DDL:
+
+| Operation | Pattern |
+|-----------|---------|
+| Add column | `ALTER TABLE t ADD COLUMN IF NOT EXISTS col TYPE ...` |
+| Create table | `CREATE TABLE IF NOT EXISTS t (...)` |
+| Create index | `CREATE INDEX IF NOT EXISTS idx ON t (...)` |
+| Drop column | `ALTER TABLE t DROP COLUMN IF EXISTS col` |
+| Drop table | `DROP TABLE IF EXISTS t` |
+| Drop index | `DROP INDEX IF EXISTS idx` |
+
+This protects against bootstrap re-apply and partial-failure recovery scenarios where the DDL succeeded but the `schema_migrations` insert did not commit.
+
+### 3. Sequence Numbering
+
+Files are named `NNNN_<description>.sql` with a zero-padded four-digit prefix. The next number is always `max(existing) + 1` on the `main` branch at the time the PR is opened.
+
+### 4. No Data Mutations in Schema Migrations
+
+Schema migrations (`ALTER TABLE`, `CREATE INDEX`, etc.) must not contain `INSERT`, `UPDATE`, or `DELETE` statements against application tables. Seed data belongs in a separate mechanism.
+
+### 5. Backward Compatibility Window
+
+A migration must not break the previous service version that is still running during a rolling deployment. Destructive changes (drop column, drop table) require a two-phase approach:
+
+1. **Phase 1**: Deploy a version that stops reading/writing the column.
+2. **Phase 2**: Add the migration that drops the column.
+
+## Violations and Recovery
+
+If a migration file has already been mutated or renamed in a released version:
+
+1. **Do not revert the file to its original state** — databases running the current version already applied the mutated content.
+2. Add a new migration that makes the schema converge regardless of which version of the mutated migration was applied. Use `IF NOT EXISTS` / `IF EXISTS` guards.
+3. Document the incident in the service's `CONTRIBUTING.md`.

--- a/changes/2026-04-06-runner-app-re-enrollment.md
+++ b/changes/2026-04-06-runner-app-re-enrollment.md
@@ -4,33 +4,15 @@
 
 - [OpenZiti Integration — Runner Provisioning](../architecture/openziti.md#runner-provisioning)
 - [OpenZiti Integration — App Identity Lifecycle](../architecture/openziti.md#app-identity-lifecycle)
+- [OpenZiti Integration — Enrollment Invariants](../architecture/openziti.md#enrollment-invariants)
 - [Runners — Enrollment](../architecture/runners.md#enrollment)
-- [Runners — Registration Flow](../architecture/runners.md#registration-flow)
-- [Runners — Deletion](../architecture/runners.md#deletion)
 
 ## Delta
 
-**Runner enrollment fails on restart.** `CreateRunnerIdentity` in Ziti Management creates a new OpenZiti identity with `externalId: runnerId` without deleting the previous one. The OpenZiti Controller enforces a unique index on `externalId`, causing a `400 Bad Request` (`duplicate value in unique index on identities store`).
-
-Specific gaps between desired state and current implementation:
-
-1. **Ziti Management `CreateRunnerIdentity`** does not look up or delete a previous managed identity for the same runner before creating a new one.
-2. **Ziti Management `CreateRunnerIdentity`** creates the per-runner OpenZiti service (`runner-{runnerId}`) on every enrollment call. The architecture specifies service creation during registration (`RegisterRunner`), not enrollment. This also fails on re-enrollment (duplicate service name).
-3. **Runners Service `RegisterRunner`** does not create the per-runner OpenZiti service. The architecture specifies it should call Ziti Management `CreateService`.
-4. **Runners Service `DeleteRunner`** does not clean up the runner's OpenZiti identity or service. The architecture specifies it should call Ziti Management `DeleteRunnerIdentity`.
-5. **Ziti Management** is missing the `CreateService`, `DeleteRunnerIdentity`, and `DeleteAppIdentity` RPCs described in the architecture.
-6. **`CreateAppIdentity`** has the same re-enrollment gap as runners — no cleanup of previous identity.
+Re-enrollment succeeds on the OpenZiti Controller (previous identity is deleted by `externalId` before creating a new one) but fails at the database layer. The previous managed identity record is not cleaned up before inserting the new one, violating the unique constraint on `identity_id`. Both runner and app enrollment are affected.
 
 ## Acceptance Signal
 
-- A runner can be restarted (or upgraded) and successfully re-enroll without manual intervention.
-- `CreateRunnerIdentity` deletes the previous identity before creating a new one.
-- `CreateRunnerIdentity` does not create the OpenZiti service (service creation happens at registration).
-- `RegisterRunner` creates the per-runner OpenZiti service via `CreateService`.
-- `DeleteRunner` cleans up the OpenZiti identity and service via `DeleteRunnerIdentity`.
-- App enrollment (`CreateAppIdentity`) handles re-enrollment identically.
+- A runner can be restarted and successfully re-enroll without manual intervention.
+- App re-enrollment behaves identically.
 - E2E test: register runner → enroll → restart → re-enroll succeeds.
-
-## Notes
-
-The architecture docs incorrectly claimed "the previous identity is cleaned up by Ziti Management lease GC." Lease GC only applies to ephemeral service identities (Orchestrator, Gateway pods), not to runner/app managed identities. The architecture has been updated to describe explicit cleanup during re-enrollment.


### PR DESCRIPTION
## Summary

Three documentation changes addressing the CrashLoopBackOff investigation findings and architecture issue #130.

### 1. Enrollment Invariants (`architecture/openziti.md`)

New `### Enrollment Invariants` section under Runner Provisioning, cross-referenced from App Identity Lifecycle. Documents the five invariants that enrollment RPCs must satisfy:

1. **Idempotent by externalId** — query + delete previous OpenZiti identity before create
2. **Managed identity record cleanup** — delete previous `managed_identities` row before insert (unique index on `identity_id`)
3. **No service creation during enrollment** — service belongs to registration, not enrollment
4. **Enrollment is the only credential source** — no rotation without re-enrollment
5. **Atomic cleanup** — no orphaned identities or DB rows on partial failure

### 2. Updated re-enrollment change file

`changes/2026-04-06-runner-app-re-enrollment.md` — updated to reflect current implementation state:

- **Resolved:** `ziti-management` PR #41 (merged to `main`, closing #39) added `deleteIdentityByExternalID` to both `CreateAndEnrollRunnerIdentity` and `CreateAndEnrollAppIdentity`. The OpenZiti Controller side of re-enrollment is now idempotent.
- **Remaining gap:** `CreateRunnerIdentity` / `CreateAppIdentity` in `server.go` do not delete the previous `managed_identities` row before `InsertManagedIdentity`. Migration `0006_make_identity_id_unique` enforces a unique index, so re-enrollment still fails at the DB layer.
- Removed stale references to PR #40 and `noa/issue-1` branch.

### 3. Database migrations policy (`architecture/operations/database-migrations.md`)

New operations doc codifying migration rules:

- Immutable filenames and contents once merged
- Idempotent DDL patterns (`IF NOT EXISTS` / `IF EXISTS`)
- Sequence numbering, no data mutations, backward compatibility window
- Recovery procedure for already-mutated migrations

Prompted by the `users-service` `0001_init.sql` mutation and `0003` rename that caused CrashLoopBackOff on bootstrap re-apply.

## Related

- Closes #130
- Architecture PR #109 (merged) — original re-enrollment doc updates
- `agynio/ziti-management` PR #41 (merged) — OpenZiti externalId cleanup fix
- `agynio/ziti-management` issue #39 (closed) — original bug report
- `agynio/users` PR #19 — migration ghost entry cleanup