### PR TITLE
docs: name the Terminal Proxy in service identity self-enrollment

### DIFF
--- a/architecture/openziti.md
+++ b/architecture/openziti.md
@@ -25,7 +25,7 @@ The OpenZiti Go SDK implements Go's standard `net.Listener` and `net.Conn` inter
 | **Tracing** | Bind (server) | `zitiContext.ListenWithOptions("tracing", ...)` → accept connections |
 | **Egress Gateway** | Bind (server) | `zitiContext.ListenWithOptions("@egress-services", ...)` → binds every per-rule egress service tagged `egress-services` |
 
-The Orchestrator, Gateway, and LLM Proxy obtain their OpenZiti identities at runtime via self-enrollment through the [Ziti Management](#ziti-management-service) service. Runners and Apps obtain their identities via the service token enrollment flow — see [Runner Provisioning](#runner-provisioning) and [App Identity Lifecycle](#app-identity-lifecycle). See [Service Identity Self-Enrollment](#service-identity-self-enrollment) and [Authentication](authn.md#enrollment).
+The Orchestrator, Gateway, LLM Proxy, and Terminal Proxy obtain their OpenZiti identities at runtime via self-enrollment through the [Ziti Management](#ziti-management-service) service. Runners and Apps obtain their identities via the service token enrollment flow — see [Runner Provisioning](#runner-provisioning) and [App Identity Lifecycle](#app-identity-lifecycle). See [Service Identity Self-Enrollment](#service-identity-self-enrollment) and [Authentication](authn.md#enrollment).
 
 ## Ziti Management Service
 
@@ -62,8 +62,8 @@ All interactions with the OpenZiti Controller's Edge Management API are encapsul
 | `DeleteIdentity` | Orchestrator | Delete an OpenZiti identity and its platform mapping |
 | `ListManagedIdentities` | Orchestrator | List all identities managed by the platform (for reconciliation) |
 | `ResolveIdentity` | Gateway | Map an OpenZiti identity ID to platform identity (identity_id, identity_type) |
-| `RequestServiceIdentity` | Orchestrator, Gateway | Create and enroll an OpenZiti identity for the calling service, return enrolled identity (cert + key) |
-| `ExtendIdentityLease` | Orchestrator, Gateway | Extend the lease on a service identity. Returns `NOT_FOUND` if the identity has no record (e.g. already garbage-collected) — the caller treats this as identity loss, see [Identity Loss](#identity-loss) |
+| `RequestServiceIdentity` | Orchestrator, Gateway, LLM Proxy, Terminal Proxy | Create and enroll an OpenZiti identity for the calling service, return enrolled identity (cert + key) |
+| `ExtendIdentityLease` | Orchestrator, Gateway, LLM Proxy, Terminal Proxy | Extend the lease on a service identity. Returns `NOT_FOUND` if the identity has no record (e.g. already garbage-collected) — the caller treats this as identity loss, see [Identity Loss](#identity-loss) |
 | `CreateServicePolicy` | Expose Service | Create a single OpenZiti service policy (Bind or Dial). Returns the policy ID |
 | `DeleteServicePolicy` | Expose Service | Delete an OpenZiti service policy by ID |
 | `DeleteService` | Expose Service | Delete an OpenZiti service by ID |
@@ -112,7 +112,7 @@ Lease expiry usually means the pod that held the enrolled certificate has stoppe
 Three identity lifecycle patterns coexist:
 
 - **Agent identities** — managed by the **Agents Orchestrator**. The Orchestrator creates and deletes agent identities via Ziti Management as part of its reconciliation loop. The Runner is not involved in identity management — it receives the enrollment JWT as opaque configuration and passes it to the agent pod's Ziti sidecar container.
-- **Service identities** — self-managed by each infrastructure service (Orchestrator, Gateway). Each pod requests its own identity from Ziti Management at startup and extends the lease on a timer. See [Service Identity Self-Enrollment](#service-identity-self-enrollment).
+- **Service identities** — self-managed by each infrastructure service (Orchestrator, Gateway, LLM Proxy, Terminal Proxy). Each pod requests its own identity from Ziti Management at startup and extends the lease on a timer. See [Service Identity Self-Enrollment](#service-identity-self-enrollment).
 - **Runner and App identities** — provisioned via enrollment using a service token. Runners and Apps present their service token on startup, the Runners/Apps Service creates the OpenZiti identity via Ziti Management (deleting any previous identity for that runner/app first), and returns the enrolled credentials. See [Runner Provisioning](#runner-provisioning) and [App Identity Lifecycle](#app-identity-lifecycle).
 
 The agent identity pattern follows directly from the [Control Plane & Data Plane](control-data-plane.md) classification: the Orchestrator is control plane (decides what should exist), the Runner is data plane (executes what it is told).
@@ -182,7 +182,7 @@ This is the same reconciliation pattern used for agent workloads — no new mech
 
 ## Service Identity Self-Enrollment
 
-Infrastructure services that participate in the OpenZiti overlay (Orchestrator, Gateway) obtain their OpenZiti identities at runtime by self-enrolling through Ziti Management.
+Infrastructure services that participate in the OpenZiti overlay (Orchestrator, Gateway, LLM Proxy, Terminal Proxy) obtain their OpenZiti identities at runtime by self-enrolling through Ziti Management.
 
 ### Design
 

--- a/architecture/terminal-proxy.md
+++ b/architecture/terminal-proxy.md
@@ -107,12 +107,21 @@ Checks run at ticket issuance (Gateway → OpenFGA):
 
 The WebSocket itself is authenticated solely by the ticket. Ticket properties: single-use, 30-second expiry, bound to `(identity, workload_id, container_name, command)`.
 
+## OpenZiti Identity
+
+The Terminal Proxy dials runners over the overlay, so it holds an identity of its own. It is an infrastructure service and follows [Service Identity Self-Enrollment](openziti.md#service-identity-self-enrollment): each pod requests an ephemeral identity from Ziti Management at startup, renews its lease on a timer, and terminates if the identity is lost.
+
+The identity is per-pod and is never mounted from a Secret. This service is designed to run several replicas — the ticket signing key is shared precisely so any replica can validate a ticket issued by another — and a mounted identity would be shared by all of them, outliving the pods that used it.
+
+Its identity carries the `terminal-proxy-hosts` role attribute, which the static `terminal-proxy-dial-runners` policy grants against `#runner-services`. See [Runners — Terminal Proxy Integration](runners.md#terminal-proxy-integration).
+
 ## Failure Modes
 
 | Failure | Behavior |
 |---|---|
 | Proxy restart | All sessions drop (stateless service). Clients reconnect via a fresh `CreateTerminalSession` |
 | Runner unreachable (Ziti dial fails) | Session fails to establish; client receives a close with an error reason |
+| Proxy's Ziti identity lost (lease GC'd) | Pod terminates; the replacement enrolls a fresh identity. See [Identity Loss](openziti.md#identity-loss) |
 | Workload stopped mid-session | Exec stream ends; client receives `exit` with `reason: cancelled` |
 | Client vanishes (missed pongs) | Proxy cancels the exec (`CancelExecution`), releasing the PTY |
 


### PR DESCRIPTION
The Terminal Proxy dials runners over the overlay, so it holds its own OpenZiti identity — but the enumerations in openziti.md still list only the services that predated it. terminal-proxy.md was written as part of the sandboxes change and the openziti lists were never updated to match. Leaving it unnamed made the Service Identity Self-Enrollment section read as though it did not apply, and an implementation grew that mounted a stable identity from a Secret, which that same section rules out for every service it does name. Adds it to the five enumerations and gives terminal-proxy.md an OpenZiti Identity section covering what it holds, the terminal-proxy-hosts role attribute, and why the identity is never mounted: the service runs multiple replicas by design (the ticket signing key is shared precisely so any replica can validate another's ticket), and a mounted identity would be shared by all of them and outlive the pods that used it.