### PR TITLE
Grant a private resource to an environment

### DIFF
--- a/architecture/authz.md
+++ b/architecture/authz.md
@@ -594,7 +594,9 @@ App visibility affects who can read app records: `public` apps are visible to an
 
 ### Networks Service
 
-Networks, Tunnels, PrivateResources, and PrivateResourceAccess grants are all organization-scoped resources managed by the [Networks service](networks-service.md). No new OpenFGA types are introduced — checks rely on existing organization-level relations and per-agent `can_edit_config`.
+Networks, Tunnels, PrivateResources, and PrivateResourceAccess grants are all organization-scoped resources managed by the [Networks service](networks-service.md). No new OpenFGA types are introduced — checks rely on existing organization-level relations and on `can_edit_config` on the [`agent`](#agent) or [`environment`](#environment) a grant targets.
+
+An [environment principal](private-networks.md#why-an-environment-is-a-principal) reaches every workload running that environment, including a sandbox any holder of `can_use` may start. `can_edit_config` is the right gate for it — the same one that governs the environment's ENVs, volumes, and egress rule attachments, all of which a shell in such a sandbox already reaches. Granting a private resource to an environment adds a destination to that set; it does not widen who is standing in front of it.
 
 | Operation | Check |
 |-----------|-------|
@@ -605,6 +607,7 @@ Networks, Tunnels, PrivateResources, and PrivateResourceAccess grants are all or
 | `CreatePrivateResource`, `UpdatePrivateResource`, `DeletePrivateResource` | `owner` on `organization:<org_id>` |
 | `GetPrivateResource`, `ListPrivateResources` | `member` on `organization:<org_id>` |
 | `CreatePrivateResourceAccess` (`agent` principal) | `can_edit_config` on `agent:<agent_id>` + cross-org guard (`organization:<resource.org_id>` holds `org` on `agent:<agent_id>`) |
+| `CreatePrivateResourceAccess` (`environment` principal) | `can_edit_config` on `environment:<environment_id>` + cross-org guard (`organization:<resource.org_id>` holds `org` on `environment:<environment_id>`) |
 | `CreatePrivateResourceAccess` (`user`, `app`, or `group` principal) | `owner` on `organization:<resource.org_id>` + cross-org guard (`organization:<resource.org_id>` holds `org` on the principal) |
 | `DeletePrivateResourceAccess` | Same check as the corresponding `CreatePrivateResourceAccess` |
 | `ListPrivateResourceAccess` | `member` on `organization:<org_id>` |

--- a/architecture/networks-service.md
+++ b/architecture/networks-service.md
@@ -13,7 +13,7 @@ Structurally analogous to the [EgressRules service](egress-rules-service.md) —
 | **Network CRUD** | Create, read, update, delete `Network` resources. Provisions the per-network Bind policy on create; deletes the policy on delete |
 | **TunnelCredential CRUD** | Issue and revoke tunnel enrollment credentials. Each credential maps 1:1 to an OpenZiti identity with role attributes `["tunnels", "network-<id>"]` |
 | **PrivateResource CRUD** | Create, read, update, delete `PrivateResource` resources. Validates intercept hostname against reserved zones (`*.agyn`, `*.svc`, `*.cluster.local`, `100.64.0.0/10`, `localhost`, `127.0.0.0/8`, `::1/128`) and the per-org uniqueness constraint per port in `intercept_ports`. Provisions the OpenZiti service + configs with the [tagging convention](private-networks.md#openziti-resource-tagging) |
-| **PrivateResourceAccess CRUD** | Create and delete access grants. Each grant materializes as exactly one OpenZiti Dial policy. Principals: `agent`, `user`, `app`, `group`. List grants by resource, by principal, by organization |
+| **PrivateResourceAccess CRUD** | Create and delete access grants. Each grant materializes as exactly one OpenZiti Dial policy. Principals: `agent`, `environment`, `user`, `app`, `group`. List grants by resource, by principal, by organization |
 | **Tunnel liveness tracking** | Poll the OpenZiti Controller for per-identity session info; surface `enrolled_at` and `last_seen_at` on `TunnelCredential`; emit `tunnel_status.changed` notifications on transitions |
 | **Reconciliation** | Periodic sweep to repair drift between resource records and actual OpenZiti state |
 | **Change notifications** | Publish `network.updated`, `tunnel_credential.updated`, `tunnel_status.changed`, `private_resource.updated`, `private_resource_access.updated` events to the organization's [Notifications](notifications.md) room |
@@ -29,7 +29,7 @@ Control plane — Gateway-exposed CRUD with periodic reconciliation. Not on a re
 | **Repository** | `agynio/networks` |
 | **API** | gRPC (internal) + Gateway (external via ConnectRPC) |
 | **State** | PostgreSQL — `networks`, `tunnel_credentials`, `private_resources`, `private_resource_access` tables |
-| **External dependencies** | [Ziti Management](openziti.md), [Authorization](authz.md) (caller-permission checks + cross-org guard via OpenFGA `org` relation on the principal — covers `agent`, `user`, `app`, and `group` principals uniformly), [Identity](identity.md) (existence check + type validation for individual principals `agent`/`user`/`app` via `GetIdentityType`), [Groups](groups-service.md) (existence check for `group` principals via `GetGroup`), [Messaging](messaging.md) (event-bus publication + subscription), [Notifications](notifications.md) (client-facing UI updates) |
+| **External dependencies** | [Ziti Management](openziti.md), [Authorization](authz.md) (caller-permission checks + cross-org guard via OpenFGA `org` relation on the principal — covers `agent`, `user`, `app`, and `group` principals uniformly), [Identity](identity.md) (existence check + type validation for individual principals `agent`/`user`/`app` via `GetIdentityType`), [Groups](groups-service.md) (existence check for `group` principals via `GetGroup`), [Agents](agents-service.md) (existence and organization check for `environment` principals via `GetEnvironment` — an environment is a configuration resource, not an identity, so it is not in the Identity registry), [Messaging](messaging.md) (event-bus publication + subscription), [Notifications](notifications.md) (client-facing UI updates) |
 
 ## API
 
@@ -66,7 +66,7 @@ Control plane — Gateway-exposed CRUD with periodic reconciliation. Not on a re
 
 | Method | Description |
 |---|---|
-| **CreatePrivateResourceAccess** | Grant access. Validates: principal exists (for `agent` / `user` / `app` via `Identity.GetIdentityType` — also confirms `principal_type` matches the registered identity type; for `group` via `Groups.GetGroup`); the principal belongs to the resource's organization (cross-org `Check` via [Authorization](authz.md) `org` relation on `<principal_type>:<principal_id>`); the grant is unique on `(resource_id, principal_type, principal_id)`. Creates the per-grant Dial policy |
+| **CreatePrivateResourceAccess** | Grant access. Validates: principal exists (for `agent` / `user` / `app` via `Identity.GetIdentityType` — also confirms `principal_type` matches the registered identity type; for `group` via `Groups.GetGroup`; for `environment` via `Agents.GetEnvironment`); the principal belongs to the resource's organization (cross-org `Check` via [Authorization](authz.md) `org` relation on `<principal_type>:<principal_id>`, which the [`environment` type](authz.md#environment) carries like every other principal); the grant is unique on `(resource_id, principal_type, principal_id)`. Creates the per-grant Dial policy |
 | **DeletePrivateResourceAccess** | Revoke access. Deletes the Dial policy |
 | **ListPrivateResourceAccess** | List grants, filterable by `resource_id`, by `principal_type` + `principal_id`, or by `network_id` |
 
@@ -105,7 +105,7 @@ For each PrivateResourceAccess, one OpenZiti Dial policy:
 | **Dial policy** (`identityRoles: ["#<principal-role>"]`, `serviceRoles: ["@private-<resource_id>"]`) | `CreateServicePolicy` | On `CreatePrivateResourceAccess` |
 | **Dial policy** deletion | `DeleteServicePolicy` | On `DeletePrivateResourceAccess` |
 
-The principal role attribute is one of `agent-<id>`, `user-<id>`, or `group-<id>` per [Private Networks — Dial Policy](private-networks.md#dial-policy-per-access-grant).
+The principal role attribute is one of `agent-<id>`, `environment-<id>`, `user-<id>`, `app-<id>`, or `group-<id>` per [Private Networks — Dial Policy](private-networks.md#dial-policy-per-access-grant). None of them is provisioned here: every one is stamped on the identity by the service that owns it, and a grant only writes the policy that matches it.
 
 Service config shapes (`host.v1`, `intercept.v1`) are in [Private Networks — Per-Resource OpenZiti Service](private-networks.md#per-resource-openziti-service).
 
@@ -185,6 +185,8 @@ Known consumers (informational):
 
 The handler re-reads the affected grants from the local database (the event payload carries only `group_id`), deletes them transactionally, and removes the OpenZiti Dial policies via Ziti Management. Idempotent — re-running on duplicate delivery has no additional effect (grants already deleted).
 
+**There is no equivalent cleanup for a deleted environment**, because the [Agents](agents-service.md) service publishes no environment lifecycle event to subscribe to. The grant is left behind, and it is inert: `environment-<id>` is stamped only on workloads running that environment, and a deleted environment has none and can get none — [deletion is blocked](resource-definitions.md#environment) while any agent or sandbox references it. A Dial policy naming a role attribute no identity carries grants nothing. This is a hygiene gap, not an access one, and closing it wants an `agyn.agents.environment.deleted` event rather than a per-pass existence check on every grant.
+
 ## Client-Facing Updates
 
 Separately from the service-to-service event bus, the Networks service publishes UI-facing updates to the organization's [Notifications](notifications.md) room (`organization:<org_id>`) for Console reactivity:
@@ -210,6 +212,7 @@ These are fire-and-forget [Notifications](notifications.md) updates for the brow
 | `CreatePrivateResource`, `UpdatePrivateResource`, `DeletePrivateResource` | `owner` on `organization:<org_id>` |
 | `GetPrivateResource`, `ListPrivateResources` | `member` on `organization:<org_id>` |
 | `CreatePrivateResourceAccess` (agent principal) | `can_edit_config` on `agent:<agent_id>` + resource org-membership check |
+| `CreatePrivateResourceAccess` (environment principal) | `can_edit_config` on `environment:<environment_id>` + resource org-membership check — the same permission that edits the environment's other contents, and the same one an [egress rule attachment](egress-rules-service.md#authorization) to an environment requires |
 | `CreatePrivateResourceAccess` (user, app, or group principal) | `owner` on `organization:<org_id>` + resource org-membership check |
 | `DeletePrivateResourceAccess` | Same check as the corresponding `CreatePrivateResourceAccess` |
 | `ListPrivateResourceAccess` | `member` on `organization:<org_id>` |
@@ -233,6 +236,7 @@ All RPCs are external; the Networks service has no internal-only methods today.
 | `ZITI_MANAGEMENT_ADDRESS` | Deployment config | gRPC address of [Ziti Management](openziti.md) |
 | `AUTHORIZATION_SERVICE_ADDRESS` | Deployment config | gRPC address of [Authorization](authz.md) |
 | `GROUPS_SERVICE_ADDRESS` | Deployment config | gRPC address of [Groups](groups-service.md) (existence checks for `group_id` principals on access grants) |
+| `AGENTS_SERVICE_ADDRESS` | Deployment config | gRPC address of [Agents](agents-service.md) (existence checks for `environment` principals on access grants) |
 | `NATS_URL` | Deployment config | NATS connection URL for the platform [event bus](messaging.md) |
 | `NOTIFICATIONS_ADDRESS` | Deployment config | gRPC address of [Notifications](notifications.md) (client-facing UI updates) |
 | `RECONCILIATION_INTERVAL` | Deployment config | How often the reconciliation loop runs (default `60s`) |

--- a/architecture/private-networks.md
+++ b/architecture/private-networks.md
@@ -16,7 +16,7 @@ For the user-facing model, see [Product — Private Networks](../product/private
 | **Tunnel** | A long-running OpenZiti tunneler instance inside the operator's private network. Enrolls into the platform via a one-time-token JWT issued from the [Networks service](networks-service.md), then phones home to the OpenZiti Controller and binds the services its network's resources expose. One Tunnel belongs to exactly one Network. A Network can have many Tunnels for HA. |
 | **TunnelCredential** | The enrollment artifact issued by the platform for a new tunnel instance — a one-time-token JWT plus a recommended install snippet per supported tunneler distribution. Credentials are revocable; revocation deletes the underlying OpenZiti identity, severing any tunneler that holds it. |
 | **PrivateResource** | A single addressable endpoint behind a Network: a `target_host:target_ports` target the Tunnel forwards to, exposed to agents as an `intercept_host:intercept_ports` hostname they dial. One resource has a single protocol (`tcp` / `http` / `https`). UDP is not supported in v1. |
-| **Resource access grant** | A `(PrivateResource, principal)` tuple authorizing the principal to dial the resource. Principals may be an `agent`, `user`, `app`, or `group`. Underneath, each grant materializes as exactly one OpenZiti Dial policy. |
+| **Resource access grant** | A `(PrivateResource, principal)` tuple authorizing the principal to dial the resource. Principals may be an `agent`, `environment`, `user`, `app`, or `group`. Underneath, each grant materializes as exactly one OpenZiti Dial policy. |
 
 Networks, Tunnels, PrivateResources, and access grants are all organization-scoped. There is no cross-org reachability.
 
@@ -83,13 +83,25 @@ Public hostnames (e.g., `gitlab.com`) are not in the reserved list and are allow
 |---|---|---|
 | `id` | string (UUID) | Unique identifier |
 | `private_resource_id` | string (UUID) | Reference to the PrivateResource |
-| `principal_type` | enum | `agent` \| `user` \| `app` \| `group` |
-| `principal_id` | string (UUID) | Identity or group ID |
+| `principal_type` | enum | `agent` \| `environment` \| `user` \| `app` \| `group` |
+| `principal_id` | string (UUID) | Identity, environment, or group ID |
 | `provisioning_state` | enum | `active` \| `failed` \| `removing` — reflects whether the backing OpenZiti Dial policy was successfully provisioned. See [Provisioning Status](#provisioning-status) |
 | `openziti_dial_policy_id` | string | OpenZiti Dial policy backing this grant (one Dial policy per grant — simpler reconciliation and revocation) |
 | `created_at` | timestamp | |
 
 Unique on `(private_resource_id, principal_type, principal_id)`. Grants are immutable — create and delete only.
+
+### Why an environment is a principal
+
+Every other principal is an identity. An [environment](resource-definitions.md#environment) is not — it is a configuration resource, and it is a principal here because it is the only handle that reaches a [sandbox](resource-definitions.md#sandbox).
+
+A sandbox workload carries no `agent-<id>` attribute: there is no agent class behind it. It cannot be a group member — groups collect users, agents, and apps. So under identity principals alone, nothing can grant a sandbox access to a private resource, and the engineer at a sandbox shell — the person most likely to want an internal database — is the one principal type the access model cannot express.
+
+What agent workloads and sandbox workloads do share is the environment they run. The [Agents Orchestrator](agents-orchestrator.md#workload-spec-assembly) stamps `environment-<environmentId>` on every workload identity it creates, agent workloads and sandboxes alike, which is the same attribute [egress rule attachments](egress-rules-service.md) already target. Granting to an environment therefore needs no new OpenZiti mechanism and no new attribute — only a principal type that resolves to one.
+
+**A grant to an environment reaches everyone who can start a sandbox in it.** Access follows the environment, not the person: any agent pointed at it and any sandbox started in it can dial the resource, and starting a sandbox requires only [`can_use`](authz.md#environment). This is the same reach an [EgressRule](egress-rules-service.md) attached to an environment already has, and it is why the grant is authorized by `can_edit_config` on the environment rather than by anything on the resource.
+
+Agent instances and individual sandboxes as principals are deliberately out of scope. Both are narrower than an environment and would need their own role attributes — `workload-<id>` exists but dies with the workload, so neither is a grant that outlives a restart. Until that is designed, the environment is the unit.
 
 ## OpenZiti Topology
 
@@ -98,11 +110,14 @@ Unique on `(private_resource_id, principal_type, principal_id)`. Grants are immu
 | Identity Type | Role Attributes |
 |---|---|
 | Tunnel | `["tunnels", "network-<network_id>"]` |
-| Agent pod (Ziti sidecar) | Existing — `["agents", "agent-<agentId>", "workload-<workloadId>"]`, plus `"group-<groupId>"` for every group the agent belongs to (see [Groups service](groups-service.md)) |
+| Agent pod (Ziti sidecar) | Existing — `["agents", "agent-<agentId>", "workload-<workloadId>", "environment-<environmentId>"]`, plus `"group-<groupId>"` for every group the agent belongs to (see [Groups service](groups-service.md)) |
+| Sandbox pod (Ziti sidecar) | Existing — `["agents", "workload-<workloadId>", "environment-<environmentId>"]`. No `agent-<id>`: a sandbox has no agent class behind it |
 | User device | Existing — `["devices", "user-<userId>"]`, plus `"group-<groupId>"` for every group the user belongs to |
 | App | Existing — `["apps", "app-<appId>"]`, plus `"group-<groupId>"` for every group the app belongs to |
 
 The `network-<id>` attribute on Tunnels is what lets multiple tunnel hosts share the same set of bindable services for HA. Resources bind by network role attribute, never by specific tunnel identity ID.
+
+`environment-<environmentId>` is stamped by the [Agents Orchestrator](agents-orchestrator.md#workload-spec-assembly) at workload spec assembly and is the only attribute a sandbox and an agent workload running the same environment have in common. Nothing new is introduced for [environment grants](#why-an-environment-is-a-principal) — the attribute already exists and already carries [egress rule attachments](egress-rules-service.md).
 
 ### Per-Resource OpenZiti Service
 
@@ -165,14 +180,17 @@ CreateServicePolicy(
 
 Where `<principal-role-attribute>` resolves by principal type:
 
-| Principal | Role attribute |
-|---|---|
-| `agent:<id>` | `agent-<id>` |
-| `user:<id>` | `user-<id>` |
-| `app:<id>` | `app-<id>` |
-| `group:<id>` | `group-<id>` |
+| Principal | Role attribute | Resolves to |
+|---|---|---|
+| `agent:<id>` | `agent-<id>` | Every workload of that agent |
+| `environment:<id>` | `environment-<id>` | Every workload running that environment — agent workloads and [sandboxes](resource-definitions.md#sandbox) alike |
+| `user:<id>` | `user-<id>` | The user's enrolled devices |
+| `app:<id>` | `app-<id>` | The app's own identity |
+| `group:<id>` | `group-<id>` | Every member transitively |
 
 Static policies, networks, and resources don't conflict — each grant is its own policy.
+
+A workload picks up a new grant on its SDK's next service-list poll (≤15s) — including a workload that was already running when the grant was made. Nothing restarts, because the attribute was stamped at workload creation and only the policy is new.
 
 ## Provisioning Status
 

--- a/architecture/resource-definitions.md
+++ b/architecture/resource-definitions.md
@@ -489,19 +489,19 @@ The `protocol` field is platform metadata used to gate features like header inje
 
 ## Private Resource Access
 
-A relationship granting a principal (agent, user, or group) the ability to dial a [PrivateResource](#private-resource). Each grant materializes as an OpenZiti Dial policy. Managed by the [Networks service](networks-service.md).
+A relationship granting a principal (agent, environment, user, app, or group) the ability to dial a [PrivateResource](#private-resource). Each grant materializes as an OpenZiti Dial policy. Managed by the [Networks service](networks-service.md).
 
 | Field | Type | Description |
 |-------|------|-------------|
 | `private_resource_id` | string (UUID) | Reference to the [PrivateResource](#private-resource) |
-| `principal_type` | enum | `agent` \| `user` \| `group` \| `app` |
-| `principal_id` | string (UUID) | Identity or group ID |
+| `principal_type` | enum | `agent` \| `environment` \| `user` \| `group` \| `app` |
+| `principal_id` | string (UUID) | Identity, [Environment](#environment), or group ID |
 | `provisioning_state` | enum | `active` \| `failed` \| `removing`. Reflects whether the backing OpenZiti Dial policy was successfully provisioned. `failed` is retried by reconciliation |
 | `openziti_dial_policy_id` | string | OpenZiti Dial policy created for this grant (one Dial policy per grant). Internal — not returned through the Gateway |
 
 Grants are immutable — create and delete only. Unique on `(private_resource_id, principal_type, principal_id)`. The resource and the principal must belong to the same organization — the [Networks service](networks-service.md#authorization) enforces this on create.
 
-For `user` principals, the grant resolves to the user's enrolled device identities (any device with role attribute `user-<id>` can dial). For `app` principals, the grant resolves to the app's single OpenZiti identity (role attribute `app-<id>`). For `group` principals, the grant resolves to every member's identity transitively (any identity with role attribute `group-<id>` — includes apps, users' devices, and agent workloads that are members of the group).
+For `user` principals, the grant resolves to the user's enrolled device identities (any device with role attribute `user-<id>` can dial). For `app` principals, the grant resolves to the app's single OpenZiti identity (role attribute `app-<id>`). For `group` principals, the grant resolves to every member's identity transitively (any identity with role attribute `group-<id>` — includes apps, users' devices, and agent workloads that are members of the group). For `environment` principals, the grant resolves to every workload running that environment — agent workloads and [sandboxes](#sandbox) alike — and is the only principal type that reaches a sandbox, which carries no agent identity and cannot be a group member. See [Private Networks — Why an environment is a principal](private-networks.md#why-an-environment-is-a-principal).
 
 ---
 

--- a/changes/2026-08-10-private-resource-environment-grants.md
+++ b/changes/2026-08-10-private-resource-environment-grants.md
@@ -1,0 +1,47 @@
+# Environment as a Private Resource Access Principal
+
+## Target
+
+- [Private Networks — Why an environment is a principal](../architecture/private-networks.md#why-an-environment-is-a-principal)
+- [Private Networks — Dial Policy (per Access Grant)](../architecture/private-networks.md#dial-policy-per-access-grant)
+- [Private Networks — Role Attributes](../architecture/private-networks.md#role-attributes)
+- [Networks Service — PrivateResourceAccess CRUD](../architecture/networks-service.md#privateresourceaccess-crud)
+- [Networks Service — Events Consumed](../architecture/networks-service.md#events-consumed)
+- [Resource Definitions — Private Resource Access](../architecture/resource-definitions.md#private-resource-access)
+- [Authorization — Networks Service](../architecture/authz.md#networks-service)
+- [Private Networks — Granting access](../product/private-networks/private-networks.md#granting-access)
+
+## Delta
+
+**A sandbox cannot be granted access to a private resource, and no principal type can express one.** `PrivateResourceAccess` accepts `agent`, `user`, `app`, and `group`. A sandbox workload matches none of them: it carries no `agent-<id>` attribute because there is no agent class behind it, and it cannot be a group member because groups collect users, agents, and apps. The engineer at a sandbox shell — the caller most likely to want an internal Postgres — is the one principal the access model has no way to name.
+
+`principal_type` gains `environment`. A grant to an environment resolves to every workload running it, agent workloads and sandboxes alike.
+
+**Nothing new is provisioned in OpenZiti.** The [Agents Orchestrator](../architecture/agents-orchestrator.md#workload-spec-assembly) already stamps `environment-<environmentId>` on every workload identity it creates, which is the attribute [egress rule attachments](../architecture/egress-rules-service.md) target for exactly this reason. The grant's Dial policy names `#environment-<id>` and the rest of the topology is unchanged — same per-resource service, same per-grant policy, same reconciliation, same ≤15s propagation. A workload already running picks the grant up on its next service-list poll; nothing restarts, because the attribute predates the policy.
+
+### Supporting changes
+
+**An environment is not an identity**, so the two per-principal steps that assume one need a branch. Existence and type validation go to `Agents.GetEnvironment` rather than `Identity.GetIdentityType` — the Networks service gains the [Agents](../architecture/agents-service.md) service as a dependency and `AGENTS_SERVICE_ADDRESS` as configuration. The cross-org guard is unchanged in shape: the [`environment` OpenFGA type](../architecture/authz.md#environment) carries `org` like every other principal, so the same `Check` covers it.
+
+**Authorization is `can_edit_config` on the environment**, matching what an [egress rule attachment](../architecture/egress-rules-service.md#authorization) to an environment already requires, and matching the `agent` principal's use of `can_edit_config` on the agent. Not `owner` on the organization: an environment grant is the same class of act as attaching a credential-injecting egress rule to that environment, and the platform already settled that at `can_edit_config`.
+
+The consequence is stated at every surface where someone can act on it: a grant to an environment reaches anyone holding `can_use` on it, because they can start a sandbox and a sandbox is a shell. It adds a destination to the set a shell there already reaches — the environment's secret-backed ENVs, its egress rules, its volumes — rather than widening who is standing in front of that set.
+
+## Acceptance Signal
+
+- An operator grants a private resource to an environment; a sandbox started in that environment dials the resource by its intercept hostname and connects.
+- An agent whose environment holds the grant dials the same resource, with no grant of its own.
+- A workload already running when the grant is created picks it up within ≤15s, without restarting.
+- Revoking the grant stops both within ≤15s and tears down in-flight connections.
+- `CreatePrivateResourceAccess` with an `environment` principal is refused for a caller holding `can_use` but not `can_edit_config` on that environment.
+- The same call is refused when the environment belongs to a different organization than the resource.
+- A grant naming an environment that does not exist is refused at create time.
+- `ListPrivateResourceAccess` filtered by `principal_type=environment, principal_id=<id>` returns the grant.
+- Deleting the environment leaves the grant behind and grants nothing: no workload can carry `environment-<deleted-id>`.
+
+## Notes
+
+- **Agent instances and individual sandboxes are deliberately out of scope.** Both are narrower than an environment and neither has a role attribute that outlives a workload — `workload-<id>` dies with the pod, so a grant against it would not survive a restart. Naming either as a principal needs a durable per-instance or per-sandbox attribute first, which is its own design.
+- **No cleanup event exists for a deleted environment.** The `group` principal has `agyn.groups.group.deleted`; [Agents](../architecture/agents-service.md) publishes no environment lifecycle event to mirror it, so a grant to a deleted environment is left in place. It is inert rather than dangerous — `environment-<id>` is stamped only on workloads running that environment, and [deletion is blocked](../architecture/resource-definitions.md#environment) while any agent or sandbox references it, so no identity can ever carry the attribute the orphaned policy names. Closing the hygiene gap wants an `agyn.agents.environment.deleted` event, not a per-pass existence check on every grant.
+- **Environments do not become group members.** A group collects identities; an environment is a configuration resource. Granting a group and granting an environment stay separate mechanisms.
+- **No Console work is specified here.** The access-list UI on the resource detail page needs an environment picker alongside the existing principal pickers; that is a Console change and is left to the [Console spec](../product/console/console.md).

--- a/product/private-networks/private-networks.md
+++ b/product/private-networks/private-networks.md
@@ -7,7 +7,7 @@ Private Networks let operators give agents access to resources inside their own 
 Three capabilities:
 
 - **Reach private hosts** — agents can dial `prod-postgres.internal.corp:5432`, `gitlab.lan:443`, or any other endpoint inside the operator's network without that endpoint being publicly routable.
-- **Per-principal access control** — each resource has an explicit access list. Agents, individual users (via their enrolled devices), and groups can be granted dial access; revocation is immediate.
+- **Per-principal access control** — each resource has an explicit access list. Agents, environments (which covers sandboxes), individual users (via their enrolled devices), and groups can be granted dial access; revocation is immediate.
 - **HA via multiple tunnels** — a Network can have multiple tunneler instances installed in different locations. OpenZiti load-balances and fails over between them transparently.
 
 The agent runs unmodified tools (`psql`, `curl`, `git`, language-specific HTTP clients). It connects to a hostname; the platform routes the connection through the tunneler to the real host.
@@ -17,6 +17,7 @@ The agent runs unmodified tools (`psql`, `curl`, `git`, language-specific HTTP c
 - As an operator, I want my agent to query an internal PostgreSQL inside my VPC without opening the database to the public internet or running a bastion.
 - As an operator, I want my agent to clone from a private GitLab on my office LAN by dialing its real hostname, with no special URL rewriting.
 - As an operator, I want to grant a team of analysts SSH access to internal hosts from their own machines, using their device identities, with permissions managed by group membership.
+- As an engineer at a sandbox shell, I want to reach the internal database my agents already reach, without an operator having to invent an agent for me to borrow.
 - As an operator, I want to run two tunneler instances in different availability zones of my VPC so a single host outage doesn't take down access.
 - As an operator, I want to revoke an agent's access to a private database the moment I detect anomalous behavior — without restarting the agent.
 
@@ -27,7 +28,7 @@ The agent runs unmodified tools (`psql`, `curl`, `git`, language-specific HTTP c
 | **Network** | A named container for a private network's resources and the tunneler instances that reach it. Networks are organization-scoped. A Network has no settings beyond a name and description — its purpose is to be the OpenZiti binding boundary and the unit of HA. |
 | **Tunnel credential** | An enrollment artifact issued by the platform for a single tunneler instance. The credential is a one-time-token JWT plus an install snippet for the supported tunneler distributions (Docker, Linux/macOS binary, Kubernetes helm chart). One Tunnel belongs to exactly one Network; a Network can have many Tunnels. |
 | **Private resource** | A single addressable endpoint behind the Network — a `target_host:target_ports` target the Tunnel forwards to, exposed to agents as a hostname they dial. A resource has a single protocol (`tcp`, `http`, or `https`). UDP is not supported in v1. |
-| **Access** | The list of principals (agents, users, apps, groups) authorized to dial a Private Resource. A user with access dials from their enrolled devices; an app dials via its own identity; a group with access grants every member transitively. |
+| **Access** | The list of principals (agents, environments, users, apps, groups) authorized to dial a Private Resource. A user with access dials from their enrolled devices; an app dials via its own identity; a group with access grants every member transitively; an environment grants every workload running it, including sandboxes. |
 | **Group** | An org-scoped named collection of identities (users, agents, apps). Granting access to a group is equivalent to granting to every member. See [Groups](../../architecture/groups-service.md). |
 
 ## How traffic flows
@@ -96,9 +97,14 @@ Access is managed on the resource detail page or via the resource's access list.
 | Principal | Effect |
 |---|---|
 | **Agent** | The agent's workloads can dial the resource |
+| **Environment** | Every workload running the environment can dial — agents pointed at it and [sandboxes](../sandboxes/sandboxes.md) started in it. The only way to give a sandbox access |
 | **User** | The user's enrolled devices can dial the resource. Useful for human-driven workflows — a dev's laptop can `psql` an internal DB through the same network |
 | **App** | The app dials the resource using its own OpenZiti identity. Useful for platform-installed apps that need direct access to a private service |
 | **Group** | Every group member (users, agents, apps) can dial. Membership changes propagate automatically |
+
+**Granting to an environment is a broader act than granting to an agent.** A sandbox is a shell, and anyone who may start one in that environment gets the resource with it — so the grant follows the environment's edit permission, the same one that governs its secrets and egress rules. Grant to the agent when one agent needs the resource; grant to the environment when the people and workloads *working in* that environment do.
+
+Granting to an individual agent instance or to one specific sandbox is not supported. Both are narrower than an environment, and neither survives a workload restart today.
 
 Revocation deletes the underlying OpenZiti dial policy immediately. In-flight connections that depended on the policy are torn down. **Propagation window** to live workloads / SDKs: ≤15 seconds (dominated by the SDK's service-list poll interval, the same propagation behavior the [Egress Gateway](../egress-gateway/egress-gateway.md#attaching-rules-to-agents) uses).
 
@@ -146,6 +152,7 @@ Resources are created, edited, and deleted by organization owners through the Co
 - For each port in `intercept_ports`, the tuple `(intercept_host, port)` must be unique across all resources in the organization. Operators namespace by hostname (`prod-postgres.corp:5432` vs `dev-postgres.corp:5432`).
 - A Tunnel belongs to one Network. Running one tunneler for two networks requires two separate tunneler installations.
 - Runners are not eligible group members and not eligible access principals — they are infrastructure, not actors in the access model.
+- Environments are not group members. A group collects identities; an environment is a configuration resource, and it is a principal here only because it is what an agent workload and a sandbox have in common.
 - A private resource conflict with an EgressRule on the same hostname surfaces as an OpenZiti Controller error at the second `CreateService` call — no friendly cross-primitive detection in v1.
 
 ## Related Architecture


### PR DESCRIPTION
A sandbox cannot be given access to a private resource, and **no principal type can express one**. `PrivateResourceAccess` takes `agent`, `user`, `app`, and `group`; a sandbox workload matches none of them — it carries no `agent-<id>` attribute because there is no agent class behind it, and it cannot be a group member because groups collect users, agents, and apps. The engineer at a sandbox shell, the caller most likely to want an internal Postgres, is the one principal the access model has no way to name.

`principal_type` gains `environment`. A grant resolves to every workload running that environment — agent workloads and sandboxes alike.

## Nothing new in OpenZiti

The Orchestrator already stamps `environment-<environmentId>` on every workload identity it creates, which is the attribute [egress rule attachments](https://github.com/agynio/architecture/blob/main/architecture/egress-rules-service.md) target for exactly this reason. The grant's Dial policy names it; the rest of the topology is unchanged — same per-resource service, same per-grant policy, same reconciliation, same ≤15s propagation. A workload already running picks the grant up on its next service-list poll without restarting, because the attribute predates the policy.

## Decisions worth reviewing

- **`can_edit_config` on the environment**, not `owner` on the organization. Attaching a credential-injecting egress rule to an environment already sits there and is the same class of act; it also matches how the `agent` principal uses `can_edit_config` on the agent.
- **Existence checks branch to `Agents.GetEnvironment`** — an environment is a configuration resource, not an identity, so it is not in the Identity registry. The cross-org guard needed no change: the `environment` OpenFGA type carries `org` like every other principal.
- **The escalation is stated, not designed around.** A grant reaches anyone holding `can_use`, because they can start a sandbox and a sandbox is a shell. It adds a destination to what a shell there already reaches — the environment's secret-backed ENVs, its egress rules, its volumes — rather than widening who is standing in front of that set.

## Deliberate gaps

- **Agent instances and individual sandboxes stay out of scope.** Both are narrower than an environment, and neither has a role attribute outliving a workload — `workload-<id>` dies with the pod, so a grant against it would not survive a restart.
- **No cleanup event for a deleted environment.** `group` has `agyn.groups.group.deleted`; Agents publishes no environment lifecycle event to mirror it. The orphaned grant is inert — `environment-<id>` is stamped only on workloads running that environment, and deletion is blocked while any agent or sandbox references it, so no identity can ever carry the attribute the policy names. Hygiene, not access; closing it wants the event, not a per-pass existence check on every grant.

Branched off `main`, independent of #177.