### PR TITLE
One trace hook shipped with agynd, handed the trace it writes into

### DIFF
--- a/architecture/agynd-cli.md
+++ b/architecture/agynd-cli.md
@@ -54,7 +54,7 @@ Before spawning the agent CLI, `agynd` fetches class configuration from the plat
 | **LLM endpoint** | Writes [LLM Proxy](llm-proxy.md) endpoint configuration into the agent CLI's config file so the agent CLI knows where to make model calls. See [LLM Endpoint Configuration](#llm-endpoint-configuration) |
 | **CLI first-run state** | Writes the agent CLI's own first-run state file — `~/.claude.json` for Claude Code — so the CLI starts into work rather than an interactive setup wizard. See [Agent CLI First-Run State](#agent-cli-first-run-state) |
 | **MCP tools** | Configures the agent CLI with [MCP](mcp.md) server endpoints (`localhost:<port>` per server) from the `AGENT_MCP_SERVERS` env var so the agent CLI connects to each MCP sidecar directly over streamable HTTP |
-| **Tracing plugin** | Installs the platform's [tracing plugin](tracing.md#tracing-plugins) into the agent CLI by registering its turn-completion hook in the CLI's own config — `config.toml` for Codex, `~/.claude/settings.json` for Claude Code — the same files this step already writes. The plugin ships with the [agent runtime image](agent-init.md); `agynd` registers it rather than delivering it. After each turn it reads the CLI's session transcript and exports the turn to [Tracing](tracing.md) at `tracing.ziti`, which is how the prompt, the model's reply, and each tool call's input and output are recorded |
+| **Trace hook** | Opens the trace for this wake cycle and registers the platform's [trace hook](tracing.md#the-trace-hook) on the agent CLI's turn completion, in the CLI's own config — `config.toml` for Codex, `~/.claude/settings.json` for Claude Code — the same files this step already writes. The hook ships with `agynd` and is told which transcript format to expect and which trace to write into. After each turn it reads the CLI's session transcript and exports the turn to [Tracing](tracing.md) at `tracing.ziti`, which is how the prompt, the model's reply, and each tool call's input and output are recorded |
 | **Init scripts** | Fetches [init scripts](resource-definitions.md#initscript) via `ListInitScripts(environment_id)` and `ListInitScripts(agent_id)`, then executes the environment's scripts followed by the agent's, each group in creation order, using the container's default shell. Each script runs with its working directory set to `WORKSPACE_DIR` when that variable is defined in the subprocess environment, and to `/tmp` otherwise. Runs after environment setup and before spawning the agent CLI. If a script exits with a non-zero code, the script name and stderr output are printed to the container's stderr and execution continues with the next script. In a [sandbox](../product/sandboxes/sandboxes.md) there is no agent: `agynd` runs the environment's scripts and then holds, spawning no agent CLI — see [Agent Init Container](agent-init.md#startup-sequence). |
 | **PATH** | Prepends `/agyn/bin` to `PATH` in the subprocess environment, making the `agyn` platform CLI and the configured agent CLI binary (`codex`, `claude`, or `agn`) available by name to the agent process and any child commands it runs. One entry suffices because every delivered binary lives there — see [Agent Init — Shared Volume Contract](agent-init.md#shared-volume-contract). |
 
@@ -185,7 +185,7 @@ A [sandbox](../product/sandboxes/sandboxes.md) runs `agynd` as a holder — no a
 
 So the CLI-local preparation runs in holder mode too: the first-run state file, the [file placeholder](#native-mode-configuration), and the configuration file carrying tool permissions and MCP wiring. Someone opening a shell should find the same configured CLI an agent workload would have spawned, not a setup wizard and then a permission prompt.
 
-What does not run in holder mode is what has no subject. Skills and [init scripts](resource-definitions.md#initscript) scoped to an agent have no agent to scope to, and the tracing plugin has no agent CLI to hook. The rule is that preparation determined by the environment runs, and preparation determined by the agent does not.
+What does not run in holder mode is what has no subject. Skills and [init scripts](resource-definitions.md#initscript) scoped to an agent have no agent to scope to, and the trace hook has no agent CLI to register on. The rule is that preparation determined by the environment runs, and preparation determined by the agent does not.
 
 ### 4. Agent Process Management
 
@@ -276,11 +276,11 @@ graph TB
         subgraph "Agent Container"
             agynd[agynd]
             AgentCLI[Agent CLI<br/>agn / 3rd-party]
-            Plugin[Tracing Plugin<br/>turn-completion hook]
+            Plugin[Trace Hook<br/>turn completion]
             Skills[Skills on filesystem]
 
             agynd -->|spawns via SDK| AgentCLI
-            agynd -->|registers hook| Plugin
+            agynd -->|registers hook, hands trace| Plugin
             Skills -->|read by| AgentCLI
             AgentCLI -->|session transcript| Plugin
         end

--- a/architecture/openziti.md
+++ b/architecture/openziti.md
@@ -494,13 +494,13 @@ All containers in the pod share the same network namespace and the same OpenZiti
 |------------|-------|
 | agynd → Gateway | `.ziti` hostname via Ziti sidecar TPROXY |
 | Agent CLI → LLM Proxy | `llm-proxy.ziti` via Ziti sidecar TPROXY |
-| agynd and tracing plugin → Tracing | `tracing.ziti` via Ziti sidecar TPROXY |
+| agynd and trace hook → Tracing | `tracing.ziti` via Ziti sidecar TPROXY |
 | Agent CLI → MCP sidecars | `localhost:<port>` (direct, no Ziti) |
 | Gateway → internal services | Istio |
 | LLM Proxy → internal services | Istio |
 | Tracing → internal services | Istio |
 
-The Gateway routes agent requests to internal services (Threads, Files, etc.) via Istio. The LLM Proxy handles LLM API calls — it resolves models via the LLM service and forwards requests to external providers. The Tracing service receives span data from agents — [`agynd` and the tracing plugin](tracing.md#span-producers) export directly, each attributed to the identity that sent it.
+The Gateway routes agent requests to internal services (Threads, Files, etc.) via Istio. The LLM Proxy handles LLM API calls — it resolves models via the LLM service and forwards requests to external providers. The Tracing service receives span data from agents — [`agynd` and its trace hook](tracing.md#span-producers) export directly, each attributed to the identity that sent it.
 
 ## OpenZiti Identities Summary
 

--- a/architecture/tracing.md
+++ b/architecture/tracing.md
@@ -331,15 +331,15 @@ Spans reach the Tracing service directly from whatever produced them. Each produ
 
 | Producer | Emits |
 |----------|-------|
-| [Tracing plugin](#tracing-plugins) | `llm.call` and `tool.execution`, read from the agent CLI's session transcript |
+| [Trace hook](#the-trace-hook) | `llm.call` and `tool.execution`, read from the agent CLI's session transcript |
 | [`agynd`](agynd-cli.md) | `invocation.message`, when it feeds an inbox item to the agent CLI |
 | Platform services | spans for the work a request passes through |
 
 ### The trace is the wake cycle
 
-A workload is started when an [agent instance](agent-instances.md) has work and stopped when it goes idle, so the workload *is* one wake cycle. Its `WORKLOAD_ID` names it, and every producer inside the container derives the same trace id from that value.
+A workload is started when an [agent instance](agent-instances.md) has work and stopped when it goes idle, so the workload *is* one wake cycle. `agynd` opens a trace for it during [environment preparation](agynd-cli.md#3-environment-preparation) and hands the id to the trace hook it installs, so both producers write into one trace.
 
-Nothing is coordinated to achieve this. `agynd` and the plugin read `WORKLOAD_ID` from the environment the container already carries, derive the trace id the same way, and land in one trace by construction — with no identifier passed between them, and no drift if `agynd` restarts inside the pod.
+The id is derived from `WORKLOAD_ID` rather than drawn, so an `agynd` restarting inside the pod reopens the trace it was already writing instead of splitting the cycle in two.
 
 A cycle serves an inbox that spans threads, so its trace holds many turns. Each `invocation.message` marks where one begins, which is what lets a reader show a single turn or the whole cycle.
 
@@ -349,9 +349,9 @@ The Tracing service derives attribution from the verified OpenZiti connection ra
 
 No producer asserts a thread. An instance serves an inbox drawn from many threads, so there is no thread a span belongs to — only the message that opened the turn it sits under, which `invocation.message` carries.
 
-## Tracing Plugins
+## The Trace Hook
 
-What an agent did is read from the **session transcript** the agent CLI writes, not from the telemetry it exports. A platform-owned plugin, installed into each CLI by `agynd`, reads that transcript after every turn and exports the reconstructed turn to the Tracing service.
+What an agent did is read from the **session transcript** the agent CLI writes, not from the telemetry it exports. `agynd` registers a hook on each CLI's turn completion; the hook reads that transcript and exports the reconstructed turn to the Tracing service.
 
 ### Why not the CLI's own telemetry
 
@@ -359,15 +359,15 @@ An agent CLI's OTel export describes that a model call happened — endpoint, mo
 
 The transcript is the opposite. It is the record the CLI keeps in order to resume a session, so it holds the prompt, the assistant's reply, every tool call with its input and output, and the usage counts — the material this service exists to store.
 
-### Plugin contract
+### Hook contract
 
-Each plugin is platform-owned, ships with the agent runtime image, and is installed by `agynd` during [environment preparation](agynd-cli.md#3-environment-preparation). It registers on the CLI's turn-completion hook, and:
+The hook is a single platform binary, shipped with [`agynd`](agynd-cli.md) and delivered by the same init container, so one implementation serves every CLI: a hook is a command to run, and what differs between CLIs is only the transcript it is handed. `agynd` registers it during [environment preparation](agynd-cli.md#3-environment-preparation), telling it which format to expect and which trace to write into. On each invocation it:
 
-1. Reads the session transcript the hook identifies.
+1. Reads the session transcript the CLI identifies.
 2. Reconstructs the turns not yet sent, in the shape described below.
-3. Exports them as spans to the Tracing service at `tracing.ziti`, in the trace derived from `WORKLOAD_ID`. The pod's Ziti sidecar carries the connection and the workload's identity authenticates it, so the plugin holds no credential of its own.
+3. Exports them as spans to the Tracing service at `tracing.ziti`, in the trace `agynd` opened. The pod's Ziti sidecar carries the connection and the workload's identity authenticates it, so the hook holds no credential of its own.
 4. Records what it sent, so a resumed session — which replays the transcript from its start — uploads each turn once.
-5. Swallows its own failures. Tracing is an optional dependency; a plugin never ends a turn that otherwise succeeded.
+5. Swallows its own failures. Tracing is an optional dependency; the hook never ends a turn that otherwise succeeded.
 
 | Agent CLI | Hook | Transcript |
 |-----------|------|------------|
@@ -377,7 +377,9 @@ Each plugin is platform-owned, ships with the agent runtime image, and is instal
 
 ### Turn shape
 
-A turn becomes an `llm.call` per model step — carrying the model, the full request context and the usage counts — and a `tool.execution` per tool call, carrying its input and output. Each execution hangs off the call that invoked it, and the calls hang off the [`invocation.message`](#span-producers) `agynd` emitted for the item that opened the turn. A subagent's turns hang off the turn that spawned them.
+A turn becomes an `llm.call` per model step — carrying the model, the full request context and the usage counts — and a `tool.execution` per tool call, carrying its input and output. Each execution hangs off the call that invoked it, and a subagent's turns hang off the turn that spawned them.
+
+Calls root in the trace rather than under an [`invocation.message`](#span-producers). A transcript names a turn in the CLI's own terms — a line id, a session and a timestamp — never the platform's message id, so the hook has no message span to point at. The shared trace is what joins them, and `invocation.message` marks where each turn begins.
 
 Span ids are derived from the turn rather than drawn, so a resumed session that replays the transcript writes the ids it wrote before and the [upsert](#upsert-semantics) lands on the existing rows. The same derivation completes a turn first exported while it was still running.
 

--- a/changes/2026-08-09-transcript-sourced-tracing.md
+++ b/changes/2026-08-09-transcript-sourced-tracing.md
@@ -3,7 +3,7 @@
 ## Target
 
 - [Tracing — Span Producers](../architecture/tracing.md#span-producers)
-- [Tracing — Tracing Plugins](../architecture/tracing.md#tracing-plugins)
+- [Tracing — The Trace Hook](../architecture/tracing.md#the-trace-hook)
 - [Tracing — Attribute Injection and Verification](../architecture/tracing.md#attribute-injection-and-verification)
 - [agynd — Environment Preparation](../architecture/agynd-cli.md#3-environment-preparation)
 
@@ -17,11 +17,13 @@ The agent CLI writes it to disk instead. Every turn is appended to a session tra
 
 ### What must change
 
-The span producer stops being the CLI's OTel SDK. The [tracing plugin](../architecture/tracing.md#tracing-plugins) is written for each agent CLI, ships with the agent runtime image, and `agynd` registers its hook while writing the CLI's config — the file it already writes for the LLM endpoint and MCP servers.
+The span producer stops being the CLI's OTel SDK. The [trace hook](../architecture/tracing.md#the-trace-hook) reads the transcript instead, and `agynd` registers it while writing the CLI's config — the file it already writes for the LLM endpoint and MCP servers.
+
+It is one binary rather than one plugin per CLI, and it ships with `agynd`. A hook is a command to run, so nothing about it is CLI-specific except the transcript it is handed; a per-CLI plugin would duplicate the turn model, the export and the delivery record — some 70% of it — across implementations, and let the span vocabulary drift between them with nothing to catch it.
 
 **The tracing proxy is removed.** It existed to inject attribution onto spans passing through it, and there is nothing left for it to inject. The Tracing service derives identity from the connection, so a workload authenticating as its instance already *is* the attribution. Thread attribution goes with it: an instance serves an inbox drawn from many threads, and the per-turn value the proxy injected was documented as best-effort because there is no single thread a workload belongs to. `agynd` asserts the message on the `invocation.message` it emits, and nothing asserts a thread.
 
-Producers export to `tracing.ziti` directly, each carrying its own identity. A turn's spans and the message that opened it meet in one trace because both derive it from `WORKLOAD_ID` — the workload *is* one wake cycle, so nothing is passed between them and nothing drifts if `agynd` restarts in the pod.
+Producers export to `tracing.ziti` directly, each carrying its own identity. `agynd` opens a trace for the wake cycle and hands the id to the hook it registers, so a turn's spans and the message that opened it land together. The id is derived from `WORKLOAD_ID` rather than drawn, so an `agynd` restarting in the pod reopens the trace it was already writing.
 
 The CLI's own OTel export stops being collected: it describes the framework's internals and answers no question the run view asks.
 


### PR DESCRIPTION
Corrects the spec merged in #172 on two points that the implementation contradicted.

**One hook, not a plugin per CLI.** A hook is a command to run, so nothing about it is CLI-specific except the transcript it is handed. A per-CLI plugin would duplicate the turn model, the export and the delivery record — about 70% of each implementation — and let the span vocabulary drift between them with nothing to catch it. It ships with `agynd`, delivered by the same init container, rather than with the agent runtime image.

**`agynd` opens the trace and hands it over.** The spec had both producers deriving the trace id from `WORKLOAD_ID` independently. `agynd` now opens it and passes the id to the hook it registers. The derivation stays, so an `agynd` restarting in the pod reopens the trace it was already writing.

Also records what the shared trace does and does not buy: calls root in the trace rather than under `invocation.message`, because a transcript names a turn in the CLI's own terms and never the platform's message id.

Implemented in agynio/agynd-cli#174.