### PR TITLE
docs: upgrade the local platform in place, not by replacing the VM

### DIFF
--- a/architecture/agyn-cli.md
+++ b/architecture/agyn-cli.md
@@ -337,7 +337,7 @@ The `local` command group runs the full Agyn platform on the user's machine from
 | `agyn local stop` \| `restart` | Stop / restart the VM |
 | `agyn local status` | State, version, port, endpoint health, CA trust. `--output table\|json\|yaml` |
 | `agyn local delete` | Remove the VM. `--purge` also removes downloaded images and certs |
-| `agyn local upgrade` | Recreate the VM from a newer image. Destructive (the VM's state is replaced) — requires confirmation |
+| `agyn local upgrade` | Upgrade the `agyn-platform` and `agyn-apps` releases in the running VM to the newest charts, keeping the VM and its data. Everything from the image (k3s, Istio, cert-manager, OpenZiti) moves only by recreating the VM — see [Upgrade Model](operations/local-bundle.md#upgrade-model) |
 | `agyn local doctor` | Dependency and environment checks with fix hints |
 | `agyn local config` | `list` \| `get <key>` \| `set <key> <value>` |
 | `agyn local ca` | `show` \| `export` \| `install` \| `uninstall` |

--- a/architecture/operations/local-bundle.md
+++ b/architecture/operations/local-bundle.md
@@ -29,7 +29,15 @@ No GitOps tooling is involved at any stage — neither image contains Argo CD, a
 
 ### Upgrade Model
 
-Upgrades are **image replacement, not in-place upgrades**. Nothing inside the VM reconciles or upgrades itself. To move to a new platform version, the consumer downloads the new image and recreates the VM (`agyn local upgrade`).
+Two things can move, and they move separately.
+
+**The platform** — the `agyn-platform` and `agyn-apps` Helm releases — upgrades in place. [`agyn local upgrade`](../agyn-cli.md#local-platform-commands-agyn-local) moves them to the newest published charts inside the running VM, keeping its databases, threads, agents and workloads. Values are reused from the installed release rather than re-rendered: the bake configured this cluster, and `start` has since written the bootstrap token and the host's port into it, so re-rendering would revert both.
+
+**Everything under it** — k3s, Istio, cert-manager, OpenZiti, Postgres — comes from the image and moves only by replacing the image: `agyn local delete` then `agyn local start`. Nothing inside the VM reconciles or upgrades itself, and no in-place path exists for these.
+
+Image replacement is deliberately not what `upgrade` means. It discards everything in the VM, it is not reversible, and a user asking to pick up a new platform release is not asking for that. Recreating the VM stays available, spelled as what it is.
+
+An in-place upgrade rewrites every workload the charts own, so a service running from source against the VM (see [Local Development](local-development.md)) is reset to its chart image.
 
 ## Artifacts and Publishing
 

--- a/changes/2026-07-29-local-upgrade-in-place.md
+++ b/changes/2026-07-29-local-upgrade-in-place.md
@@ -1,0 +1,34 @@
+# In-Place Platform Upgrades for the Local Bundle
+
+## Target
+
+- [Local Bundle — Upgrade Model](../architecture/operations/local-bundle.md#upgrade-model)
+- [agyn-cli — Local Platform Commands](../architecture/agyn-cli.md#local-platform-commands-agyn-local)
+
+## Delta
+
+`agyn local upgrade` recreates the VM from a newer image. Everything in it — databases, threads, agents, workloads — is discarded, so the command is destructive and gated behind a confirmation.
+
+- There is no way to move to a newer platform release without losing the VM's contents. The only upgrade path is image replacement.
+- The image is described as never reconciling or upgrading itself, with no distinction between the platform releases installed into it at bake time and the infrastructure underneath them.
+- Recreating the VM has no name of its own: it is what `upgrade` does, rather than something a user asks for.
+
+Desired state: `upgrade` moves the `agyn-platform` and `agyn-apps` Helm releases in the running VM to the newest published charts and keeps the VM. Values are reused from the installed release rather than re-rendered, because the bake configured the cluster and `start` has since written the bootstrap token and the host's chosen port into it. Infrastructure baked into the image — k3s, Istio, cert-manager, OpenZiti, Postgres — still moves only by replacing the image, spelled `delete` then `start`.
+
+## Acceptance Signal
+
+`agyn local upgrade` against a VM with data leaves that data in place and reports the chart versions before and after.
+
+Running it twice in a row is a no-op the second time.
+
+A VM whose platform predates a chart release picks that release up without being recreated; a VM whose k3s or Istio predates a new image does not.
+
+`upgrade` never deletes the VM. Recreating it requires `delete` and `start`.
+
+A service running from source against the VM is reported as being reset to its chart image, because an upgrade rewrites every workload the charts own.
+
+## Notes
+
+- Rationale: image replacement is not what "upgrade" sounds like it does, it is not reversible, and a user picking up a platform release is not asking to lose their work. Keeping it available under `delete` + `start` costs nothing and makes the destructive path explicit.
+- The two layers move at different rates: the platform charts release continuously, while the image's infrastructure changes rarely. Tying them to one command forced the slow layer's cost onto the fast layer's cadence.
+- The upgrade runs against the newest published charts rather than a pinned set. A local VM is not a production cluster, and pinning is available by driving Helm directly.


### PR DESCRIPTION
`agyn local upgrade` recreated the VM from a newer image, discarding every database, thread, agent and workload in it. That is not what "upgrade" sounds like it does, it is not reversible, and a user picking up a platform release is not asking to lose their work.

The two layers now move separately:

- **The platform** (`agyn-platform`, `agyn-apps`) upgrades in place, keeping the VM and its data. Values are reused from the installed release rather than re-rendered — the bake configured the cluster, and `start` has since written the bootstrap token and the host's port into it.
- **Everything the image provides** (k3s, Istio, cert-manager, OpenZiti, Postgres) still moves only by replacing the image, spelled `delete` then `start`. The destructive path stays available, named for what it is.

Also records that an in-place upgrade rewrites every workload the charts own, so a service running from source against the VM is reset to its chart image.

Implemented in agynio/bundle-vm (`scripts/upgrade-platform.sh`) and agynio/agyn-cli (`agyn local upgrade`).