### PR TITLE
docs: more than one local VM

### DIFF
--- a/architecture/agyn-cli.md
+++ b/architecture/agyn-cli.md
@@ -334,6 +334,8 @@ The `local` command group runs the full Agyn platform on the user's machine from
 | Command | Description |
 |---------|-------------|
 | `agyn local start` | Download the image if needed → create/boot the VM → optionally install the CA. Flags: `--version`, `--port`, `--cpus`, `--memory`, `--install-ca` \| `--no-ca`, `--download-only`, `-y` |
+| `agyn local list` | The configured VMs with status, ports and profile; the selected one is marked |
+| `agyn local select` \| `use NAME` | Choose the VM other commands act on — interactively, or by name for scripts |
 | `agyn local stop` \| `restart` | Stop / restart the VM |
 | `agyn local status` | State, version, port, endpoint health, CA trust. `--output table\|json\|yaml` |
 | `agyn local delete` | Remove the VM. `--purge` also removes downloaded images and certs |
@@ -346,8 +348,10 @@ The `local` command group runs the full Agyn platform on the user's machine from
 
 | Concern | Behavior |
 |---------|----------|
-| **Single instance** | One Lima VM named `agyn` per machine; no multi-instance |
-| **State containment** | Everything lives under `~/.agyn/local/` — `images/<version>/<arch>/` (verified downloads), `certs/`, `lima/` (dedicated `LIMA_HOME`) — so `delete --purge` is a clean sweep. Settings live in `~/.agyn/config.yaml` under a `local:` key (`port`, `version`, `cpus`, `memory`) |
+| **One VM by default, more on request** | A single VM needs no naming: no flag, no selection, and everything derived from it keeps the plain names (`agyn`, profile `local`, context `agyn-local`). `--instance NAME` addresses another, and `agyn local select` fixes the choice. Resolution is `--instance`, then the selection, then the default. A second VM exists for what one cannot do: moving data between versions an [upgrade](operations/local-bundle.md#upgrade-model) cannot bridge, or holding separate clusters side by side |
+| **Per-VM naming** | Two VMs share nothing that identifies them: the Lima instance, the [profile](#profiles) (`local`, then `local-<name>`), the kubeconfig context (`agyn-local-<name>`) and the CA file are all named for the VM |
+| **Port allocation** | The default VM takes the well-known `2496`/`6445`. Further VMs are given the next free pair, skipping ports already listening or claimed by another configured VM — running a second cluster should not require arithmetic |
+| **State containment** | Everything lives under `~/.agyn/local/` — `images/<version>/<arch>/` (verified downloads, shared between VMs on the same version), `certs/`, `lima/` (dedicated `LIMA_HOME`) — so `delete --purge` is a clean sweep. Settings live in `~/.agyn/config.yaml` under `local.instances.<name>` (`port`, `apiPort`, `version`, `cpus`, `memory`); a pre-existing flat `local:` block is migrated on load |
 | **Version resolution** | `version: latest` resolves via `bundle-vm/latest.json` on the CDN; pinned versions bypass it. Downloads are sha256-verified against the published checksums, resumable, and atomic |
 | **Networking** | The host port (default `2496`) is a Lima forward onto the VM's ingress NodePort; port collision detection suggests alternatives. `*.agyn.dev` resolves to `127.0.0.1`, so endpoints are `https://console.agyn.dev:<port>` etc. — see [Local Bundle — Networking](operations/local-bundle.md#networking) |
 | **Certificates** | `agyn local ca` extracts the CA baked into the image and installs it into the system trust store (macOS keychain / Linux ca-certificates; requires sudo) |

--- a/architecture/operations/local-bundle.md
+++ b/architecture/operations/local-bundle.md
@@ -63,7 +63,9 @@ Base images are build inputs, not consumer artifacts — they are published as O
 
 ## Runtime
 
-The image runs under [Lima](https://lima-vm.io/) (QEMU-backed) using the published `lima.yaml`. One instance per machine, named `agyn` — no multi-instance.
+The image runs under [Lima](https://lima-vm.io/) (QEMU-backed) using the published `lima.yaml`.
+
+One VM is the ordinary case and is never named: it is the instance `agyn`, reached with no flag. More than one is supported for what a single VM cannot do — moving data between versions an [upgrade](#upgrade-model) cannot bridge, or holding separate clusters side by side during development. Each additional VM is named, gets its own [profile, kubeconfig context and CA](../agyn-cli.md#design), and is given free host ports rather than the well-known `2496`.
 
 ### Networking
 

--- a/changes/2026-07-31-multiple-local-vms.md
+++ b/changes/2026-07-31-multiple-local-vms.md
@@ -1,0 +1,38 @@
+# More Than One Local VM
+
+## Target
+
+- [agyn-cli — Local Platform Commands](../architecture/agyn-cli.md#local-platform-commands-agyn-local)
+- [Local Bundle — Runtime](../architecture/operations/local-bundle.md#runtime)
+
+## Delta
+
+There is exactly one local VM per machine, named `agyn`, and no way to address another.
+
+- Everything derived from the VM is a constant rather than a name: the Lima instance, the `local` profile, the `agyn-local` kubeconfig context, the CA file path, and the host ports `2496`/`6445`.
+- Settings live in a single flat `local:` block, which can describe only one VM.
+- Two tasks are therefore impossible: moving data between two platform versions when an [in-place upgrade](2026-07-29-local-upgrade-in-place.md) cannot bridge them, and running separate clusters side by side while developing against them.
+
+Desired state: a VM is named, and everything derived from it is named with it. `--instance NAME` addresses one for a single command; `agyn local select` chooses interactively and remembers; `agyn local use NAME` does the same without a prompt; `agyn local list` shows what exists. Resolution is `--instance`, then the stored selection, then the default.
+
+The single-VM case is unchanged in every visible respect: no flag, no selection, and the default VM keeps the plain `agyn` / `local` / `agyn-local` names it already had. A pre-existing flat `local:` config is migrated on load.
+
+Further VMs are given free host ports rather than the well-known pair, skipping ports already listening or claimed by another configured VM.
+
+## Acceptance Signal
+
+A machine with one VM behaves exactly as before: no flag names it, its profile is `local`, its context is `agyn-local`, and its config file keeps working without being edited.
+
+`agyn local start --instance v2` creates a second VM without disturbing the first, on ports neither the first VM nor anything else on the machine is using.
+
+`agyn local select` lists the VMs and stores the choice; subsequent commands act on it with no flag.
+
+Each VM's `agyn` commands reach that VM's Gateway, with that VM's token and CA.
+
+Deleting one VM leaves the other's profile, context, CA and data intact.
+
+## Notes
+
+- Interactive choices — VM, profile, organization — are made by moving a highlight with the arrow keys rather than typing a number from a list. Typing a number requires finding it, matching it to a row and typing it correctly, and commits the moment it is typed.
+- `agyn profile select` is added alongside; profiles previously had `use NAME` but no interactive picker, which is the case where the names are least likely to be remembered.
+- Downloaded images stay shared between VMs on the same version: Lima copies the disk into each instance, so nothing is gained by downloading twice.


### PR DESCRIPTION
A single VM per machine could not do two things: move data between platform versions an [in-place upgrade](https://github.com/agynio/architecture/blob/main/changes/2026-07-29-local-upgrade-in-place.md) cannot bridge, and hold separate clusters side by side during development.

A VM is named now, and everything derived from it is named with it — the Lima instance, the profile (`local` → `local-<name>`), the kubeconfig context, the CA file. Further VMs get free host ports rather than the well-known `2496`/`6445`.

**The single-VM case is unchanged in every visible respect**: no flag, no selection, and the default VM keeps the plain `agyn` / `local` / `agyn-local` names. An existing flat `local:` config is migrated on load.

Also records that interactive choices (VM, profile, organization) are made by moving a highlight with the arrow keys rather than typing a number, and that `agyn profile select` now exists.

Implemented in agynio/agyn-cli.