### PR TITLE
docs: align sandbox architecture references

### DIFF
--- a/architecture/agents-service.md
+++ b/architecture/agents-service.md
@@ -151,10 +151,13 @@ The Agents service publishes events to the [Notifications](notifications.md) ser
 | `agent.updated` | `agent:{class_id}` | The agent class is created, updated, or deleted, *or* any of its sub-resources (MCP, Skill, Hook, ENV, InitScript, Volume, Volume Attachment, Image Pull Secret Attachment) is created, updated, or deleted |
 | `message.created` | `instance_inbox:{instance_id}` | A new [inbox item](agent-instances.md#inbox) is written for an instance (via `FanoutInboxItem` from Threads or `WriteInboxItem` from an app) |
 | `instance.updated` | `agent:{class_id}` | Instance state transitions (`active`, `paused`, `terminated`) or metadata changes on any instance of the class |
+| `sandbox.updated` | `sandbox_owner:{owner_id}` and `sandbox_org:{organization_id}` | Sandbox lifecycle or bookkeeping changes: create, status transition, stop, delete/terminate, `last_session_at` update, or workload association update |
 
 **Transitive `updated_at` propagation.** A successful write to a sub-resource bumps the owning agent's `updated_at` in the same transaction. Consumers that compare timestamps — for example, the [Agents Orchestrator's Start Decision](agents-orchestrator.md#start-decision), which uses `Agent.updated_at > failed_workload.removed_at` to decide whether a configuration change warrants a retry — therefore only need to read the agent record. No traversal of sub-resources is required.
 
-Room subscription authorization is documented in [Notifications — Authorization](notifications.md#authorization): `member` on the agent's organization.
+Room subscription authorization is documented in [Notifications — Authorization](notifications.md#authorization). Agent rooms require `member` on the agent's organization. Sandbox owner rooms require the caller identity to match `{owner_id}`; sandbox org rooms require `can_list_sandboxes` on `organization:{organization_id}` so organization owners can maintain list-all views.
+
+`sandbox.updated` payloads include the sandbox ID, organization ID, owner ID, name, environment ID, status, idle timeout, TTL, `last_session_at`, and current workload ID when one exists. Terminated sandboxes are still emitted to both rooms so default lists can remove the row while `--terminated` views retain audit visibility.
 
 ## Authorization
 
@@ -171,6 +174,13 @@ Agent access is split into two layers: organization-level gates the creation and
 | `ListMyAgentRoles` | Self only — returns the caller's own role assignments |
 | Update, Delete on Volume | `owner` on `organization:<volume.org_id>` |
 | Get, List on Volume (via Gateway) | `member` on `organization:<volume.org_id>` |
+| `CreateSandbox` | `can_create_sandbox` on `organization:<org_id>`; owner is derived from authenticated context |
+| `GetSandbox` | Sandbox owner or `can_list_sandboxes` on `organization:<sandbox.org_id>` |
+| `ListSandboxes` (own) | `member` on `organization:<org_id>` and server filters to `owner_id == caller.identity_id` |
+| `ListSandboxes` (`all=true`) | `can_list_sandboxes` on `organization:<org_id>` |
+| `StopSandbox`, `DeleteSandbox` | `can_stop` / `can_delete` on `sandbox:<id>` |
+| `EnsureSandboxRunning` | `can_connect` on `sandbox:<id>` |
+| `UpdateSandboxLastSession` | Internal only (Terminal Proxy via Istio) |
 
 `SetAgentRole` rejects identities that are not members of the agent's organization. The check is performed against the `member` relation on the agent's org before the role tuple is written.
 
@@ -184,7 +194,7 @@ See [Authorization — Agents Service](authz.md#agents-service) for the full ref
 
 ## Tuple Lifecycle
 
-The Agents service is the writer of OpenFGA tuples on the `agent` type. All writes and deletes are issued through the [Authorization](authz.md) service; the Agents service does not store any of these tuples locally.
+The Agents service is the writer of OpenFGA tuples on the `agent` and `sandbox` types. All writes and deletes are issued through the [Authorization](authz.md) service; the Agents service does not store any of these tuples locally.
 
 | Event | Tuples written | Tuples deleted |
 |-------|----------------|----------------|
@@ -195,6 +205,8 @@ The Agents service is the writer of OpenFGA tuples on the `agent` type. All writ
 | `SetAgentRole(identity, role)` (identity already holds a different role) | `identity:<id>, <new_role>, agent:<agent_id>` | `identity:<id>, <old_role>, agent:<agent_id>` |
 | `RemoveAgentRole(identity)` | — | `identity:<id>, <role>, agent:<agent_id>` |
 | `DeleteAgent` | — | All tuples on `agent:<id>` (`org`, `internal_access`, every `owner`/`maintainer`/`participant`) |
+| `CreateSandbox` | `organization:<org_id>, org, sandbox:<id>`; `identity:<creator_id>, owner, sandbox:<id>` | — |
+| `DeleteSandbox` / terminal TTL expiration | — | All tuples on `sandbox:<id>` (`org`, `owner`) |
 
 Tuple writes and deletes are issued in the same `Write` call as the underlying DB mutation when atomicity is required (see [Authorization — Relationship Writes](authz.md#relationship-writes)).
 

--- a/architecture/authz.md
+++ b/architecture/authz.md
@@ -70,13 +70,15 @@ type organization
     define can_view_volumes: owner or admin from cluster
     define can_add_member: admin from cluster
     define can_create_thread: member or thread_create
+    define can_create_sandbox: member
+    define can_list_sandboxes: owner
     define thread_create: [identity]
     define thread_write: [identity]
     define participant_add: [identity]
     define inbox_write: [identity]
 ```
 
-`owner` implies `member`, `can_invite`, `can_manage_members`, `can_view_threads`, `can_view_workloads`, and `can_view_volumes`. `owner` does **not** imply `can_create_thread` directly — instead `can_create_thread` is computed from `member`, and owners are also members, so owners can always create threads.
+`owner` implies `member`, `can_invite`, `can_manage_members`, `can_view_threads`, `can_view_workloads`, `can_view_volumes`, and `can_list_sandboxes`. `owner` does **not** imply `can_create_thread` or `can_create_sandbox` directly — instead those permissions are computed from `member`, and owners are also members, so owners can always create threads and sandboxes.
 
 `thread_create`, `thread_write`, `participant_add`, and `inbox_write` are **app installation permissions** — direct relations written when an app is installed. See [App Installation Permissions](#app-installation-permissions). `inbox_write` is consumed by the [`agent_instance`](#agent_instance) type via `inbox_write from org`.
 
@@ -182,6 +184,27 @@ When an instance is created, the Agents service writes:
 
 `DeleteInstance` (terminal) removes every tuple on `agent_instance:<id>`.
 
+#### sandbox
+
+[Sandboxes](../product/sandboxes/sandboxes.md) are org-scoped resources owned by the user who created them. Organization owners can list, stop, and delete every sandbox in the organization, but terminal attach is owner-only: an org owner cannot connect to another user's sandbox unless they are also that sandbox's `owner`.
+
+```
+type sandbox
+  relations
+    define org: [organization]
+    define owner: [identity]
+    define can_connect: owner
+    define can_stop: owner or owner from org
+    define can_delete: owner or owner from org
+    define can_list_all: owner from org
+```
+
+When a sandbox is created, the Agents service writes:
+- `organization:<org_id>, org, sandbox:<sandbox_id>`
+- `identity:<creator_id>, owner, sandbox:<sandbox_id>`
+
+When a sandbox is deleted/terminated, the Agents service removes every tuple on `sandbox:<sandbox_id>`. The sandbox record may remain soft-retained in Agents for audit and usage history; OpenFGA tuples are removed once it is no longer manageable/connectable as an active resource.
+
 #### group
 
 Groups are org-scoped collections of identities. The type defines membership, group-level admin, and computed view/edit permissions. See [Groups Service](groups-service.md) for the full lifecycle.
@@ -220,6 +243,8 @@ Other types (agent, thread, organization, etc.) reference groups via `group#memb
 | **can_view_workloads** | computed | List and read active workloads (and their containers and logs) in the organization. Held by owners and cluster admins |
 | **can_view_volumes** | computed | List and read provisioned volumes in the organization. Held by owners and cluster admins |
 | **can_create_thread** | computed | Create threads in the organization. Computed from `member` or `thread_create` |
+| **can_create_sandbox** | computed | Create sandboxes in the organization. Computed from `member` |
+| **can_list_sandboxes** | computed | List all sandboxes in the organization. Held by owners |
 | **thread_create** | app permission | Written for app installations that declare the `thread:create` permission |
 | **thread_write** | app permission | Written for app installations that declare the `thread:write` permission |
 | **participant_add** | app permission | Written for app installations that declare the `participant:add` permission |
@@ -227,7 +252,8 @@ Other types (agent, thread, organization, etc.) reference groups via `group#memb
 
 #### Computed relations
 
-- `owner` implies `member`, `can_invite`, `can_manage_members`, `can_view_threads`, `can_view_workloads`, and `can_view_volumes`.
+- `owner` implies `member`, `can_invite`, `can_manage_members`, `can_view_threads`, `can_view_workloads`, `can_view_volumes`, and `can_list_sandboxes`.
+- `can_create_sandbox` follows `member`; every active organization member can create a sandbox.
 - `can_add_member`, `can_view_threads`, `can_view_workloads`, and `can_view_volumes` each include `admin from cluster` — any identity with the `admin` relation on `cluster:global` holds these permissions on every organization. Modeled as cross-type computed relations, not as explicit per-organization tuples.
 - `can_create_thread` is computed from `member` or `thread_create` — any org member can create threads, as can any app identity that has been granted the `thread:create` installation permission.
 
@@ -284,6 +310,8 @@ Services own the tuples for the resources they manage. Tuples are written and de
 | Agent created | `organization:<org_id>, org, agent:<id>`; `identity:<creator>, owner, agent:<id>`; if `availability=internal`: `organization:<org_id>, internal_access, agent:<id>` | Agents |
 | Agent instance created | `agent:<class_id>, class, agent_instance:<id>`; `organization:<org_id>, org, agent_instance:<id>` | Agents |
 | Agent instance deleted (terminated) | Delete all tuples on `agent_instance:<id>` | Agents |
+| Sandbox created | `organization:<org_id>, org, sandbox:<id>`; `identity:<creator_id>, owner, sandbox:<id>` | Agents |
+| Sandbox deleted/terminated | Delete all tuples on `sandbox:<id>` | Agents |
 | Agent availability flipped `private → internal` | `organization:<org_id>, internal_access, agent:<id>` | Agents |
 | Agent availability flipped `internal → private` | Delete `organization:<org_id>, internal_access, agent:<id>` | Agents |
 | `SetAgentRole(identity, role)` | `identity:<id>, <role>, agent:<agent_id>`; if the identity previously held a different role on the agent: delete `identity:<id>, <old_role>, agent:<agent_id>` | Agents |
@@ -365,6 +393,13 @@ All agent resources (Agents, Volumes, MCPs, Skills, Hooks, ENVs, InitScripts, Vo
 | `GetUnackedInboxItems`, `AckInboxItems`, `GetUnackedInboxCount` | Self only — `caller.identity_id == agent_instance_id` (no OpenFGA check) |
 | Get, List (any resource, internal) | Internal only (Orchestrator via Istio) — used by [workload spec assembly](agents-orchestrator.md#workload-spec-assembly); returns resolved sub-resources across organizations without an org or per-agent check |
 | `ResolveAgentIdentity` | Internal only (Tracing via Istio) |
+| `CreateSandbox` | `can_create_sandbox` on `organization:<org_id>`; owner is derived from authenticated context |
+| `GetSandbox` | `owner` on `sandbox:<id>` or `can_list_sandboxes` on `organization:<sandbox.org_id>` |
+| `ListSandboxes` (own) | `member` on `organization:<org_id>` and server filters `owner_id == caller.identity_id` |
+| `ListSandboxes` (`all=true`) | `can_list_sandboxes` on `organization:<org_id>` |
+| `StopSandbox`, `DeleteSandbox` | `can_stop` / `can_delete` on `sandbox:<id>` |
+| `EnsureSandboxRunning` | `can_connect` on `sandbox:<id>` |
+| `UpdateSandboxLastSession` | Internal only (Terminal Proxy via Istio) |
 
 Agent workload identities (`identity_type == "agent_instance"`) satisfy `member` on their organization — resolved through the instance's `org` relation on the [`agent_instance` type](#agent_instance) — and may call read APIs needed for self-configuration, including `ListENVs` against their class (via the instance's `class` relation). `ListENVs` never returns resolved secret values — secret-backed ENVs expose only the `secret_id` reference. The Orchestrator injects all ENV values (plain-text and resolved secrets) as container environment variables at assembly time. The per-agent role model gates access by other identities and does not alter instance self-read.
 
@@ -387,7 +422,7 @@ Runners can be cluster-scoped (`organization_id` null) or org-scoped.
 | `GetWorkload`, `StreamWorkloadLogs` | `can_view_workloads` on `organization:<workload.org_id>` |
 | `ListWorkloadsByAgentInstance` (via Gateway) | `member` on `organization:<workload.org_id>` |
 | `ListWorkloadsByAgentInstance` (internal) | Internal only (Orchestrator via Istio) — used by the [start decision](agents-orchestrator.md#start-decision) |
-| `TouchWorkload` | Agent instance's own identity (`workload.agent_instance_id == caller.identity_id`) |
+| `TouchWorkload` | For `owner_kind=agent_instance`: agent instance's own identity (`workload.owner_id == caller.identity_id`). For `owner_kind=sandbox`: internal only from Terminal Proxy via Istio after terminal ticket validation |
 | `CreateVolume`, `UpdateVolume`, `BatchUpdateVolumeSampledAt` | Internal only (Orchestrator via Istio) |
 | `ListVolumes` (via Gateway) | `can_view_volumes` on `organization:<org_id>` (required request parameter) |
 | `ListVolumes` (internal) | Internal only (Orchestrator via Istio) — supports `runner_id_in`, `pending_sample`, and `status_in` filters across organizations; `organization_id` not required. Used by [volume reconciliation](agents-orchestrator.md#volume-reconciliation) and the [metering sampling loop](agents-orchestrator.md#sampling-algorithm) |

--- a/architecture/authz.md
+++ b/architecture/authz.md
@@ -580,6 +580,8 @@ The internal `Publish` RPC is Istio-only (trusted internal services). The extern
 | `instance_inbox:{id}` | `id == caller.identity_id` AND `caller.identity_type == agent_instance` (identity equality, no OpenFGA). `instance_inbox:me` is rewritten before the check. Only the instance itself may subscribe to its inbox room |
 | `workload:{id}` | `member` on `organization:<workload.org_id>` |
 | `agent:{id}` | `member` on `organization:<agent.org_id>` |
+| `sandbox_owner:{owner_id}` | `owner_id == caller.identity_id` (identity equality, no OpenFGA). `:me` is not accepted for this room pattern |
+| `sandbox_org:{organization_id}` | `can_list_sandboxes` on `organization:<organization_id>` |
 | `trace:{trace_id}` | `member` on `organization:<trace.org_id>` |
 
 ### Metering Service

--- a/architecture/gateway.md
+++ b/architecture/gateway.md
@@ -66,6 +66,7 @@ Only methods intended for external use appear in gateway proto services. Interna
 | Gateway Proto Service | Internal Service | Methods |
 |-----------------------|-----------------|---------|
 | `AgentsGateway` | [Agents](agents-service.md) | All CRUD methods for agents and sub-resources |
+| `TerminalGateway` | [Terminal Proxy](terminal-proxy.md) | CreateTerminalSession |
 | `ThreadsGateway` | [Threads](threads.md) | All methods |
 | `ChatGateway` | [Chat](chat.md) | All methods |
 | `NotificationsGateway` | [Notifications](notifications.md) | Subscribe (server-streaming) |
@@ -76,6 +77,19 @@ Only methods intended for external use appear in gateway proto services. Interna
 | `RunnersGateway` | [Runners](runners.md) | RegisterRunner, GetRunner, ListRunners, UpdateRunner, DeleteRunner, EnrollRunner, ListWorkloads, ListWorkloadsByAgentInstance, GetWorkload, TouchWorkload, StreamWorkloadLogs, GetVolume, ListVolumes, ListVolumesByAgentInstance |
 | `OrganizationsGateway` | [Organizations](organizations.md) | CreateOrganization, GetOrganization, ListOrganizations, UpdateOrganization, DeleteOrganization, CreateMembership, AcceptMembership, DeclineMembership, RemoveMembership, UpdateMembershipRole, ListMembers, ListMyMemberships |
 | `LLMGateway` | [LLM](llm.md) | CreateProvider, GetProvider, ListProviders, UpdateProvider, DeleteProvider, CreateModel, GetModel, ListModels, UpdateModel, DeleteModel |
+
+### Terminal Sessions
+
+`CreateTerminalSession` is the Gateway-exposed ticket issuance endpoint for browser and CLI terminal access. The client supplies a target `workload_id`, `container_name`, and optional command override. The request does not carry an identity; Gateway derives the caller identity from authenticated context and passes it only to the internal [Terminal Proxy](terminal-proxy.md) `IssueTicket` RPC.
+
+Gateway authorizes the target before issuing a ticket:
+
+| Target workload | Authorization |
+|-----------------|---------------|
+| Sandbox workload | `can_connect` on `sandbox:<sandbox_id>`. This is owner-only; org owners can stop/delete non-owned sandboxes but cannot attach unless they also own the sandbox |
+| Agent workload container | `can_edit_config` on the agent class |
+
+On success the response contains a short-lived signed ticket, the Terminal Proxy WebSocket URL, and the ticket expiry. The command is bound into the ticket at issuance; the WebSocket handshake carries terminal size only and cannot change the command.
 
 ### Handler Implementation
 

--- a/architecture/notifications.md
+++ b/architecture/notifications.md
@@ -84,6 +84,8 @@ Rooms are scoped by resource type and ID:
 | `instance_inbox:{id}` | `instance_inbox:9c1e6679-...` | Threads and apps → new [inbox items](agent-instances.md#inbox) for an [agent instance](agent-instances.md) |
 | `workload:{id}` | `workload:7c9e6679-...` | Runner → workload status changes, log events |
 | `agent:{id}` | `agent:f47ac10b-...` | Agents → agent (class) resource updates |
+| `sandbox_owner:{owner_id}` | `sandbox_owner:550e8400-...` | Agents → `sandbox.updated` events for a sandbox owner's own list/detail views |
+| `sandbox_org:{organization_id}` | `sandbox_org:9f8e7d6c-...` | Agents → `sandbox.updated` events for organization-owner list-all views |
 | `trace:{trace_id}` | `trace:5b8efff7-...` | Tracing → span created/updated events for a trace |
 | `organization:{id}` | `organization:9f8e7d6c-...` | EgressRules → `egress_rule.updated` / `egress_rule_attachment.updated` events |
 
@@ -100,7 +102,7 @@ For identity-scoped rooms, the literal string `me` is reserved as the id segment
 
 The Notifications service rewrites `:me` to the caller's `identity_id` on receipt, before authorization. Authorization rules are unchanged — the rewritten room passes the existing `id == caller.identity_id` check by construction.
 
-`:me` lets a client subscribe to its own room without first resolving its `identity_id` through another channel. It applies to identity-scoped rooms (`thread_participant:`, `instance_inbox:`); for `workload:`, `agent:`, and `trace:` the id segment is a resource id and `:me` has no meaning.
+`:me` lets a client subscribe to its own room without first resolving its `identity_id` through another channel. It applies only to self-addressed identity rooms (`thread_participant:`, `instance_inbox:`). `sandbox_owner:{owner_id}` is also identity-keyed, but callers subscribe with the concrete owner id because it is a UI room pattern for sandbox lists, not a self-subscription sentinel target. For `workload:`, `agent:`, `sandbox_org:`, and `trace:` the id segment is a resource id and `:me` has no meaning.
 
 Identity ids are UUIDs, so the literal `me` cannot collide with any real id.
 
@@ -132,6 +134,8 @@ External `Subscribe` (Socket.IO) requires an authenticated caller. Room access i
 | `instance_inbox:{id}` | `id == caller.identity_id` and `caller.identity_type == agent_instance` (only the instance itself subscribes). `:me` is rewritten before the check. |
 | `workload:{id}` | `member` on `organization:<workload.org_id>` |
 | `agent:{id}` | `member` on `organization:<agent.org_id>` |
+| `sandbox_owner:{owner_id}` | `owner_id == caller.identity_id` (identity equality — only the sandbox owner subscribes to their own live sandbox list/detail room). `:me` is not accepted for this room pattern. |
+| `sandbox_org:{organization_id}` | `can_list_sandboxes` on `organization:<organization_id>` (organization owners only; backs list-all sandbox views). |
 | `trace:{trace_id}` | `member` on `organization:<trace.org_id>` (org resolved from stored span data) |
 | `organization:{id}` | `member` on `organization:<id>` (used by the [Egress Gateway](egress-gateway.md) to receive `egress_rule.updated` / `egress_rule_attachment.updated` events published by the [EgressRules service](egress-rules-service.md); the gateway subscribes per org for which it has cached rules) |
 

--- a/architecture/organizations.md
+++ b/architecture/organizations.md
@@ -2,9 +2,9 @@
 
 ## Overview
 
-The platform uses **organizations** as the grouping unit for configuration resources. An organization owns agents, LLM providers, models, secret providers, secrets, and chats. Resources that belong to an organization have an `organization_id` field.
+The platform uses **organizations** as the grouping unit for configuration resources. An organization owns agents, sandboxes, environments, volumes, LLM providers, models, secret providers, secrets, and chats. Resources that belong to an organization have an `organization_id` field.
 
-Not all resources belong to organizations. Threads, files, agent state, and workloads are **independent resources** — access to them is governed by [ReBAC permissions](authz.md) rather than organizational membership. This separation reflects the domain: conversations (threads) and runtime artifacts (state, workloads) connect participants across organizational boundaries, while configuration resources (agents, providers, secrets) are organizational infrastructure.
+Not all resources belong to organizations. Threads, files, agent state, and workloads are **independent resources** — access to them is governed by [ReBAC permissions](authz.md) rather than organizational membership. This separation reflects the domain: conversations (threads) and runtime artifacts (state, workloads) connect participants across organizational boundaries, while configuration resources (agents, sandboxes, providers, secrets) are organizational infrastructure.
 
 ## Organization Model
 
@@ -12,7 +12,20 @@ Not all resources belong to organizations. Threads, files, agent state, and work
 |-------|------|-------------|
 | `id` | string (UUID) | Unique organization identifier |
 | `name` | string | Display name |
+| `sandbox_default_idle_timeout` | duration string | Default idle timeout snapshotted onto newly created sandboxes. Platform-bounded; default `30m` |
+| `sandbox_default_ttl` | duration string | Default hard lifetime snapshotted onto newly created sandboxes. Platform-bounded; default `72h`, maximum `336h` |
 | `created_at` | timestamp | Creation time |
+
+## Sandbox Settings
+
+Organizations own the default sandbox lifecycle settings used by the [Agents service](agents-service.md) when creating [Sandboxes](resource-definitions.md#sandbox):
+
+| Setting | Default | Bounds | Description |
+|---------|---------|--------|-------------|
+| `sandbox_default_idle_timeout` | `30m` | Platform minimum/maximum | How long a sandbox may remain detached before its workload is stopped. The sandbox record and workspace volume survive idle stop |
+| `sandbox_default_ttl` | `72h` | Platform maximum `336h` | Hard sandbox lifetime from creation. On expiry the sandbox is terminated and its workspace volume is deleted |
+
+Only organization owners may update these settings. Values are validated by Organizations before persistence. The Agents service snapshots both values onto each sandbox at creation; changing organization defaults never mutates existing sandboxes.
 
 ## Organizations Service
 
@@ -94,6 +107,7 @@ Who can do what is governed by the [authorization model](authz.md):
 | **Update member role** | `can_manage_members` on the organization | Organization owners (via `owner` implies `can_manage_members`) | Updates the role. If `active`, deletes old OpenFGA tuple and writes new one |
 | **List members** | `can_manage_members` on the organization | Organization owners | Returns memberships for the organization |
 | **List my memberships** | Caller is the identity | Any identity | Returns the caller's own memberships across all organizations |
+| **Update sandbox settings** | `owner` on the organization | Organization owners | Validates and stores new default sandbox TTL/idle-timeout values for future sandbox creation |
 
 The Organizations service does not perform explicit identity type checks (e.g., "is the caller a cluster admin?"). All access decisions flow through [Authorization](authz.md) `Check` calls. See [Authorization — Organization Permissions](authz.md#organization-permissions) for how `can_add_member`, `can_invite`, and `can_manage_members` are defined.
 
@@ -108,6 +122,7 @@ The Organizations service does not perform explicit identity type checks (e.g., 
 | **UpdateMembershipRole** | Update the role of a membership. Caller must have `can_manage_members`. If `active`, updates the OpenFGA tuple |
 | **ListMembers** | List memberships for an organization. Supports filtering by `status` (`pending`, `active`, or all). Caller must have `can_manage_members` |
 | **ListMyMemberships** | List the calling identity's own memberships across all organizations. Supports filtering by `status`. Used by Chat for the organization switcher and by Console for pending invite display |
+| **UpdateOrganization** | Update organization details and sandbox defaults. Caller must be owner |
 
 ### CreateMembership Flow
 
@@ -168,7 +183,7 @@ Org-scoped resources belong to an organization. They have an `organization_id` f
 
 | Service | Resources | Notes |
 |---------|-----------|-------|
-| [Agents](agents-service.md) | Agents, Volumes | Direct `organization_id` on the resource |
+| [Agents](agents-service.md) | Agents, Sandboxes, Volumes | Direct `organization_id` on the resource |
 | [Agents](agents-service.md) | MCPs, Skills, Hooks, ENVs, InitScripts, Volume Attachments | Inherit org scope through parent (agent, MCP, or hook). No `organization_id` column — org is resolved via the parent chain. Can be denormalized if query patterns require it |
 | [LLM](llm.md) | LLM Providers, Models | `organization_id` on the resource |
 | [Secrets](secrets.md) | Secret Providers, Secrets | `organization_id` on the resource |

--- a/architecture/runners.md
+++ b/architecture/runners.md
@@ -6,9 +6,9 @@ The Runners service manages runner registrations and workload runtime state. It 
 
 1. **Runners** — registered runner instances (cluster-scoped and org-scoped), their enrollment state, and metadata.
 2. **Workloads** — the runtime state of workloads running on registered runners. Which workloads are running, on which runner, with which containers.
-3. **Provisioned volumes** — storage instances provisioned on runners for specific [agent instances](agent-instances.md).
+3. **Provisioned volumes** — storage instances provisioned on runners for specific runtime owners.
 
-**Naming note:** `instance_id` on workload and volume records is the **runner-assigned runtime identifier** (Pod name, PVC name) — a legacy name that predates agent instances. The platform-level [agent instance](agent-instances.md) is referenced by the distinct `agent_instance_id` field. The two are unrelated.
+**Naming note:** `instance_id` on workload and volume records is the **runner-assigned runtime identifier** (Pod name, PVC name). It is unrelated to the platform owner. Platform ownership is recorded separately as `owner_kind` + `owner_id`.
 
 The [Agents Orchestrator](agents-orchestrator.md) reads and writes workload state through this service. The [Gateway](gateway.md) exposes query methods for the UI. The [Terminal Proxy](terminal-proxy.md) resolves which runner hosts a workload to route exec connections.
 
@@ -28,13 +28,13 @@ The [Agents Orchestrator](agents-orchestrator.md) reads and writes workload stat
 
 | Method | Description |
 |--------|-------------|
-| **CreateWorkload** | Record a new workload before it is started on the runner. The Orchestrator generates the workload ID and sets `status=starting`. Called before `Runner.StartWorkload` to avoid a reconciliation race |
+| **CreateWorkload** | Record a new workload before it is started on the runner. The Orchestrator generates the workload ID, sets `status=starting`, and supplies the generalized owner (`owner_kind=agent_instance` or `sandbox`, `owner_id=<id>`). Called before `Runner.StartWorkload` to avoid a reconciliation race |
 | **UpdateWorkload** | Update mutable workload fields: status, containers, `removed_at`, `last_metering_sampled_at`. When `status`, any element of `containers`, or `agent_state` changed, emits a `workload.updated` event on the organization's [Notifications](notifications.md) topic so subscribers (e.g., the Console) can refresh without polling |
 | **BatchUpdateWorkloadSampledAt** | Set `last_metering_sampled_at` for a list of workload IDs in a single DB write. Used by the metering sampling loop after a successful batch publish |
 | **GetWorkload** | Get a workload by ID. Returns workload metadata and containers for views such as Console Workload Detail |
-| **ListWorkloads** | List workloads in an organization with server-side sort, filter, and pagination. Response items include denormalized `agent_name` and `runner_name`. See [ListWorkloads request shape](#listworkloads-request-shape) |
+| **ListWorkloads** | List workloads in an organization with server-side sort, filter, and pagination. Response items include owner-aware display fields and `runner_name`. See [ListWorkloads request shape](#listworkloads-request-shape) |
 | **ListWorkloadsByAgentInstance** | List workload records whose `agent_instance_id` matches the requested [agent instance](agent-instances.md). Supports optional filtering by `status_in`. Results are ordered by `created_at DESC` — used by the [Agents Orchestrator](agents-orchestrator.md#start-decision) to inspect the most recent terminal workload for an instance, by [Chat](chat.md#activity-status) to derive activity status, and by Console Thread Detail to show workloads for a thread's instance participants |
-| **TouchWorkload** | Update `last_activity_at` timestamp on a workload. Called by [`agynd`](agynd-cli.md) (via [Gateway](gateway.md)) as a keepalive while the agent is actively processing. When `agent_state` is `idle`, atomically transitions it to `processing` and emits a `workload.updated` event. Otherwise lightweight — updates only the timestamp with no event |
+| **TouchWorkload** | Update `last_activity_at` timestamp on a workload. Called by [`agynd`](agynd-cli.md) (via [Gateway](gateway.md)) as a keepalive while the agent is actively processing, and by the [Terminal Proxy](terminal-proxy.md#sandbox-activity-reporting) for each attached sandbox terminal session. When an agent workload's `agent_state` is `idle`, atomically transitions it to `processing` and emits a `workload.updated` event. Otherwise lightweight — updates only the timestamp with no event |
 
 ### Volume State
 
@@ -94,14 +94,14 @@ Environment create/update already validated that the flavor's runner is visible 
 | `runner_id` | string (UUID) | Runner hosting this workload |
 | `owner_kind` | enum | `agent_instance` \| `sandbox`. What kind of entity this workload runs for. Sandboxes are first-class workload owners — no synthetic agent instances are created for them |
 | `owner_id` | string (UUID) | The owning [agent instance](agent-instances.md) (whose inbox the workload processes) or [Sandbox](resource-definitions.md#sandbox). For `agent_instance` owners this is the field previously named `agent_instance_id` |
-| `agent_id` | string (UUID), nullable | Agent class the owning instance was spawned from (denormalized for filtering and display). NULL for sandbox-owned workloads |
+| `agent_id` / `agent_class_id` | string (UUID), nullable | Agent class the owning instance was spawned from (denormalized for filtering and display). NULL for sandbox-owned workloads. Contract names may preserve legacy `agent_id` fields for compatibility; new callers use the presence-aware class field |
 | `organization_id` | string (UUID) | Organization scope (denormalized from the owner) |
 | `status` | enum | Container lifecycle state: `starting`, `running`, `stopping`, `stopped`, `failed`. `running` means all init containers completed and main containers are up — it does **not** imply the agent process is currently producing output. See [`agent_state`](#workload-resource) for that signal |
-| `agent_state` | enum | `idle`, `processing`. Whether the agent process inside a `running` workload is currently producing output. Initialized to `processing` on `CreateWorkload`. Transitioned `idle → processing` by [`TouchWorkload`](#workload-state); transitioned `processing → idle` by the [Agent Activity Sweep](#agent-activity-sweep). Distinct from `status`, which tracks container lifecycle. Surfaced to Chat via [`activity_status`](chat.md#activity-status) |
+| `agent_state` | enum, nullable/not meaningful for sandboxes | For `agent_instance` workloads: `idle` or `processing`, whether the agent process inside a `running` workload is currently producing output. Initialized to `processing` on `CreateWorkload`, transitioned `idle → processing` by [`TouchWorkload`](#workload-state), and transitioned `processing → idle` by the [Agent Activity Sweep](#agent-activity-sweep). For `sandbox` workloads this field is not an agent signal and must not be used for lifecycle decisions; sandbox idleness is derived from `last_activity_at` touches driven by terminal sessions |
 | `containers` | list | Containers in the workload (see below) |
 | `created_at` | timestamp | Creation time |
 | `updated_at` | timestamp | Last status update |
-| `last_activity_at` | timestamp | Last activity reported by [`agynd`](agynd-cli.md) via `TouchWorkload`. Set to `created_at` on workload creation, and reset to `now()` when `status` transitions from `starting` to `running` so the [Agent Activity Sweep](#agent-activity-sweep) gives `agynd` a fresh keepalive window after the agent boots. Updated by `agynd` keepalive calls while the agent is actively processing. Used by the [Agents Orchestrator](agents-orchestrator.md) for [idle timeout](#idle-timeout) enforcement and by the Runners service for the [Agent Activity Sweep](#agent-activity-sweep) |
+| `last_activity_at` | timestamp | Last activity reported via `TouchWorkload`. Set to `created_at` on workload creation, and reset to `now()` when `status` transitions from `starting` to `running` so activity reporters receive a fresh keepalive window after the workload boots. Updated by [`agynd`](agynd-cli.md) keepalive calls for agent workloads and Terminal Proxy session touches for sandbox workloads. Used by the [Agents Orchestrator](agents-orchestrator.md) for [idle timeout](#idle-timeout) enforcement and by the Runners service for the [Agent Activity Sweep](#agent-activity-sweep) |
 | `last_metering_sampled_at` | timestamp (nullable) | Timestamp through which compute usage has been recorded to the [Metering Service](metering.md). NULL until the first metering sample is emitted. Updated via `UpdateWorkload` after each successful emission |
 | `removed_at` | timestamp (nullable) | When the workload was actually stopped on the runner. NULL while active or stopping. Set after `StopWorkload` succeeds. Record is retained as audit history |
 | `failure_reason` | enum, nullable | Machine-readable cause when `status=failed`. One of `start_failed`, `image_pull_failed`, `config_invalid`, `crashloop`, `runtime_lost`. NULL for non-failed workloads. Set by the [Agents Orchestrator](agents-orchestrator.md#workload-reconciliation) at the moment of the `failed` transition |
@@ -115,11 +115,11 @@ Tracks persistent volumes actually provisioned on runners. For agent-owned volum
 |-------|------|-------------|
 | `id` | string (UUID) | Primary key, generated by the Orchestrator. Set as a label on the PVC so the reconciliation loop can match runner volumes back to Runners service records |
 | `instance_id` | string (nullable) | Runner-assigned **runtime** identifier (PVC name). NULL until the reconciliation loop confirms the PVC exists on the runner. Unrelated to the platform owner (`owner_id`) |
-| `volume_id` | string (UUID), nullable | ID of the [Volume](resource-definitions.md#volume) in the Agents service. Together with `owner_id`, uniquely identifies the provisioned instance. NULL for sandbox workspace volumes (runtime-only, no Volume definition) |
+| `volume_id` / `volume_definition_id` | string (UUID), nullable | ID of the [Volume](resource-definitions.md#volume) in the Agents service. Together with `owner_id`, uniquely identifies the provisioned instance. NULL for sandbox workspace volumes (runtime-only, no Volume definition). Contract names may preserve legacy `volume_id` fields for compatibility; new callers use the presence-aware definition field |
 | `owner_kind` | enum | `agent_instance` \| `sandbox` |
 | `owner_id` | string (UUID) | The owning agent instance or [Sandbox](resource-definitions.md#sandbox) |
 | `runner_id` | string (UUID) | Runner on which the volume is provisioned |
-| `agent_id` | string (UUID), nullable | Agent class that owns the volume definition (denormalized). NULL for sandbox-owned volumes |
+| `agent_id` / `agent_class_id` | string (UUID), nullable | Agent class that owns the volume definition (denormalized). NULL for sandbox-owned volumes. Contract names may preserve legacy `agent_id` fields for compatibility; new callers use the presence-aware class field |
 | `organization_id` | string (UUID) | Organization scope |
 | `size_gb` | decimal | Size in gigabytes, from the Agents service Volume definition |
 | `status` | enum | `provisioning`, `active`, `deprovisioning`, `deleted`, `failed` — see [Volume Reconciliation](agents-orchestrator.md#volume-reconciliation) |
@@ -162,7 +162,9 @@ Per-container fields are refreshed by the [Agents Orchestrator](agents-orchestra
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
 | `organization_id` | string (UUID) | Yes | Authorization scope. Caller must hold `can_view_workloads` on this organization |
-| `filter.agent_id_in` | list<string (UUID)> | No | Return only workloads for these agents (OR across ids) |
+| `filter.agent_id_in` / `filter.agent_class_id_in` | list<string (UUID)> | No | Return only agent-instance-owned workloads for these agent classes (OR across ids). Sandbox workloads do not match this filter |
+| `filter.owner_kind_in` | list<enum> | No | Return only workloads owned by these owner kinds (`agent_instance`, `sandbox`) |
+| `filter.owner_id_in` | list<string (UUID)> | No | Return only workloads for these agent instance or sandbox owners (OR across ids) |
 | `filter.runner_id_in` | list<string (UUID)> | No | Return only workloads on these runners (OR across ids) |
 | `filter.status_in` | list<Workload.Status> | No | Return only workloads in these statuses |
 | `filter.started_after` | timestamp | No | Return only workloads with `created_at >= started_after` |
@@ -181,10 +183,11 @@ The server applies a stable secondary sort by `id` (ascending) on every response
 
 | Field | Type | Description |
 |-------|------|-------------|
-| `agent_name` | string | Current name of the agent at `agent_id`. Resolved at query time |
+| `agent_name` / `agent_class_name` | string, nullable | Current name of the agent class for agent-instance-owned workloads. NULL for sandbox-owned workloads |
+| `owner_name` | string, nullable | Display name for the runtime owner when available, such as the sandbox name for `owner_kind=sandbox` |
 | `runner_name` | string | Current name of the runner at `runner_id`. Resolved at query time |
 
-The Runners service owns neither agents nor runners' names — it resolves them via batch lookups against the [Agents service](agents-service.md) and its own `runners` table when assembling the response. `agent_id` / `runner_id` remain in the response for stable linking.
+The Runners service owns neither agents nor sandbox records — it resolves names via batch lookups against the [Agents service](agents-service.md) and its own `runners` table when assembling the response. `owner_kind`, `owner_id`, class IDs, and `runner_id` remain in the response for stable linking.
 
 ### ListVolumes request shape
 
@@ -196,6 +199,8 @@ Same sort/filter/pagination envelope as `ListWorkloads`. Filters:
 | `filter.status_in` | list<Volume.Status> | No | Return only volumes in these statuses |
 | `filter.runner_id_in` | list<string (UUID)> | No | Return only volumes provisioned on these runners |
 | `filter.attached_to_kind_in` | list<enum> | No | `agent`, `mcp`, `hook`, or `unattached` |
+| `filter.owner_kind_in` | list<enum> | No | Return only volumes owned by these owner kinds (`agent_instance`, `sandbox`) |
+| `filter.owner_id_in` | list<string (UUID)> | No | Return only volumes for these agent instance or sandbox owners (OR across ids) |
 | `filter.pending_sample` | bool | No | Metering sampler only. Not exposed through the Gateway |
 
 Sort fields: `name`, `size`, `status`, `created`. Default: `name` asc.
@@ -204,10 +209,11 @@ Response items include the [Volume Resource](#volume-resource) fields plus:
 
 | Field | Type | Description |
 |-------|------|-------------|
-| `volume_name` | string | Current name of the [Agents service Volume](resource-definitions.md#volume) at `volume_id` |
+| `volume_name` / `volume_definition_name` | string, nullable | Current name of the [Agents service Volume](resource-definitions.md#volume) at `volume_id`. NULL for sandbox workspace volumes because they are runtime-only and have no Agents service Volume definition |
+| `owner_name` | string, nullable | Display name for the runtime owner when available, such as the sandbox name for `owner_kind=sandbox` |
 | `attachments` | list<Attachment> | All containers currently mounting this provisioned volume — multiple if a single PVC is mounted by agent + MCP + hook in the same pod. Each `Attachment` has `kind` (`agent` / `mcp` / `hook`), `id`, and `name`. Empty when unattached |
 
-The Runners service resolves `volume_name` and each attachment's `name` via batch lookups against the [Agents service](agents-service.md) when assembling the response. `volume_id` and each `attachments[].id` remain in the response for stable linking.
+The Runners service resolves `volume_name`, `owner_name`, and each attachment's `name` via batch lookups against the [Agents service](agents-service.md) when assembling the response. Definition IDs, `owner_kind`, `owner_id`, and each `attachments[].id` remain in the response for stable linking.
 
 ## Registration Flow
 
@@ -276,27 +282,27 @@ The service token is long-lived and reusable. If the runner restarts, it re-enro
 
 ## Workload State Management
 
-The [Agents Orchestrator](agents-orchestrator.md) and [`agynd`](agynd-cli.md) write workload state. The orchestrator manages lifecycle; `agynd` reports activity.
+The [Agents Orchestrator](agents-orchestrator.md), [`agynd`](agynd-cli.md), and Terminal Proxy write workload state. The orchestrator manages lifecycle; `agynd` and Terminal Proxy report activity.
 
 **Orchestrator** calls the Runners service to record workload lifecycle events:
 
-1. **Start**: orchestrator starts a workload on a runner via Runner `StartWorkload`, then calls `CreateWorkload` on the Runners service with the runner ID, workload ID, agent instance ID, agent (class) ID, and initial container list. `last_activity_at` is set to `created_at`; `agent_state` is initialized to `processing` (the orchestrator only starts workloads in response to unacked messages, so the agent is expected to begin producing output immediately). Volume records are populated separately by the volume sync loop — not as part of the start flow.
+1. **Start**: orchestrator starts a workload on a runner via Runner `StartWorkload`, then calls `CreateWorkload` on the Runners service with the runner ID, workload ID, `owner_kind`, `owner_id`, nullable agent class fields for agent-instance workloads, and initial container list. `last_activity_at` is set to `created_at`; `agent_state` is initialized to `processing` for agent-instance workloads (the orchestrator only starts those workloads in response to unacked messages, so the agent is expected to begin producing output immediately). Sandbox workloads do not use `agent_state` for lifecycle decisions. Volume records are populated separately by the volume sync loop — not as part of the start flow.
 2. **Update**: orchestrator detects status changes during reconciliation (via Runner `InspectWorkload`) and calls `UpdateWorkload` to update status and container states. When the call promotes `status` from `starting` to `running`, the Runners service also resets `last_activity_at = now()` so the [Agent Activity Sweep](#agent-activity-sweep) gives `agynd` a fresh window to make its first `TouchWorkload`.
 3. **Stop**: orchestrator calls `UpdateWorkload(status=stopping)`, stops the workload via Runner `StopWorkload`, then calls `UpdateWorkload(status=stopped, removed_at=now)`. The record is retained for audit. The metering sampling loop handles the tail sample on its next tick.
 
-**`agynd`** calls `TouchWorkload` (via [Gateway](gateway.md)) to update `last_activity_at` while the agent is actively processing. See [Idle Timeout](#idle-timeout).
+**Activity reporters** call `TouchWorkload` to update `last_activity_at`: [`agynd`](agynd-cli.md) calls it via [Gateway](gateway.md) while an agent workload is actively processing, and Terminal Proxy calls it internally while a sandbox terminal session is attached. See [Idle Timeout](#idle-timeout).
 
-The Runners service is a passive store — it does not interact with runners directly. It records what the orchestrator and `agynd` tell it.
+The Runners service is a passive store — it does not interact with runners directly. It records what the orchestrator, `agynd`, and Terminal Proxy tell it.
 
 ## Idle Timeout
 
 The Runners service supports idle timeout enforcement by tracking `last_activity_at` on each workload. The mechanism involves three components:
 
-1. **[`agynd`](agynd-cli.md)** — while the agent CLI is actively processing (executing LLM calls, running tools), `agynd` calls `TouchWorkload` via [Gateway](gateway.md) every 10 seconds. When the agent is idle (waiting for new messages), `agynd` stops calling `TouchWorkload`. This gives the orchestrator a clear signal of agent activity.
+1. **Activity reporters** — while the agent CLI is actively processing (executing LLM calls, running tools), [`agynd`](agynd-cli.md) calls `TouchWorkload` via [Gateway](gateway.md) every 10 seconds. When the agent is idle (waiting for new messages), `agynd` stops calling `TouchWorkload`. While a sandbox terminal session is attached, Terminal Proxy calls `TouchWorkload` internally every 10 seconds. These signals give the orchestrator a clear view of agent or sandbox activity.
 2. **Runners service** — stores `last_activity_at` on the workload record. `TouchWorkload` is a lightweight RPC that updates only this timestamp.
-3. **[Agents Orchestrator](agents-orchestrator.md)** — during each reconciliation pass, queries the Runners service for running workloads. For each workload, compares `now - last_activity_at` against the agent's `idle_timeout` (from the [Agent resource definition](resource-definitions.md#agent), default `"5m"`). If the timeout is exceeded, the orchestrator stops the workload.
+3. **[Agents Orchestrator](agents-orchestrator.md)** — during each reconciliation pass, queries the Runners service for running workloads. For each workload, compares `now - last_activity_at` against the applicable idle timeout: the agent's `idle_timeout` for agent-instance workloads (from the [Agent resource definition](resource-definitions.md#agent), default `"5m"`) or the sandbox's snapshotted `idle_timeout`. If the timeout is exceeded, the orchestrator stops the workload.
 
-This design ensures that long-running agent tasks (which may take hours) are never prematurely terminated — as long as the agent is working, `agynd` keeps touching. The idle clock only starts when the agent finishes processing and enters a wait state.
+This design ensures that long-running agent tasks (which may take hours) and attached sandbox terminal sessions are never prematurely terminated — as long as activity continues, the reporter keeps touching. The idle clock starts when the agent finishes processing or the sandbox terminal session detaches.
 
 ## Agent Activity Sweep
 
@@ -312,7 +318,7 @@ On each tick:
 | `KEEPALIVE_GRACE` | `25s` | Time since the last `TouchWorkload` after which a `processing` workload is considered idle. Set above the [`agynd` keepalive interval](agynd-cli.md#5-activity-keepalive) (`10s`) with tolerance for one missed beat |
 | Sweep interval | `5s` | How often the sweep runs. The maximum delay between the agent stopping and the chat indicator transitioning to `finished` is `KEEPALIVE_GRACE + sweep interval` — `~30s` by default |
 
-The sweep is independent of [Idle Timeout](#idle-timeout) enforcement. The sweep flips a workload's activity bit after seconds (chat-indicator scope); the orchestrator stops the workload entirely after the agent's `idle_timeout` (default `5m`, lifecycle scope). Both consume the same `last_activity_at` signal but act on different timescales.
+The sweep is independent of [Idle Timeout](#idle-timeout) enforcement. The sweep flips a workload's activity bit after seconds (chat-indicator scope); the orchestrator stops the workload entirely after the applicable idle timeout (agent default `5m`, sandbox value snapshotted at creation; lifecycle scope). Both consume the same `last_activity_at` signal but act on different timescales.
 
 The sweep does not interact with runners — it is a DB scan plus notification emit — so the [Workload State Management](#workload-state-management) classification of Runners as a passive store still holds.
 
@@ -336,7 +342,7 @@ Runner management authorization depends on the runner's scope. Workload and volu
 | `GetWorkload`, `StreamWorkloadLogs` | `can_view_workloads` on `organization:<workload.org_id>` |
 | `ListWorkloadsByAgentInstance` (via Gateway) | `member` on `organization:<workload.org_id>` |
 | `ListWorkloadsByAgentInstance` (internal) | Internal only (Orchestrator via Istio) — used by the [start decision](agents-orchestrator.md#start-decision) |
-| `TouchWorkload` | Agent instance's own identity — `workload.agent_instance_id == caller.identity_id` |
+| `TouchWorkload` | For `owner_kind=agent_instance`: agent instance's own identity (`workload.owner_id == caller.identity_id`). For `owner_kind=sandbox`: internal only from Terminal Proxy via Istio, after ticket validation, to report attached-session activity |
 | `CreateVolume`, `UpdateVolume`, `BatchUpdateVolumeSampledAt` | Internal only (Orchestrator via Istio) |
 | `ListVolumes` (via Gateway) | `can_view_volumes` on `organization:<org_id>` (required request parameter) |
 | `ListVolumes` (internal) | Internal only (Orchestrator via Istio) — supports `runner_id_in`, `pending_sample`, and `status_in` filters across organizations; `organization_id` not required |
@@ -356,7 +362,7 @@ The following methods are exposed through the [Gateway](gateway.md):
 
 Runner management methods (`RegisterRunner`, `GetRunner`, `ListRunners`, `UpdateRunner`, `DeleteRunner`) are used for runner provisioning via the [Terraform provider](operations/terraform-provider.md) and [agyn CLI](agyn-cli.md). `EnrollRunner` is called by runners at startup to exchange a service token for an OpenZiti identity (see [Enrollment](#enrollment)).
 
-Workload query methods (`ListWorkloads`, `ListWorkloadsByAgentInstance`, `GetWorkload`) provide external access to workload state. `TouchWorkload` is called by [`agynd`](agynd-cli.md) to report agent activity for [idle timeout](#idle-timeout) enforcement.
+Workload query methods (`ListWorkloads`, `ListWorkloadsByAgentInstance`, `GetWorkload`) provide external access to workload state. `TouchWorkload` is exposed for [`agynd`](agynd-cli.md) to report agent activity; sandbox activity reports are internal calls from Terminal Proxy after terminal ticket validation. Both paths feed [idle timeout](#idle-timeout) enforcement.
 
 `StreamWorkloadLogs` is a server-streaming method for reading container logs. The Runners service authorizes the caller as a member of the workload's organization, looks up the hosting runner from the workload record, dials the runner via OpenZiti (`zitiContext.Dial("runner-{runnerId}")`), and forwards [`Runner.StreamWorkloadLogs`](runner.md#streaming) output back to the caller. The Gateway exposes the method as a pass-through — it does not interpret the stream.
 
@@ -364,7 +370,7 @@ Volume query methods (`GetVolume`, `ListVolumes`, `ListVolumesByAgentInstance`) 
 
 Internal-only methods (`CreateWorkload`, `UpdateWorkload`, `BatchUpdateWorkloadSampledAt`, `CreateVolume`, `UpdateVolume`, `BatchUpdateVolumeSampledAt`) are called by the [Agents Orchestrator](agents-orchestrator.md) and are not exposed through the Gateway.
 
-The Orchestrator also reaches `ListWorkloads`, `ListVolumes`, `ListWorkloadsByAgentInstance`, `ListVolumesByAgentInstance`, and `GetRunner` via Istio, with filter shapes (`runner_id_in`, `pending_sample`, cross-org `agent_instance_id`) that are not accepted on the Gateway path. The Gateway-exposed variants of those RPCs require `organization_id` and apply OpenFGA checks; the internal variants are gated by [Istio `AuthorizationPolicy`](authz.md#internal-rpc-authorization) restricted to the Orchestrator's ServiceAccount.
+The Orchestrator also reaches `ListWorkloads`, `ListVolumes`, `ListWorkloadsByAgentInstance`, `ListVolumesByAgentInstance`, and `GetRunner` via Istio, with filter shapes (`runner_id_in`, `pending_sample`, owner filters, and cross-organization instance queries) that are not accepted on the Gateway path. The Gateway-exposed variants of those RPCs require `organization_id` and apply OpenFGA checks; the internal variants are gated by [Istio `AuthorizationPolicy`](authz.md#internal-rpc-authorization) restricted to the Orchestrator's ServiceAccount.
 
 ## Terminal Proxy Integration
 


### PR DESCRIPTION
## Summary
- Aligns sandbox references across runners, authz, gateway, agents-service notifications, and organization sandbox settings.
- Documents sandbox OpenFGA relations and tuple lifecycle in the architecture source of truth.
- Adds TerminalGateway `CreateTerminalSession` authorization notes and sandbox notification room/payload behavior.
- References #162 and aligns with merged agynio/authorization#29 plus approved agynio/api#159.

## Validation
- `git diff --check` — passed (0 failed)
- `node - architecture/runners.md architecture/authz.md architecture/gateway.md architecture/agents-service.md architecture/organizations.md <<'NODE' ... NODE` — checked 5 files; 0 missing local Markdown link targets

No unrelated implementation changes included.