### PR TITLE
Move terminal session logic out of the Gateway

### DIFF
--- a/architecture/gateway.md
+++ b/architecture/gateway.md
@@ -91,14 +91,11 @@ Both carry the Gateway's rate limits rather than its identity middleware. `Appro
 
 ### Terminal Sessions
 
-`CreateTerminalSession` is the Gateway-exposed ticket issuance endpoint for browser and CLI session access. The client supplies a target `workload_id`, `container_name`, and a [session kind](terminal-proxy.md#session-kinds) with that kind's parameters. The Gateway derives the command from the kind; only `EXEC` carries a caller-supplied command, and it is authorized before being bound into the ticket. The request does not carry an identity; Gateway derives the caller identity from authenticated context and passes it only to the internal [Terminal Proxy](terminal-proxy.md) `IssueTicket` RPC.
+`CreateTerminalSession` is the Gateway-exposed ticket issuance endpoint for browser and CLI session access. The client supplies a target `workload_id`, `container_name`, and a [session kind](terminal-proxy.md#session-kinds) with that kind's parameters.
 
-Gateway authorizes the target before issuing a ticket:
+The Gateway routes and does not interpret. It checks the request is well-formed, resolves the caller's identity from authenticated context — the request never carries one — and forwards to the internal [Terminal Proxy](terminal-proxy.md) `IssueTicket` RPC.
 
-| Target workload | Authorization |
-|-----------------|---------------|
-| Sandbox workload | `can_connect` on `sandbox:<sandbox_id>`. This is owner-only; org owners can stop/delete non-owned sandboxes but cannot attach unless they also own the sandbox |
-| Agent workload container | `can_edit_config` on the agent class |
+Everything that follows from the kind belongs to the proxy, which owns terminal sessions: the [authorization check](terminal-proxy.md#authorization), resolving the kind to a command, and validating that kind's parameters. None of it is Gateway logic, and putting it here would put a service's domain rules in its router.
 
 On success the response contains a short-lived signed ticket, the Terminal Proxy WebSocket URL, and the ticket expiry. The command is bound into the ticket at issuance; the WebSocket handshake carries terminal size only and cannot change the command.
 

--- a/architecture/sandbox-sync.md
+++ b/architecture/sandbox-sync.md
@@ -25,7 +25,7 @@ Shared storage remains the right answer *inside* the cluster — a read-write-ma
 | Engineer's machine | `agyn sandbox sync` | Creates and inspects sessions; talks to the daemon over a unix socket |
 | Engineer's machine | Sync daemon | Owns every session: watching, reconciliation, transfer, reconnection, halt state |
 | Engineer's machine | Local endpoint | In-process filesystem access to the local root |
-| Gateway | `CreateTerminalSession(kind: SYNC)` | Authorizes and binds the in-sandbox command into a ticket |
+| Gateway | `CreateTerminalSession(kind: SYNC)` | Routes the request to the Terminal Proxy, carrying the caller identity |
 | Terminal Proxy | Sync session | A non-TTY session kind that does not report sandbox activity, and whose output frames are tagged by source stream. The proxy interprets no payload |
 | Sandbox container | `agyn sandbox sync serve` | Stateless remote endpoint — scans, stages, applies |
 
@@ -48,9 +48,9 @@ sequenceDiagram
     participant E as agyn sandbox sync serve
 
     D->>G: CreateTerminalSession(sandbox, kind: SYNC, root)
-    G->>G: OpenFGA check — caller is the sandbox owner
-    G->>G: Validate and normalize root; bind command into ticket
-    G->>TP: IssueTicket (internal)
+    G->>TP: IssueTicket (internal, caller identity from context)
+    TP->>TP: OpenFGA check — caller is the sandbox owner
+    TP->>TP: Validate and normalize root; bind command into ticket
     TP-->>D: { ticket, url }
     D->>TP: WebSocket connect (ticket)
     TP->>R: OpenZiti Dial runner-{runnerId} → Exec (tty: false)
@@ -60,7 +60,7 @@ sequenceDiagram
 
 Sync sessions reuse the [Terminal Proxy session establishment](terminal-proxy.md#session-establishment) unchanged, including its authorization: the caller must be the sandbox **owner**. Organization owners can manage a sandbox but cannot attach to one they do not own, and that applies to sync exactly as it applies to shells.
 
-The client requests a **session kind**, not a command. The Gateway holds the command for each kind and binds it into the ticket, so the client supplies no argument beyond the root path. That path is validated in two places — lexically at the Gateway, then resolved against the real filesystem by the endpoint at handshake, since only a process inside the container can follow symlinks or see where the workspace is mounted. See [Terminal Proxy — Root validation](terminal-proxy.md#root-validation).
+The client requests a **session kind**, not a command. The Terminal Proxy holds the command for each kind and binds it into the ticket, so the client supplies no argument beyond the root path. That path is validated in two places — lexically at the proxy, then resolved against the real filesystem by the endpoint at handshake, since only a process inside the container can follow symlinks or see where the workspace is mounted. See [Terminal Proxy — Root validation](terminal-proxy.md#root-validation).
 
 ## Endpoint Protocol
 

--- a/architecture/terminal-proxy.md
+++ b/architecture/terminal-proxy.md
@@ -21,7 +21,7 @@ Despite the name, the proxy is not shell-specific: it carries any bidirectional 
 | **Repository** | `agynio/terminal-proxy` |
 | **API** | WebSocket (external, via ingress) + gRPC (internal ticket issuance) |
 | **State** | None — sessions are in-memory; tickets are self-contained signed tokens validated by any replica |
-| **External dependencies** | [Runners](runners.md) (workload → runner resolution, activity reporting), [OpenZiti](openziti.md) (dial runners), [Authorization](authz.md) (checks at ticket issuance, via Gateway), [Agents](agents-service.md) (sandbox session bookkeeping) |
+| **External dependencies** | [Runners](runners.md) (workload → runner resolution, activity reporting), [OpenZiti](openziti.md) (dial runners), [Authorization](authz.md) (checks at ticket issuance), [Agents](agents-service.md) (sandbox session bookkeeping) |
 
 ## Session Establishment
 
@@ -37,8 +37,9 @@ sequenceDiagram
     participant K as Container PTY
 
     C->>G: CreateTerminalSession(workload_id, container_name, kind)
-    G->>G: OpenFGA check (see Authorization)
-    G->>TP: IssueTicket (internal)
+    G->>TP: IssueTicket (internal, caller identity from context)
+    TP->>TP: OpenFGA check (see Authorization)
+    TP->>TP: Resolve kind to a command; validate the kind's parameters
     TP-->>C: { ticket, url }
     C->>TP: WebSocket connect (ticket) + handshake {cols, rows}
     TP->>RS: GetWorkload → runner_id
@@ -47,14 +48,14 @@ sequenceDiagram
     C-->>K: raw bytes, both directions, until exit
 ```
 
-1. **`CreateTerminalSession`** (Gateway RPC): the caller requests a session for `(workload_id, container_name, kind)`. The Gateway performs the authorization check, resolves the kind to a command, then asks the Terminal Proxy to issue a **ticket** — single-use, bound to the caller's identity and the target, expiring in 30 seconds. The response carries the ticket and the proxy's WebSocket URL. Long-lived auth tokens never appear in WebSocket URLs (same reasoning as the [Media Proxy](media-proxy.md)'s avoidance of tokens in `GET` URLs).
+1. **`CreateTerminalSession`** (Gateway RPC): the caller requests a session for `(workload_id, container_name, kind)`. The Gateway checks the request is well-formed, resolves the caller's identity from authenticated context, and forwards to the Terminal Proxy's internal `IssueTicket`. Everything that follows from the kind — the authorization check, resolving the kind to a command, validating that kind's parameters — happens in the proxy, which owns terminal sessions; the Gateway routes and does not interpret. `IssueTicket` returns a **ticket**: single-use, bound to the caller's identity and the target, expiring in 30 seconds. Long-lived auth tokens never appear in WebSocket URLs (same reasoning as the [Media Proxy](media-proxy.md)'s avoidance of tokens in `GET` URLs).
 2. **WebSocket connect**: the client opens the WebSocket with the ticket, sends a JSON handshake carrying **only the initial terminal size**, and the proxy resolves the hosting runner via `Runners.GetWorkload`, dials it over OpenZiti (`runner-{runnerId}` — see [Runners — Terminal Proxy Integration](runners.md#terminal-proxy-integration)), and opens `Runner.Exec` with TTY enabled.
 
-The command is fixed at ticket issuance, never at attach time. It is derived from the requested [session kind](#session-kinds) and authorized and bound into the ticket by the Gateway. The WebSocket handshake carries no command — a client cannot escalate beyond what the ticket was issued for.
+The command is fixed at ticket issuance, never at attach time. It is derived from the requested [session kind](#session-kinds) and bound into the ticket by the proxy. The WebSocket handshake carries no command — a client cannot escalate beyond what the ticket was issued for.
 
 ## Session Kinds
 
-`CreateTerminalSession` takes a **session kind** rather than a command. The Gateway holds the command for each kind, so a client never supplies one and the ticket always describes something the platform defined.
+`CreateTerminalSession` takes a **session kind** rather than a command. The proxy holds the command for each kind, so a client never supplies one and the ticket always describes something the platform defined. The mapping lives here rather than in the [Gateway](gateway.md) because it is terminal-session domain logic, and the Gateway routes external requests to internal services rather than interpreting them.
 
 | Kind | TTY | Command | Consumer |
 |---|---|---|---|
@@ -90,8 +91,8 @@ The consequence to be aware of: the final shell is **not** a login shell, so she
 
 | Check | Where | Why there |
 |---|---|---|
-| Absolute, lexically normalized, no `..` traversal | Gateway, at issuance | Purely textual, and it is what keeps the ticket honest |
-| Resolves inside the workload's workspace mount, after following symlinks | The endpoint, at handshake | Only the process inside the container can see the filesystem. The Gateway has no mount data for a container — `Runners.Container` carries name, role, image, and status — and does not call the Runners service at all; the proxy does |
+| Absolute, lexically normalized, no `..` traversal | The proxy, at issuance | Purely textual, and it is what keeps the ticket honest |
+| Resolves inside the workload's workspace mount, after following symlinks | The endpoint, at handshake | Only the process inside the container can see the filesystem. Nothing outside it has mount data for a container — `Runners.Container` carries name, role, image, and status — so this cannot be checked before the session exists |
 
 A root failing the second check fails the session at handshake with the resolved path named. This is not a privilege boundary — a sandbox owner can already obtain a shell — but it keeps tickets meaningful and prevents the surface from generalizing into arbitrary remote execution.
 
@@ -151,7 +152,7 @@ Agent workloads get no activity touches from terminal sessions — inspecting an
 
 ## Authorization
 
-Checks run at ticket issuance (Gateway → OpenFGA):
+Checks run in the Terminal Proxy at ticket issuance, against OpenFGA. The Gateway supplies the caller's identity from authenticated context and nothing else — it does not decide who may attach:
 
 | Target | Check |
 |---|---|

--- a/changes/2026-08-04-sandbox-workspace-sync.md
+++ b/changes/2026-08-04-sandbox-workspace-sync.md
@@ -12,13 +12,14 @@
 
 ### Gateway
 
-- `CreateTerminalSession` takes a free-form optional command override rather than a **session kind**. The kind-to-command mapping, the `SYNC` kind, and lexical root-path validation for it do not exist. Tickets are not bound to a kind.
+- `CreateTerminalSession` takes a free-form optional command override rather than a **session kind**. The field is added and forwarded; nothing else changes. The Gateway routes and does not interpret — the kind-to-command mapping, parameter validation, and the authorization check all belong to the Terminal Proxy, which owns terminal sessions.
+- The documented behaviour was that the Gateway derives the command, validates the root, and runs the OpenFGA check. It never did any of them: it forwards `command` verbatim, and both the authorization check and the shell defaulting are already in the proxy. [gateway.md](../architecture/gateway.md#terminal-sessions) is corrected to describe routing rather than domain logic.
 
 ### Terminal Proxy
 
 - Sessions are TTY-only. Non-TTY session kinds — no PTY, no resize — are not supported.
 - Both `Runner.Exec` output streams are written to the WebSocket as untagged binary frames. That is correct for TTY sessions, where a PTY merges them anyway, but leaves a non-TTY consumer unable to separate protocol from diagnostics — a single stderr byte corrupts the stream. Non-TTY kinds need `separate_stderr` requested and each binary frame tagged with its source stream.
-- `SESSION_KIND_UNSPECIFIED` has no defined rejection behavior, there is no kind-to-command table, and no absolute-path invocation for the in-sandbox binary.
+- `SESSION_KIND_UNSPECIFIED` has no defined rejection behavior, there is no kind-to-command table, and no absolute-path invocation for the in-sandbox binary. The shell is a hardcoded constant in the service and mirrored in its ticket store; it must become a per-kind mapping owned here, alongside lexical validation of each kind's parameters.
 - Sandbox activity reporting does not discriminate by kind: every attached session drives `TouchWorkload` and updates `last_session_at`. `SYNC` sessions must do neither, or a background sync session keeps a sandbox running for as long as an engineer's machine stays connected.
 
 ### agyn (in-sandbox)


### PR DESCRIPTION
The Gateway was documented as deriving the command from the session kind, validating the kind's parameters, and running the OpenFGA check. That is a service's domain rules living in its router — the Gateway's own stated responsibility is to *"route external API requests to internal services."*

It also never did any of it:

- `gateway/internal/gateway/terminal.go` forwards `command` verbatim; it validates only that the workload id parses and the container name is non-empty.
- `terminal-proxy/internal/proxy/server.go` — `authorizeTerminal` runs the OpenFGA check.
- `terminal-proxy/internal/ticket/store.go` — `applyCommand` does the shell defaulting.

So this moves the docs toward the implementation, not away from it.

**After:** the Terminal Proxy owns everything that follows from a kind — authorization, the kind-to-command mapping, lexical validation of the kind's parameters. The Gateway resolves the caller identity from authenticated context and forwards.

**Unchanged:** the two-place split for a `SYNC` root. Lexical checks at issuance; resolving symlinks and confining to the workspace mount stays in the endpoint, since nothing outside the container has mount data for it.

Touches `gateway.md`, `terminal-proxy.md`, `sandbox-sync.md`, and the sandbox-workspace-sync change doc. Pairs with agynio/api#175.