### PR TITLE
docs(egress): distinguish ziti service id

### DIFF
--- a/architecture/resource-definitions.md
+++ b/architecture/resource-definitions.md
@@ -243,7 +243,7 @@ A rule that mediates outbound HTTP/HTTPS traffic from agent workloads. Org-scope
 | `name` | string | | Human-readable label |
 | `matcher` | object | | Which requests the rule applies to. See [Matcher](#matcher) |
 | `effect` | object | | What happens to matching requests. See [Effect](#effect) |
-| `openziti_service_id` | string | | OpenZiti service ID created for this rule (`egress-rule-<id>`). Internal — not returned through the Gateway |
+| `openziti_service_id` | string | | OpenZiti service ID returned by Ziti Management for this rule. The OpenZiti service name is `egress-rule-<id>`; Dial policy selectors target the concrete ID as `@<openziti_service_id>`. Internal — not returned through the Gateway |
 
 Uniqueness: `(organization_id, matcher.domain_pattern)`. Reserved domain patterns are rejected at create time: `*.ziti`, `*.svc`, `*.cluster.local`, and any pattern overlapping the OpenZiti synthetic range (`100.64.0.0/10`).
 


### PR DESCRIPTION
## Summary
- Clarify the `EgressRule.openziti_service_id` field is the concrete OpenZiti service ID returned by Ziti Management.
- Clarify `egress-rule-<id>` is the OpenZiti service name, while Dial policy selectors use `@<openziti_service_id>`.
- Leave the Private Resource row unchanged; it is outside this egress selector consistency fix and was not identified as the same Dial selector bug.

Refs #156

## Validation
- `git diff --check`
- `rg -n "OpenZiti service ID created for this rule|@egress-rule|serviceRoles:\\s*\\[\\\"@egress-rule" architecture/resource-definitions.md architecture/egress-rules-service.md architecture/egress-gateway.md changes/2026-05-14-egress-gateway.md || true`