### PR TITLE
Extend can_manage_members to cluster admins

### DIFF
--- a/architecture/agent-init.md
+++ b/architecture/agent-init.md
@@ -67,14 +67,26 @@ All three init containers write into an `emptyDir` mounted at `/agyn`, which the
 /agyn/
 ├── bin/
 │   ├── agynd      # daemon binary            (agynd-cli-init)
+│   ├── tmux       # shell multiplexer        (agynd-cli-init)
 │   ├── agyn       # platform CLI binary      (agyn-cli-init)
 │   └── codex      # agent CLI binary         (agent runtime image)
+├── tmux.conf      # platform tmux config     (agynd-cli-init)
 └── config.json    # runtime config for agynd (agent runtime image)
 ```
 
-Init containers run in order and write disjoint paths, so the three images compose without coordination beyond the layout above. This is what allows each binary to ship in its own image. `agyn` and `agynd` are **reserved names** in `bin/`: an agent runtime image must not ship a binary called either.
+Init containers run in order and write disjoint paths, so the three images compose without coordination beyond the layout above. This is what allows each binary to ship in its own image. `agyn`, `agynd`, and `tmux` are **reserved names** in `bin/`: an agent runtime image must not ship a binary called any of them.
 
 `/agyn/bin` is the single `PATH` entry, and everything on it is a binary — configuration lives beside it at `/agyn`, not on `PATH`. The volume is a delivery surface written by init containers and read by the main container; it is not writable agent state, so no ownership fixing is required for non-root images.
+
+### tmux
+
+`tmux` backs [persistent shells](terminal-proxy.md#persistent-shells) and ships with `agynd` because `agynd` is what runs it — one image, one version pair, no skew between the binary and the process that starts the server.
+
+It is **statically linked against musl**, with the terminfo entries it needs compiled in. Both properties are requirements rather than preferences: a sandbox runs whatever image its environment names, and a distro build would fail on a musl base for its libc and on a slim base for `libtinfo`, while a glibc static build would fail `getpwuid` — which tmux calls to find the user's shell — because NSS cannot be linked statically. Compiled-in terminfo removes the last filesystem dependency, so the server starts in an image carrying no terminal database at all.
+
+Two things it still needs from the image, and neither is new: a shell for it to spawn, and a writable directory for its socket. The [Sandboxes App](../product/sandboxes/sandboxes-app.md#constraints) already states the first; `agynd` handles the second by placing the socket where the platform controls it rather than in the image's `/tmp`.
+
+Delivering it on `PATH` rather than beside the configuration is deliberate. It shadows any `tmux` the image ships, which is the point: a client and a server disagreeing on protocol version fail to connect, and an engineer running `tmux` inside a shell would otherwise meet that error with no way to interpret it. One binary means one version. The platform's own server is kept off the default socket regardless, so a personal `tmux` still gets its own server and its own configuration.
 
 The agent CLI binary keeps its original name — someone who execs into the container to debug sees the real one.
 
@@ -84,6 +96,7 @@ The agent CLI binary keeps its original name — someone who execs into the cont
 |---|---|
 | Agent subprocess | `agynd` prepends it when spawning |
 | Interactive session | The [Terminal Proxy](terminal-proxy.md#session-kinds) prepends it in the command it binds, expanded inside the container so the image's own `PATH` survives |
+| Persistent shell | The [tmux configuration](agynd-cli.md#shell-supervision) prepends it in the command the server spawns — the same construction, in the only place that reaches a shell the client did not start |
 | Platform-invoked process | Not at all — invoked by absolute path |
 
 ### config.json
@@ -194,7 +207,9 @@ sequenceDiagram
 Two workloads deviate from this sequence:
 
 - **A workspace-only environment** (no agent runtime image) runs the two platform init containers alone. No agent CLI and no `config.json` are present.
-- **A [sandbox](../product/sandboxes/sandboxes.md)** runs `agynd` as a long-lived holder, whether or not its environment names an agent runtime image. It fetches the environment-scoped configuration, prepares the agent CLI as far as the environment determines — its configuration file, its [first-run state](agynd-cli.md#agent-cli-first-run-state), any file placeholder — and runs the environment's [init scripts](resource-definitions.md#initscript), there being no agent and so no agent-scoped ones. Then it holds, spawning no agent CLI and running no inbox loop — preparing a CLI it will not spawn because a person will, by hand, and an unconfigured one stops to ask them a question. See [Preparation in Holder Mode](agynd-cli.md#preparation-in-holder-mode). Because nothing is spawned, nothing extends `PATH` from inside the container, and the binaries under `/agyn/bin` are reachable only by absolute path unless a session establishes `PATH` itself. Interactive sessions do: the [Terminal Proxy](terminal-proxy.md#session-kinds) prepends `/agyn/bin` to `$PATH` in the command it binds, expanded inside the container so the image's own `PATH` survives. That is what puts `agyn` and the environment's agent CLI on `PATH` for a person driving a sandbox by hand.
+- **A [sandbox](../product/sandboxes/sandboxes.md)** runs `agynd` as a long-lived holder, whether or not its environment names an agent runtime image. It fetches the environment-scoped configuration, prepares the agent CLI as far as the environment determines — its configuration file, its [first-run state](agynd-cli.md#agent-cli-first-run-state), any file placeholder — and runs the environment's [init scripts](resource-definitions.md#initscript), there being no agent and so no agent-scoped ones. Then it holds, spawning no agent CLI and running no inbox loop — preparing a CLI it will not spawn because a person will, by hand, and an unconfigured one stops to ask them a question. See [Preparation in Holder Mode](agynd-cli.md#preparation-in-holder-mode). What it does start is the [tmux server](agynd-cli.md#shell-supervision) that holds the sandbox's [persistent shells](terminal-proxy.md#persistent-shells), which is the one thing in a holder that must exist before anyone connects.
+
+No agent CLI being spawned, nothing extends `PATH` for the container at large, and `/agyn/bin` is reachable only by absolute path unless a session establishes `PATH` itself. Both kinds of session do, in the two places listed above, which is what puts `agyn` and the environment's agent CLI on `PATH` for a person driving a sandbox by hand.
 
 ## Environment Variable Contract
 

--- a/architecture/agents-orchestrator.md
+++ b/architecture/agents-orchestrator.md
@@ -295,6 +295,17 @@ The pull credential is revoked alongside the OpenZiti identity — both are per-
 
 `status=stopping` is set before the runner call so the console can show the workload as being stopped. `removed_at` is set after `StopWorkload` succeeds — it reflects the actual removal time. The metering sampling loop picks up the workload on its next tick (since `removed_at > last_metering_sampled_at`) and emits the tail sample. The workload record is retained for audit history.
 
+## Layout Snapshot Before Stop
+
+Stopping a **sandbox** workload has one extra step, taken before `StopWorkload` and after `status=stopping`: the orchestrator reads the working directory of every [shell](terminal-proxy.md#persistent-shells) in the container and writes them onto the sandbox's [layouts](resource-definitions.md#sandbox-layout) through `SetSandboxLayoutDirectories`.
+
+**Here, because nowhere else can be.** The value is only ever needed once the container is gone, and the last moment it can be read is the moment before it goes. A client cannot take it: a browser tab detaches by being closed, reloaded, or losing its network, and none of those give it a turn to act. And no client is necessarily present at all — an idle stop happens precisely because nothing has been attached for some time.
+
+The snapshot is **best-effort and never blocks the stop.** It is bounded by a short timeout, and a failure — an unreachable runner, a container already gone, a workload with no shells — is logged and the stop proceeds. A sandbox that lost its layout directories reopens its tabs where they were last recorded, or at the image's default; a sandbox that failed to stop because a bookkeeping read timed out would be a worse trade.
+
+Stops the platform did not initiate get no snapshot: an evicted pod, a node failure, or a crash leaves the previously recorded value. This is the reason the field is described as last *known* rather than last used.
+
+Agent workloads are skipped — they have no layout and no shells worth recording.
 
 ## Leader Election
 

--- a/architecture/agents-service.md
+++ b/architecture/agents-service.md
@@ -21,6 +21,7 @@ Defined in `agynio/api` at `proto/agynio/api/agents/v1/agents.proto`. Exposed ex
 | **Agents** | Agent class definitions: identity, model, [environment](resource-definitions.md#environment) reference, behavioral configuration, [availability](#availability). See [Agents vs. Agent Instances](#agents-vs-agent-instances) | ✓ |
 | **Environments** | Runtime definitions: runner reference + [flavor](resource-definitions.md#flavor) name + a workspace [image](resource-definitions.md#image) and optional agent runtime image, each with a tag. Referenced by agents and sandboxes; owner of the volumes, MCPs, init scripts, and ENVs a workload in it carries, and attachment target for egress rules. Create/update validates that the runner is visible to the organization and that each image reference resolves to a visible image of the required type with an existing tag; the flavor name is not validated — it is late-bound against the runner's [reported catalog](runners.md#runner-catalog) at workload start. Delete is rejected while any agent or sandbox references the environment. See [Flavors and Environments](../product/environments/environments.md) | ✓ |
 | **Sandboxes** | On-demand workloads started by users: name, environment reference, owner, status, idle timeout, TTL, and the identities the owner has shared it with. `CreateSandbox` accepts an `idle_timeout`, validated against the organization's `sandbox_max_idle_timeout` and falling back to its `sandbox_default_idle_timeout`; both the resolved value and the TTL are stored on the sandbox. Reconciled by the [Agents Orchestrator](agents-orchestrator.md). See [Sandboxes](../product/sandboxes/sandboxes.md) | Create, Get, List, Stop, Delete, Share, Unshare, ListShares |
+| **Sandbox Layouts** | Sub-resource of a sandbox, one per identity that has worked in it: the ordered set of tabs a client reopens to, each naming a [shell](terminal-proxy.md#persistent-shells) and its last known directory. See [Sandbox Layout](#sandbox-layout) | Get, Set |
 | **Agent Instances** | Instantiations of a class with their own state and [inbox](agent-instances.md#inbox). See [Agent Instances](agent-instances.md) | Create, Get, List, Pause, Resume, Delete |
 | **Inbox Items** | Sub-resource of an instance. Written by Threads (fan-out from `SendMessage`) or by apps (direct writes). Read and acked by `agynd`. See [Agent Instances — Inbox](agent-instances.md#inbox) | Write (apps), List (self), Ack (self) |
 | **Volumes** | Mount declarations: name, mount path, persistence, size, storage class, TTL. Belong to an environment or an MCP. A definition, not a disk — see [Resource Definitions — Volume](resource-definitions.md#volume) | ✓ |
@@ -175,11 +176,27 @@ Metering is unchanged: `FLAVOR_SECONDS` records stay attributed to the organizat
 
 Shares live on the sandbox, so they do not survive it. Deleting a sandbox and creating another starts with an empty share list.
 
+## Sandbox Layout
+
+The set of tabs a client reopens a sandbox to, stored per identity as a [Sandbox Layout](resource-definitions.md#sandbox-layout). Two methods, because it is one document:
+
+| Method | Description |
+|--------|-------------|
+| **GetSandboxLayout** | Returns the calling identity's layout for a sandbox, and its `version`. A sandbox never worked in returns an empty layout at version `0` rather than `NotFound` — no client needs to distinguish those |
+| **SetSandboxLayout** | Replaces the layout. Carries the `version` the caller read; a mismatch is `FailedPrecondition` and the caller refetches and reapplies. Returns the new version |
+
+**The service does not look in the container.** It stores what clients tell it and never asks whether a named shell exists — [attaching creates one that does not](terminal-proxy.md#persistent-shells), so a layout naming a shell the container lost is not an inconsistency to detect but the ordinary case after a restart. This is also why there is no listing method reaching the workload: nothing a client draws requires one.
+
+**Whole-document writes, guarded by a version.** Opening, closing, and reordering are the same write, and the fields this record is expected to grow arrive without a method each. The version is what makes two devices safe: the second writer is told to refetch rather than silently overwriting the first one's new tab.
+
+Layouts are deleted when their sandbox is purged, and when it transitions to `terminated` — a record retained for usage history has nothing left to reopen. A `stopped` sandbox keeps its layouts, which is the reason they live here rather than in the container.
+
 ## Internal API
 
 | Method | Description |
 |--------|-------------|
 | `ResolveAgentIdentity` | Resolves an OpenZiti platform `identity_id` to the corresponding `agent_id` and `organization_id` |
+| `SetSandboxLayoutDirectories` | Writes `cwd` onto the tabs of every layout of one sandbox, matching by `shell_id` and ignoring ids it does not find. Called by the [Orchestrator](agents-orchestrator.md#layout-snapshot-before-stop) immediately before a planned stop. Version-free — it touches one field the caller is the sole writer of, and failing a concurrent tab reorder would lose the snapshot for no benefit |
 
 This method derives agent and organization attribution from an authenticated OpenZiti connection identity. It is internal only — not exposed through the [Gateway](gateway.md).
 
@@ -210,6 +227,7 @@ The Agents service publishes events to the [Notifications](notifications.md) ser
 | `message.created` | `instance_inbox:{instance_id}` | A new [inbox item](agent-instances.md#inbox) is written for an instance (via `FanoutInboxItem` from Threads or `WriteInboxItem` from an app) |
 | `instance.updated` | `agent:{class_id}` | Instance state transitions (`active`, `paused`, `terminated`) or metadata changes on any instance of the class |
 | `sandbox.updated` | `sandbox_owner:{owner_id}`, `sandbox:{sandbox_id}`, and `sandbox_org:{organization_id}` | Sandbox lifecycle or bookkeeping changes: create, status transition, stop, delete/terminate, `last_session_at` update, share list change, or workload association update |
+| `sandbox_layout.updated` | `sandbox_layout:{identity_id}` | An identity's [layout](#sandbox-layout) changed for any sandbox — a tab opened, closed, renamed, reordered, or its directory snapshotted. Carries the sandbox id and the new version, not the document; a client holding that sandbox open refetches, and one that made the change recognizes its own version and does nothing |
 
 **Transitive `updated_at` propagation.** A successful write to a sub-resource bumps its owner's `updated_at` in the same transaction — an agent sub-resource bumps the agent, an environment sub-resource bumps the environment, and an MCP sub-resource bumps the MCP's own owner. Consumers that compare timestamps — for example, the [Agents Orchestrator's Start Decision](agents-orchestrator.md#start-decision), which compares the later of the agent's and its environment's `updated_at` against `failed_workload.removed_at` to decide whether a configuration change warrants a retry — therefore only need to read the two parent records. No traversal of sub-resources is required.
 
@@ -248,7 +266,9 @@ Agent and environment access is split into two layers: organization-level gates 
 | `StopSandbox`, `DeleteSandbox` | `can_stop` / `can_delete` on `sandbox:<id>` |
 | `EnsureSandboxRunning` | `can_connect` on `sandbox:<id>` |
 | `ShareSandbox`, `UnshareSandbox`, `ListSandboxShares` | `can_share` on `sandbox:<id>` — the owner only |
+| `GetSandboxLayout`, `SetSandboxLayout` | `can_connect` on `sandbox:<id>`. The layout addressed is always the caller's own — the identity comes from authenticated context and is not a parameter, so there is no request that reads or writes another person's tabs |
 | `UpdateSandboxLastSession` | Internal only (Terminal Proxy via Istio) |
+| `SetSandboxLayoutDirectories` | Internal only (Agents Orchestrator via Istio) |
 
 `SetAgentRole` rejects identities that are not members of the agent's organization. The check is performed against the `member` relation on the agent's org before the role tuple is written.
 

--- a/architecture/agyn-cli.md
+++ b/architecture/agyn-cli.md
@@ -404,7 +404,8 @@ Engineers use the `sandbox` command group to start on-demand workloads and attac
 | Command | Description |
 |---------|-------------|
 | `agyn sandbox start [--env NAME] [--name NAME] [--agent @HANDLE] [--sync PATH] [--idle-timeout DURATION]` | Create a sandbox running an [environment](resource-definitions.md#environment), wait for the workload, attach a shell. `--env` defaults to the organization's sole environment when exactly one exists. `--agent` resolves the agent's environment instead. `--name` is auto-generated when omitted. `--idle-timeout` sets how long the sandbox survives with nothing attached — see [Idle Timeout](#sandbox-idle-timeout). Prints a notice before attaching when the environment declares no persistent [volume](resource-definitions.md#volume) — nothing written in the shell will survive the workload stopping |
-| `agyn sandbox connect [NAME]` | Attach a shell to an existing sandbox. Calls `EnsureSandboxRunning` before requesting a terminal ticket: no-op when `running`, restart when `stopped`, fresh start attempt when `failed`. With no argument: connects when the caller owns exactly one non-terminated sandbox, otherwise lists candidates |
+| `agyn sandbox connect [NAME] [--new] [--tab ID]` | Attach to a [shell](terminal-proxy.md#persistent-shells) in an existing sandbox. Calls `EnsureSandboxRunning` before requesting a terminal ticket: no-op when `running`, restart when `stopped`, fresh start attempt when `failed`. With no argument: connects when the caller owns exactly one non-terminated sandbox, otherwise lists candidates. Returns to the caller's **most recently attached** shell, creating one when there are none; `--new` opens another, `--tab` names one |
+| `agyn sandbox tabs [NAME]` | List the caller's shells in a sandbox: name, number, directory, and whether something is attached. The same set the [Sandboxes App](../product/sandboxes/sandboxes-app.md) draws its tab strip from |
 | `agyn sandbox list [--all] [--terminated]` | List the caller's sandboxes. Terminated sandboxes are hidden unless `--terminated` is passed. `--all` lists every sandbox in the organization (org owners) |
 | `agyn sandbox stop [NAME]` | Stop the workload; keep the sandbox record and its persistent volumes. Warns first when the environment declares none |
 | `agyn sandbox delete [NAME]` | Terminate the sandbox and delete the volumes provisioned for it |
@@ -418,7 +419,13 @@ agyn sandbox cp brave-otter:/workspace/out.csv ./
 agyn sandbox cp -r ./src brave-otter:/workspace/src
 ```
 
-The shell session is a WebSocket to the Terminal Proxy, which routes to the hosting runner's `Exec` API (see [Runners — Terminal Proxy Integration](runners.md#terminal-proxy-integration)). A dropped connection ends the session, not the sandbox — `agyn sandbox connect` reattaches. `start` and `connect` require a TTY; the only non-interactive session the CLI opens is [workspace sync](#sandbox-sync-commands).
+The shell session is a WebSocket to the Terminal Proxy, which routes to the hosting runner's `Exec` API (see [Runners — Terminal Proxy Integration](runners.md#terminal-proxy-integration)). `start` and `connect` require a TTY; the only non-interactive session the CLI opens is [workspace sync](#sandbox-sync-commands).
+
+**A dropped connection ends the session, not the shell.** The PTY belongs to a process in the container, so `agyn sandbox connect` returns to the same shell with its processes still running and its screen repainted at the new terminal's size — the reconnect the [product](../product/sandboxes/sandboxes.md#shell-access) describes, rather than a fresh prompt. What does not survive is the workload: an idle stop takes every shell with it, and `connect` restarts the sandbox into recreated shells at the directories they were last recorded in.
+
+Shells are shared with the browser, both directions. A shell opened here is a tab in the [Sandboxes App](../product/sandboxes/sandboxes-app.md), and `connect` with no `--tab` returns to whichever shell was last attached from anywhere — which is usually the point. Attaching displaces whatever held it, so a browser tab left open on the same shell reports that it was taken over.
+
+The CLI writes the [layout](resource-definitions.md#sandbox-layout) as the app does. A shell opened from a terminal and never mentioned to the platform would be one the browser could not show.
 
 `agyn sandbox start --sync PATH` composes start, shell attach, and sync in one invocation.
 

--- a/architecture/agynd-cli.md
+++ b/architecture/agynd-cli.md
@@ -163,7 +163,7 @@ The model name pins a model for reproducibility. Unset — the common case, and 
 
 **Placeholder credentials split by kind**, and `agynd` writes one of the two. Agent CLIs refuse to start, or prompt interactively, with no credential present, so something has to be there — see [Placeholder Delivery](providers.md#placeholder-delivery).
 
-An **environment-variable** placeholder is not `agynd`'s to write. It must be on the container spec, injected by the [Agents Orchestrator](agents-orchestrator.md#workload-spec-assembly), because in a [sandbox](../product/sandboxes/sandboxes.md) the engineer's shell is started by the runner's `Exec` against the pod and inherits the container spec's environment, not anything PID 1 assembled. A variable set by `agynd` would be invisible to exactly the session that needs it.
+An **environment-variable** placeholder is not `agynd`'s to write. It must be on the container spec, injected by the [Agents Orchestrator](agents-orchestrator.md#workload-spec-assembly), because a [sandbox](../product/sandboxes/sandboxes.md) shell may reach the engineer by either of two routes and only the spec covers both: an ephemeral session is started by the runner's `Exec` against the pod and inherits the container spec, while a [persistent shell](terminal-proxy.md#persistent-shells) is spawned by the server `agynd` runs and inherits `agynd`'s own environment. A variable `agynd` assembled at runtime would be missing from exactly the session that arrives by the first route.
 
 A **file** placeholder is the opposite: `agynd` writes it, in both agent and holder mode, before the agent CLI is spawned or the container idles. It is not delivered — `agynd` derives it. The CLI it runs, read from [`config.json`](agent-init.md#configjson), is what determines the path and the contents both, so nothing has to be relayed and no other service holds a copy. The file lands on the container filesystem and stays there, so a session exec'd hours later finds it.
 
@@ -214,6 +214,41 @@ An agent CLI ends a turn with plain assistant text. No agent CLI protocol carrie
 When the class sets [`final_message`](resource-definitions.md#agent) to `default_thread`, `agynd` additionally posts that final text to the instance's [`default_thread_id`](agent-instances.md#default-thread), after the turn completes and before acking the turn's inbox items. The post is unconditional — `agynd` does not inspect whether the agent already sent something, which is why the default is `discard` for agents that manage their own sends. Nothing is posted when the final text is empty or the instance's default thread is NULL; `agynd` logs and continues to ack.
 
 `agynd` never derives a target from the turn's inbox items. An instance handling a sub-thread reply is frequently answering a *different* thread than the one that woke it — see [Agent Instances — Outbound](agent-instances.md#outbound).
+
+## Shell Supervision
+
+`agynd` owns the tmux server behind [persistent shells](terminal-proxy.md#persistent-shells). It starts the server at container startup — in holder mode and agent mode alike — on a platform-private socket, with the configuration [delivered beside it](agent-init.md#tmux):
+
+```sh
+/agyn/bin/tmux -L agyn -f /agyn/tmux.conf start-server
+```
+
+**Started by `agynd`, not by the first client, for two reasons.** A tmux server captures its environment from whoever starts it, and shells created hours apart must not differ by which client happened to arrive first. And a server already running is one less thing for an attach to do at the moment a person is waiting on it.
+
+`-L agyn` keeps the platform off the default socket. An engineer running `tmux` inside a shell gets their own server and their own `~/.tmux.conf`, rather than joining a server whose configuration is the platform's — tmux configuration is server-wide, so sharing one would silently discard theirs.
+
+### What the configuration must assert
+
+| Setting | Why |
+|---|---|
+| The command spawned for a new shell | `/bin/sh -lc 'PATH=/agyn/bin:$PATH exec ${SHELL:-sh}'` — the [`PATH` construction](agent-init.md#shared-volume-contract) belongs here because the shell is the server's child, not the bound command's. The login-profile ordering is the same and for the same reason |
+| The shell to spawn | Named explicitly rather than resolved from `getpwuid`. Kubernetes commonly runs a UID with no `/etc/passwd` entry, where the lookup fails and `HOME` may be unset |
+| No prefix key, no bindings | The multiplexer is platform machinery, not a UI. Every key belongs to the program in the shell, including an engineer's own nested `tmux` |
+| No status line | The client draws whatever it draws; a status bar is a row taken from the program for something no consumer reads |
+| Mouse reporting on | Wheel scrolling reaches tmux's scrollback, and mouse events still reach a program that asked for them |
+| One client per shell | The newest attachment drives the size and displaces the previous one, which is what the [Terminal Proxy](terminal-proxy.md#persistent-shells) presents as the attach semantics |
+| Clipboard passthrough | A selection made in the shell reaches the client's clipboard, since no window system is shared with it |
+| Scrollback limit | Bounded per shell. It is held in the container's memory and charged to the sandbox's flavor |
+
+The configuration is the platform's alone: a `~/.tmux.conf` is not sourced into it. The settings the model depends on are exactly the ones a personal configuration likes to change.
+
+### Environment
+
+Shells inherit **`agynd`'s** environment, because the server is `agynd`'s child. This differs from an ephemeral session, which inherits the container spec through `Runner.Exec`. Variables set on the container spec reach both — `agynd` is started from the same spec — so nothing the [Orchestrator](agents-orchestrator.md#workload-spec-assembly) injects is lost. What changes is that anything `agynd` assembles for itself is now visible to shells, and anything a session's own command sets reaches only that session's client.
+
+### Failure
+
+The server is a child of `agynd` and dies with the container, as every shell does. `agynd` does not restart shells or attempt to preserve them: a lost server means lost PTYs and lost processes, which is the same outcome as the workload stopping and is reported the same way. Losing the server without losing the container is not distinguished from either, and the next attach creates a shell rather than finding one.
 
 ## Agent Communication Protocol
 

--- a/architecture/authz.md
+++ b/architecture/authz.md
@@ -64,7 +64,7 @@ type organization
     define member: [identity]
     define owner: [identity]
     define can_invite: owner
-    define can_manage_members: owner
+    define can_manage_members: owner or admin from cluster
     define can_view_threads: owner or admin from cluster
     define can_view_workloads: owner or admin from cluster
     define can_view_volumes: owner or admin from cluster
@@ -300,7 +300,7 @@ Other types (agent, thread, organization, etc.) reference groups via `group#memb
 
 - `owner` implies `member`, `can_invite`, `can_manage_members`, `can_view_threads`, `can_view_workloads`, `can_view_volumes`, and `can_list_sandboxes`.
 - `can_create_sandbox` and `can_create_environment` follow `member`; every active organization member can create a sandbox and author an environment.
-- `can_add_member`, `can_view_threads`, `can_view_workloads`, `can_view_volumes`, and `can_list_sandboxes` each include `admin from cluster` — any identity with the `admin` relation on `cluster:global` holds these permissions on every organization. Modeled as cross-type computed relations, not as explicit per-organization tuples. Cluster-admin listing does not extend to terminal attach — `can_connect` is held only by a sandbox's `owner` and the identities that owner has shared it with.
+- `can_add_member`, `can_manage_members`, `can_view_threads`, `can_view_workloads`, `can_view_volumes`, and `can_list_sandboxes` each include `admin from cluster` — any identity with the `admin` relation on `cluster:global` holds these permissions on every organization. Modeled as cross-type computed relations, not as explicit per-organization tuples. Cluster-admin listing does not extend to terminal attach — `can_connect` is held only by a sandbox's `owner` and the identities that owner has shared it with.
 - `can_create_thread` is computed from `member` or `thread_create` — any org member can create threads, as can any app identity that has been granted the `thread:create` installation permission.
 
 See [Organizations — Members Management](organizations.md#members-management) for how these permissions govern membership operations.

--- a/architecture/notifications.md
+++ b/architecture/notifications.md
@@ -92,6 +92,7 @@ Rooms are scoped by resource type and ID:
 | `sandbox_owner:{owner_id}` | `sandbox_owner:550e8400-...` | Agents → `sandbox.updated` events for a sandbox owner's own list/detail views |
 | `sandbox:{sandbox_id}` | `sandbox:3f2b1a8c-...` | Agents → `sandbox.updated` events for one sandbox, subscribed by clients displaying a sandbox shared with the caller |
 | `sandbox_org:{organization_id}` | `sandbox_org:9f8e7d6c-...` | Agents → `sandbox.updated` events for organization-owner list-all views |
+| `sandbox_layout:{identity_id}` | `sandbox_layout:550e8400-...` | Agents → `sandbox_layout.updated` events for one identity's [tab sets](resource-definitions.md#sandbox-layout), across every sandbox they work in |
 | `trace:{trace_id}` | `trace:5b8efff7-...` | Tracing → span created/updated events for a trace |
 | `organization:{id}` | `organization:9f8e7d6c-...` | EgressRules → `egress_rule.updated` / `egress_rule_attachment.updated` events |
 
@@ -108,7 +109,7 @@ For identity-scoped rooms, the literal string `me` is reserved as the id segment
 
 The Notifications service rewrites `:me` to the caller's `identity_id` on receipt, before authorization. Authorization rules are unchanged — the rewritten room passes the existing `id == caller.identity_id` check by construction.
 
-`:me` lets a client subscribe to its own room without first resolving its `identity_id` through another channel. It applies only to self-addressed identity rooms (`thread_participant:`, `instance_inbox:`). `sandbox_owner:{owner_id}` is also identity-keyed, but callers subscribe with the concrete owner id because it is a UI room pattern for sandbox lists, not a self-subscription sentinel target. For `workload:`, `agent:`, `sandbox:`, `sandbox_org:`, and `trace:` the id segment is a resource id and `:me` has no meaning.
+`:me` lets a client subscribe to its own room without first resolving its `identity_id` through another channel. It applies only to self-addressed identity rooms (`thread_participant:`, `instance_inbox:`). `sandbox_owner:{owner_id}` and `sandbox_layout:{identity_id}` are also identity-keyed, but callers subscribe with the concrete id because they are UI room patterns held by an app that has already resolved who it is signed in as, not self-subscription sentinel targets. For `workload:`, `agent:`, `sandbox:`, `sandbox_org:`, and `trace:` the id segment is a resource id and `:me` has no meaning.
 
 Identity ids are UUIDs, so the literal `me` cannot collide with any real id.
 
@@ -143,6 +144,7 @@ External `Subscribe` (through the Gateway) requires an authenticated caller. Roo
 | `sandbox_owner:{owner_id}` | `owner_id == caller.identity_id` (identity equality — only the sandbox owner subscribes to their own live sandbox list/detail room). `:me` is not accepted for this room pattern. |
 | `sandbox:{sandbox_id}` | `can_read` on `sandbox:<sandbox_id>`. Resource-keyed rather than identity-keyed, so it reaches the identities a sandbox owner has shared with — the owner room cannot, being keyed by an owner id that is not theirs. |
 | `sandbox_org:{organization_id}` | `can_list_sandboxes` on `organization:<organization_id>` (organization owners only; backs list-all sandbox views). |
+| `sandbox_layout:{identity_id}` | `identity_id == caller.identity_id`. A [layout](resource-definitions.md#sandbox-layout) is only ever the caller's own, so the room is keyed by who it belongs to rather than by which sandbox it is for — one subscription follows a person across every sandbox they have open, which is what the room is for: the same person's other device. `:me` is not accepted, as for `sandbox_owner:`. |
 | `trace:{trace_id}` | `member` on `organization:<trace.org_id>` (org resolved from stored span data) |
 | `organization:{id}` | `member` on `organization:<id>` (used by the [Egress Gateway](egress-gateway.md) to receive `egress_rule.updated` / `egress_rule_attachment.updated` events published by the [EgressRules service](egress-rules-service.md); the gateway subscribes per org for which it has cached rules) |
 
@@ -164,7 +166,7 @@ Unlike the other flat rooms these carry every organization's lifecycle, so they 
 
 A caller presenting `identity_type == platform` is a platform service watching what it operates rather than a principal acting through one — the [Orchestrator](agents-orchestrator.md) reconciling instances and sandboxes across every organization. The type alone admits nothing: it is settled by `admin` on `cluster:global`, the tuple [Identity](identity-service.md) writes for the one configured platform identity and that nothing can request. A caller that sets the header without holding the relation is refused exactly as any other.
 
-A verified platform caller may hold the **operational** rooms — the two cluster-wide rooms above, plus `agent_instance:`, `agent:`, `sandbox:`, `sandbox_org:`, `workload:` and `volume:` — and no others. The **identity-keyed** rooms stay closed to it: `instance_inbox:`, `thread_participant:` and `sandbox_owner:` belong to a principal, and the platform places and reaps workloads rather than reading what they exchange. A platform caller naming one of those falls through to the ordinary check, which denies it.
+A verified platform caller may hold the **operational** rooms — the two cluster-wide rooms above, plus `agent_instance:`, `agent:`, `sandbox:`, `sandbox_org:`, `workload:` and `volume:` — and no others. The **identity-keyed** rooms stay closed to it: `instance_inbox:`, `thread_participant:`, `sandbox_owner:` and `sandbox_layout:` belong to a principal, and the platform places and reaps workloads rather than reading what they exchange. A platform caller naming one of those falls through to the ordinary check, which denies it.
 
 This exists because there was no way for a platform service to say what it was. The Orchestrator instead borrowed an agent instance's `identity_id` to pass checks written for that instance — which worked for the instance's own rooms and could never work for `sandbox_org:`, since an instance is a `member` of its organization and that room wants `can_list_sandboxes`.
 

--- a/architecture/organizations.md
+++ b/architecture/organizations.md
@@ -124,9 +124,9 @@ Who can do what is governed by the [authorization model](authz.md):
 | **Create membership (invite)** | `can_invite` on the organization | Organization owners (via `owner` implies `can_invite`) | Creates membership with `status: pending`. No OpenFGA tuple until accepted |
 | **Accept membership** | Target identity matches the caller | The invited identity itself | Transitions `pending` → `active`. Writes OpenFGA tuple |
 | **Decline membership** | Target identity matches the caller | The invited identity itself | Deletes the `pending` membership |
-| **Remove member** | `can_manage_members` on the organization | Organization owners (via `owner` implies `can_manage_members`) | Deletes the membership (any status). Deletes OpenFGA tuple if `active` |
-| **Update member role** | `can_manage_members` on the organization | Organization owners (via `owner` implies `can_manage_members`) | Updates the role. If `active`, deletes old OpenFGA tuple and writes new one |
-| **List members** | `can_manage_members` on the organization | Organization owners | Returns memberships for the organization |
+| **Remove member** | `can_manage_members` on the organization | Organization owners and cluster admins | Deletes the membership (any status). Deletes OpenFGA tuple if `active` |
+| **Update member role** | `can_manage_members` on the organization | Organization owners and cluster admins | Updates the role. If `active`, deletes old OpenFGA tuple and writes new one |
+| **List members** | `can_manage_members` on the organization | Organization owners and cluster admins | Returns memberships for the organization |
 | **List my memberships** | Caller is the identity | Any identity | Returns the caller's own memberships across all organizations |
 | **Update sandbox settings** | `owner` on the organization | Organization owners | Validates and stores new default sandbox TTL/idle-timeout values for future sandbox creation |
 

--- a/architecture/resource-definitions.md
+++ b/architecture/resource-definitions.md
@@ -211,6 +211,37 @@ A sandbox carries no share list as a field. Collaborators are OpenFGA tuples on 
 
 ---
 
+## Sandbox Layout
+
+One identity's set of open [shells](terminal-proxy.md#persistent-shells) in one [Sandbox](#sandbox) — what a client reopens to find its work where it left it. Managed by the [Agents](agents-service.md#sandbox-layout) service.
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `sandbox_id` | string (UUID) | | The sandbox this layout describes. Half of the key |
+| `identity_id` | string (UUID) | | Whose layout it is. The other half |
+| `version` | int64 | `0` | Incremented on every write. A writer supplies the version it read and is rejected with `FailedPrecondition` if it no longer matches — see [Agents Service — Sandbox Layout](agents-service.md#sandbox-layout) |
+| `tabs` | list | `[]` | Ordered. Position in the list is the display order |
+
+Each entry in `tabs`:
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `shell_id` | string | | Opaque, client-generated, `^[A-Za-z0-9_-]{1,64}$`. Passed verbatim to [`SHELL_ATTACH`](terminal-proxy.md#persistent-shells) |
+| `number` | int32 | | Assigned when the tab is opened and never reused within the layout. The last-resort display name, so that closing one tab does not rename the others |
+| `name_override` | string \| null | `null` | A name the user gave this tab. Null means the client derives one — the title the shell announces, else its directory. The derived name is never stored: it goes stale the moment the shell changes directory |
+| `cwd` | string \| null | `null` | Last known working directory, absolute. Supplied to `SHELL_ATTACH` and applied only when the shell has to be created. Written by the [Orchestrator](agents-orchestrator.md#layout-snapshot-before-stop) before a planned stop, which is the only moment the value is about to be needed and the last moment it can be read |
+| `last_attached_at` | timestamp \| null | `null` | When a session last attached. Orders "the one I was just in" for [`agyn sandbox connect`](agyn-cli.md#sandbox-commands) |
+
+**Keyed by identity, not by sandbox alone.** A collaborator opening a shared sandbox arrives at their own tabs rather than joining the owner's. This is presentation, not isolation: every shell in a container is visible from inside it to anyone who can open one there, and this record only decides what a client draws. See [Terminal Proxy — Authorization](terminal-proxy.md#authorization).
+
+**A document with a version rather than a row per tab.** Reordering, closing, and opening are all one write, and the fields this is expected to grow — split geometry, sizes, which tab had focus — arrive without a method each. Two devices editing concurrently is the case the version exists for; the loser refetches and reapplies.
+
+**The layout is not a record of what was running.** A stopped sandbox loses its processes. What comes back is the same tabs, named the same, in the same directories, holding new shells — see [Sandboxes App — Sandbox](../product/sandboxes/sandboxes-app.md#sandbox).
+
+Layouts are deleted with their sandbox. A sandbox that merely `stopped` keeps them, which is the whole reason they are stored outside the container; a `terminated` one drops them, the record being retained for usage history rather than for anything anyone will reopen.
+
+---
+
 ## Volume
 
 A disk mounted into a container. Each volume belongs to exactly one target — an [Environment](#environment) or an [MCP](#mcp) — identified by the corresponding foreign key. There is no free-standing volume resource and no attachment relationship: a volume is declared where it is mounted.

--- a/architecture/sandboxes-app.md
+++ b/architecture/sandboxes-app.md
@@ -50,7 +50,8 @@ The selected organization persists in local storage, as in the Console.
 | `AgentsGateway` | `ShareSandbox`, `UnshareSandbox`, `ListSandboxShares` | `can_share` on the sandbox — the owner |
 | `AgentsGateway` | `ListEnvironments`, `GetEnvironment` (metadata) | `member` on the organization. The response's `can_use` field drives the environment picker — see [Agents Service — Environment Metadata](agents-service.md#environment-metadata) |
 | `RunnersGateway` | `ListVolumes` filtered to `owner_kind=sandbox` | `can_view_volumes` on the organization — organization owners only. The app degrades without it and does not require it |
-| `TerminalGateway` | `CreateTerminalSession` (`kind: SHELL`) | `can_connect` on the sandbox, checked in the [Terminal Proxy](terminal-proxy.md#authorization) at ticket issuance |
+| `AgentsGateway` | `GetSandboxLayout`, `SetSandboxLayout` | `can_connect` on the sandbox. Always the caller's own layout — see [Agents Service — Sandbox Layout](agents-service.md#sandbox-layout) |
+| `TerminalGateway` | `CreateTerminalSession` (`kind: SHELL_ATTACH`) | `can_connect` on the sandbox, checked in the [Terminal Proxy](terminal-proxy.md#authorization) at ticket issuance |
 | `ExposeGateway` | `ListExposures`, `AddExposure`, `RemoveExposure` — all passing the sandbox's `workload_id` explicitly | `can_connect` on the sandbox for add and remove; `member` on the organization for list. See [Expose Service — Authorization](expose-service.md#authorization) |
 | `OrganizationsGateway` | `ListMyMemberships` | Any authenticated user — populates the organization switcher |
 | `UsersGateway` | `GetMe`, `SearchUsers` | Any authenticated user. `SearchUsers` backs the share picker |
@@ -60,9 +61,17 @@ The app calls no method that requires organization ownership. A member with no e
 
 ## Terminal
 
-The terminal follows the standard two-step establishment: `CreateTerminalSession(workload_id, container_name, kind: SHELL)` over the Gateway returns a ticket, then a WebSocket to the Terminal Proxy carrying the ticket and a handshake with the initial terminal size. Long-lived credentials never appear in the WebSocket URL. Rendering is xterm.js over the [wire protocol](terminal-proxy.md#wire-protocol); resize is forwarded on every pane resize.
+Each tab follows the standard two-step establishment: `CreateTerminalSession(workload_id, container_name, kind: SHELL_ATTACH, shell_id, cwd)` over the Gateway returns a ticket, then a WebSocket to the Terminal Proxy carrying the ticket and a handshake with the initial size and the app's `TERM`. Long-lived credentials never appear in the WebSocket URL. Rendering is xterm.js over the [wire protocol](terminal-proxy.md#wire-protocol); resize is forwarded on every pane resize.
 
 The `workload_id` comes from the sandbox record. A sandbox in any state other than `running` has no workload to attach to, so the detail page calls `EnsureSandboxRunning` first and attaches once the sandbox reports `running`.
+
+**The tab strip is drawn from the [layout](resource-definitions.md#sandbox-layout), not from the container.** `GetSandboxLayout` on mount gives the tabs, their order, and each one's last known directory; `SetSandboxLayout` writes back on open, close, rename, and reorder, carrying the version it read. Because [attaching creates a shell that does not exist](terminal-proxy.md#persistent-shells), the app never asks whether one is live — a tab whose shell the sandbox lost simply opens.
+
+**Nothing the strip displays requires a call into the container.** A tab's name comes from the title its shell announces, which xterm.js already parses out of the byte stream it is rendering; failing that, from the stored directory; failing that, from the tab's number. Directories are written by the [Orchestrator](agents-orchestrator.md#layout-snapshot-before-stop) before a stop, not polled by the app.
+
+**Attaching displaces whatever held the shell**, including this app on another device. A tab whose session ends with `reason: displaced` says so and offers to take it back, rather than reconnecting into a fight with the other device.
+
+Every open tab holds its own session, so a background tab keeps rendering and keeps its scrollback. It no longer has to: a detached shell survives, so a client could attach only what is visible. Keeping them attached is what makes a background tab's output live, and the cost is one WebSocket per tab rather than the loss of the shell it used to be.
 
 ## Ports
 
@@ -82,8 +91,11 @@ The app subscribes to [Notifications](notifications.md) rooms over a `Notificati
 |------|-------|---------|
 | `sandbox_owner:{caller_identity_id}` | Sandboxes list | `sandbox.updated` for the caller's own sandboxes |
 | `sandbox:{sandbox_id}` | Sandbox detail; one per shared sandbox on the list | `sandbox.updated` for a single sandbox, reaching collaborators as well as the owner |
+| `sandbox_layout:{caller_identity_id}` | Sandbox detail | `sandbox_layout.updated` — a tab opened, closed, renamed, or reordered by this person somewhere else |
 
 The owner room covers a member's own list in one subscription. Collaborated sandboxes are not covered by it — it is keyed by owner identity — so the app subscribes per shared sandbox. It follows the [Consumer Sync Protocol](notifications.md#consumer-sync-protocol): subscribe, buffer, fetch through `ListSandboxes`/`GetSandbox`, then apply. On reconnect it refetches the current view.
+
+The layout room is what makes a second device converge: it is keyed by the caller rather than by the sandbox, because a layout is only ever their own. The event carries a version, so the client that made the change recognizes its own write and refetches nothing.
 
 Status changes therefore surface whatever their cause — the idle timeout stopping a workload, the CLI starting one, a collaborator stopping a shared sandbox.
 

--- a/architecture/terminal-proxy.md
+++ b/architecture/terminal-proxy.md
@@ -41,7 +41,7 @@ sequenceDiagram
     TP->>TP: OpenFGA check (see Authorization)
     TP->>TP: Resolve kind to a command; validate the kind's parameters
     TP-->>C: { ticket, url }
-    C->>TP: WebSocket connect (ticket) + handshake {cols, rows}
+    C->>TP: WebSocket connect (ticket) + handshake {cols, rows, term}
     TP->>RS: GetWorkload → runner_id
     TP->>R: OpenZiti Dial runner-{runnerId} → Exec (tty, resize)
     R->>K: allocate PTY, spawn shell
@@ -49,7 +49,7 @@ sequenceDiagram
 ```
 
 1. **`CreateTerminalSession`** (Gateway RPC): the caller requests a session for `(workload_id, container_name, kind)`. The Gateway checks the request is well-formed, resolves the caller's identity from authenticated context, and forwards to the Terminal Proxy's internal `IssueTicket`. Everything that follows from the kind — the authorization check, resolving the kind to a command, validating that kind's parameters — happens in the proxy, which owns terminal sessions; the Gateway routes and does not interpret. `IssueTicket` returns a **ticket**: single-use, bound to the caller's identity and the target, expiring in 30 seconds. Long-lived auth tokens never appear in WebSocket URLs (same reasoning as the [Media Proxy](media-proxy.md)'s avoidance of tokens in `GET` URLs).
-2. **WebSocket connect**: the client opens the WebSocket with the ticket, sends a JSON handshake carrying **only the initial terminal size**, and the proxy resolves the hosting runner via `Runners.GetWorkload`, dials it over OpenZiti (`runner-{runnerId}` — see [Runners — Terminal Proxy Integration](runners.md#terminal-proxy-integration)), and opens `Runner.Exec` with TTY enabled.
+2. **WebSocket connect**: the client opens the WebSocket with the ticket, sends a JSON handshake carrying **only what describes its own terminal** — the initial size and its `TERM` — and the proxy resolves the hosting runner via `Runners.GetWorkload`, dials it over OpenZiti (`runner-{runnerId}` — see [Runners — Terminal Proxy Integration](runners.md#terminal-proxy-integration)), and opens `Runner.Exec` with TTY enabled.
 
 The command is fixed at ticket issuance, never at attach time. It is derived from the requested [session kind](#session-kinds) and bound into the ticket by the proxy. The WebSocket handshake carries no command — a client cannot escalate beyond what the ticket was issued for.
 
@@ -59,17 +59,43 @@ The command is fixed at ticket issuance, never at attach time. It is derived fro
 
 | Kind | TTY | Command | Consumer |
 |---|---|---|---|
-| `SHELL` | yes | `/bin/sh -lc 'PATH=/agyn/bin:$PATH exec ${SHELL:-sh}'` — see [PATH](#path-in-a-session) | `agyn sandbox start`/`connect`, Console terminal |
+| `SHELL` | yes | `/bin/sh -lc 'PATH=/agyn/bin:$PATH exec ${SHELL:-sh}'` — see [PATH](#path-in-a-session) | Console terminal on an agent container |
+| `SHELL_ATTACH` | yes | `/agyn/bin/tmux -L agyn -f /agyn/tmux.conf new -A -D -s <shell_id> [-c <cwd>]` — see [Persistent Shells](#persistent-shells) | `agyn sandbox start`/`connect`, [Sandboxes App](sandboxes-app.md) |
 | `EXEC` | yes | A caller-supplied command, run with the same `PATH` prefix | Console non-shell inspection commands |
 | `SYNC` | no | `/agyn/bin/agyn sandbox sync serve --root <path>` | [Workspace sync](sandbox-sync.md), `agyn sandbox cp` |
 
 `SESSION_KIND_UNSPECIFIED` is rejected with `InvalidArgument`. It does not default to `SHELL` — silently defaulting the field that selects a command is how an unintended command ends up in a ticket.
 
-Authorization does not vary by kind: `EXEC` carries a caller-supplied command but is authorized by the same check as `SHELL` (see [Authorization](#authorization)). What binding the command at issuance buys is not an extra permission gate but immutability — the command cannot be swapped at attach time.
+`SHELL` and `SHELL_ATTACH` are separate kinds rather than one kind with a flag, so that the command remains a function of the kind and its parameters, and a client cannot get one behavior while the ticket describes the other. Which one a consumer asks for follows what the container is for: inspecting an **agent** container is ephemeral, because the [Orchestrator](agents-orchestrator.md) may stop that workload mid-session and nothing in it is worth preserving; working in a **sandbox** is persistent.
+
+Authorization does not vary by kind: `EXEC` carries a caller-supplied command, and `SHELL_ATTACH` names a shell another identity may have created, but both are authorized by the same check as `SHELL` (see [Authorization](#authorization)). What binding the command at issuance buys is not an extra permission gate but immutability — the command cannot be swapped at attach time.
+
+In particular, **a shell id is not a capability**. Anyone authorized to open a shell in a container can enumerate and attach to every shell in it from inside that container, as they can already read its files and signal its processes. Keeping one identity's shells out of another's view is a presentation decision made by whoever stores the [layout](resource-definitions.md#sandbox-layout), not a boundary this service enforces.
+
+### Persistent Shells
+
+A **shell** is a PTY and its processes living in the container, outliving every connection to it. It is not a session: a session attaches to a shell and ends, and the shell stays. Shells are implemented as tmux sessions on a platform-private socket, started by the server [`agynd` runs](agynd-cli.md#shell-supervision); nothing above the container depends on that, which is what keeps it replaceable.
+
+`SHELL_ATTACH` takes two parameters:
+
+| Parameter | Required | Validation | Purpose |
+|---|---|---|---|
+| `shell_id` | yes | `^[A-Za-z0-9_-]{1,64}$` | Names the shell. Client-generated and opaque. `.` and `:` are excluded because tmux reads them as target separators |
+| `cwd` | no | Absolute, lexically normalized, no `..` — as [`SYNC`'s root](#root-validation) | Working directory, applied **only when the shell is created**. Ignored on attach, so a client may pass its stored value every time |
+
+The command attaches when the shell exists and creates it when it does not. That single behavior is what makes reconnecting and restoring the same path: a shell whose container was replaced comes back at the requested directory without the client knowing which case it was in.
+
+**A second session displaces the first.** One shell carries one attachment. This is what makes a page reload robust — the reloading client does not wait for its predecessor's missed pongs to be noticed — and it removes the question of whose size a shared PTY takes, since there are never two. The displaced session receives `exit` with `reason: displaced` so the client can say what happened rather than going quiet.
+
+**A shell ends when its process does.** `exit` at the prompt destroys the tmux session; the attached session sees `reason: completed`. Nothing lingers to be reattached to, and the consumer holding a tab removes it.
+
+Shells are as durable as the container. A stopped workload — idle timeout, explicit stop, eviction — takes every shell in it, and nothing checkpoints a running process. What survives a stop is the [Sandbox Layout](resource-definitions.md#sandbox-layout), which is why what follows a restart is described as recreation.
+
+The scrollback a shell retains is held in the container's own memory and counts against the sandbox's flavor. The platform configuration bounds it per shell; ten shells at the configured limit are tens of megabytes, which is the reason it is bounded rather than a reason to worry about it.
 
 ### PATH in a session
 
-The platform's binaries are delivered to `/agyn/bin` by the [binary init containers](agent-init.md), but nothing puts them on `PATH` for a session: `PATH` is extended only by `agynd` when it spawns the agent subprocess, and a sandbox does not run `agynd`. Sessions establish it themselves.
+The platform's binaries are delivered to `/agyn/bin` by the [binary init containers](agent-init.md), but nothing puts them on `PATH` for a session: `PATH` is extended only by `agynd` when it spawns the agent subprocess, and a sandbox does not run an agent. Sessions establish it themselves.
 
 **`SYNC` sidesteps the problem** by using an absolute path, which is what a machine-invoked command should do regardless.
 
@@ -84,6 +110,8 @@ The bound command therefore runs the profile first and prepends afterwards:
 The outer `sh -l` processes `/etc/profile` and the user's profile; `$PATH` is then whatever that left, and the platform entry goes in front of it. Setting `PATH` through the pod spec is not an alternative — Kubernetes `env` replaces the image's value rather than extending it, and the orchestrator cannot know what the image configured.
 
 The consequence to be aware of: the final shell is **not** a login shell, so shell-specific login files (`~/.bash_profile`) do not run, while `/etc/profile` and `~/.profile` already have. Making the final shell a login shell would re-run the profile and discard the prefix again.
+
+**`SHELL_ATTACH` establishes it in the same way but not in the same place.** Its bound command is a tmux *client*; the shell was spawned by the server, and setting `PATH` around the client would never reach it. The identical construction therefore lives in the platform's tmux configuration as the command the server spawns for a new shell — see [agynd — Shell Supervision](agynd-cli.md#shell-supervision). Placing it there also fixes it for shells the server creates while nobody is attached.
 
 ### Root validation
 
@@ -102,6 +130,15 @@ Tickets are **self-contained signed tokens** (key shared across proxy replicas),
 
 ## Wire Protocol
 
+The first client message is a JSON **handshake** describing the client's own terminal:
+
+| Field | Required | Default | Description |
+|---|---|---|---|
+| `cols`, `rows` | yes | | Initial size. Applied to the PTY before the command runs |
+| `term` | no | `xterm-256color` | The client's `TERM`. Set in the exec's environment |
+
+`term` exists because a session's command may itself be a terminal-aware program rather than a shell: a [`SHELL_ATTACH`](#persistent-shells) client decides what it may emit toward the browser or the terminal from this value, and reading it from the pod spec — where nothing sets it per client — gives a truecolor terminal the capabilities of whatever the image happened to declare. It carries no command and grants nothing; a client describing itself wrongly only misrenders its own output.
+
 One WebSocket per session. Frames:
 
 | Frame | Direction | TTY kinds | Non-TTY kinds (`SYNC`) |
@@ -109,7 +146,7 @@ One WebSocket per session. Frames:
 | Binary | client → proxy | Raw input bytes for the PTY (keystrokes, pastes, escape sequences) | Raw stdin bytes — no prefix |
 | Binary | proxy → client | Raw PTY output bytes — **no prefix** | **One-byte stream prefix** (`0x00` stdout, `0x01` stderr) followed by the payload |
 | Text (JSON) | client → proxy | Control: `{"type":"resize","cols":N,"rows":N}` | Not used |
-| Text (JSON) | proxy → client | Control: `{"type":"exit","code":N,"reason":"completed\|cancelled\|error"}` — final message before close | Same |
+| Text (JSON) | proxy → client | Control: `{"type":"exit","code":N,"reason":"completed\|cancelled\|displaced\|error"}` — final message before close | Same |
 | Ping/Pong | both | Liveness, every 30s; a peer missing two intervals is considered gone | Same |
 
 The proxy never interprets the *payload*, so one wire protocol serves every session kind — TTY kinds carry PTY bytes, `SYNC` carries the endpoint protocol. The one thing that differs is stream framing on the proxy→client direction.
@@ -120,15 +157,17 @@ The proxy never interprets the *payload*, so one wire protocol serves every sess
 
 For TTY session kinds, the proxy provides SSH-parity terminal behavior. Explicit guarantees:
 
-- **8-bit clean, zero interpretation.** The data path carries raw bytes. No line buffering, no encoding validation or transformation, no filtering of escape sequences. Colors (16/256/truecolor), alternate screen, cursor addressing, mouse reporting, bracketed paste — anything the container-side program emits and the client-side terminal understands passes through untouched. Full-screen TUIs (`vim`, `htop`, `tmux`) work.
+- **8-bit clean, zero interpretation — in the transport.** The data path carries raw bytes. No line buffering, no encoding validation or transformation, no filtering of escape sequences. Colors (16/256/truecolor), alternate screen, cursor addressing, mouse reporting, bracketed paste — anything reaching the proxy passes through untouched. Full-screen TUIs (`vim`, `htop`, `tmux`) work. What a [persistent shell](#persistent-shells) *hands* the transport is another matter: a multiplexer holds the PTY, and it forwards what it understands. That is the price of repainting a screen correctly on attach, and it is paid inside the container rather than anywhere on this path. `SHELL` and `EXEC` remain end-to-end uninterpreted.
 - **A real PTY.** The runner allocates a PTY in the container (Kubernetes `pods/exec` with `tty: true`); the shell runs as a proper foreground process group. Job control, signals-as-bytes (`Ctrl-C` → `^C` → SIGINT via the line discipline), `isatty()` — all behave as on a local terminal.
 - **Resize propagation.** The handshake carries the initial size; `resize` control messages are forwarded to the PTY (the k8s exec resize channel), delivering SIGWINCH to the foreground process. The CLI sends one on every SIGWINCH; the Console on every pane resize.
 - **No session caps.** Terminal sessions have no wall timeout, no idle timeout, and no output size limit at the exec level (`Runner.Exec` timeouts are disabled for terminal sessions). Session lifetime is bounded only by workload lifetime and explicit policy (a sandbox's own idle timeout counts *detached* time — an attached session keeps it alive indefinitely).
 - **Backpressure, not truncation.** Flow control is end-to-end: WebSocket and gRPC stream backpressure propagate to the PTY, which blocks the writer — output is never dropped or truncated by the proxy.
-- **Concurrent sessions.** Multiple sessions may target the same container (subject to the same authorization); each gets its own PTY, like multiple SSH connections to one host.
+- **Concurrent sessions.** Multiple sessions may target the same container (subject to the same authorization); each gets its own PTY, like multiple SSH connections to one host. Two sessions naming the *same* [shell](#persistent-shells) are the exception — there is one PTY to have, and the newer session takes it.
 - **Exit propagation.** When the shell exits, the proxy sends the `exit` control message and closes. The `agyn` CLI exits with the same code.
 
-What is deliberately *not* provided: session persistence across disconnects. A dropped WebSocket ends the exec — the PTY closes and the foreground process group receives SIGHUP, exactly like a dropped SSH connection. The container (and anything backgrounded with `nohup`/`setsid`, or running under `tmux`/`screen` from the image) keeps running; `agyn sandbox connect` opens a fresh shell. Server-side session multiplexing is a client-image concern (`tmux`), not a platform feature.
+**A dropped connection does not end the work, but only where a shell owns it.** For [`SHELL_ATTACH`](#persistent-shells) the exec ends and the shell does not: the PTY belongs to a process in the container, and the next session attaches to the same one, at the client's size, with the screen repainted. For `SHELL`, `EXEC`, and every consumer inspecting an agent container, the old behavior stands — the PTY closes, the foreground process group receives SIGHUP, and the next connection is a fresh shell, exactly like a dropped SSH connection.
+
+Neither kind survives the workload. A stopped sandbox takes its shells with it, and nothing checkpoints a running process; what survives is the [Sandbox Layout](resource-definitions.md#sandbox-layout), which is a record of what was open and where, not of what was running.
 
 ## CLI Behavior (`agyn sandbox start` / `connect`)
 

--- a/changes/2026-08-11-persistent-sandbox-shells.md
+++ b/changes/2026-08-11-persistent-sandbox-shells.md
@@ -1,0 +1,100 @@
+# Persistent Sandbox Shells
+
+## Target
+
+- [Terminal Proxy — Session Kinds](../architecture/terminal-proxy.md#session-kinds)
+- [Terminal Proxy — Terminal Semantics](../architecture/terminal-proxy.md#terminal-semantics)
+- [Terminal Proxy — Wire Protocol](../architecture/terminal-proxy.md#wire-protocol)
+- [Agent Init — Shared Volume Contract](../architecture/agent-init.md#shared-volume-contract)
+- [agynd-cli — Shell Supervision](../architecture/agynd-cli.md#shell-supervision)
+- [Resource Definitions — Sandbox Layout](../architecture/resource-definitions.md#sandbox-layout)
+- [Agents Service — Sandbox Layout](../architecture/agents-service.md#sandbox-layout)
+- [Agents Orchestrator — Layout Snapshot Before Stop](../architecture/agents-orchestrator.md#layout-snapshot-before-stop)
+- [Notifications — Room Naming Convention](../architecture/notifications.md#room-naming-convention)
+- [Sandboxes App](../architecture/sandboxes-app.md)
+- [agyn-cli — Sandbox Commands](../architecture/agyn-cli.md#sandbox-commands)
+- [Sandboxes — Shell Access](../product/sandboxes/sandboxes.md#shell-access)
+- [Sandboxes App — Sandbox](../product/sandboxes/sandboxes-app.md#sandbox)
+
+## Delta
+
+**A shell lives and dies with the connection that opened it.** A dropped WebSocket ends the exec, the PTY closes, and the foreground process group receives SIGHUP. Reloading the Sandboxes app page discards every open tab; opening the sandbox on a second device shows none of them. The corpus states this as deliberate — server-side multiplexing was left to the image as a `tmux` concern.
+
+It is the wrong side of the trade for the workload whose entire purpose is a person working inside it. [Sandboxes](../product/sandboxes/sandboxes.md#user-stories) already promises reconnecting "without losing running processes or files", and today that holds only for files and for work the engineer thought to background by hand.
+
+This change makes a shell an object in the sandbox that outlives any connection to it, and makes the set of open shells state the platform stores rather than state a browser tab holds.
+
+### Vocabulary
+
+Three words that are currently one:
+
+| Term | Meaning |
+|---|---|
+| **Shell** | The persistent thing — a PTY and its processes, living in the sandbox's main container, surviving every disconnect until the workload stops |
+| **Terminal session** | The transport, unchanged: one ticket, one WebSocket, one `Runner.Exec`. A session **attaches to** a shell rather than being one |
+| **Tab** | The Sandboxes app's presentation of a shell. UI vocabulary — the CLI has no tabs |
+
+### tmux is the engine, not the interface
+
+Shells are tmux sessions. A statically linked `tmux` ships with `agynd` in the [agynd-cli-init](../architecture/agent-init.md) image and lands on the shared volume; `agynd` starts the server at container boot on a platform-private socket with a platform-supplied configuration.
+
+The platform's surface does not expose tmux. Clients name a shell by an opaque id through an ordinary [session kind](../architecture/terminal-proxy.md#session-kinds); the proxy binds a command that resolves to attach-or-create. Nothing above the container knows what implements a shell, which is what keeps the engine replaceable.
+
+Building the multiplexer instead was considered and rejected. The only part that is genuinely hard is repainting a screen on attach — a raw byte replay cannot reconstruct a full-screen program, because a session in progress emits deltas against a base that has scrolled out of any buffer. Doing it correctly means maintaining a terminal emulator, which is the one part of tmux worth having and the one part expensive to own.
+
+The cost accepted in exchange: **the byte stream is no longer uninterpreted.** [Terminal Semantics](../architecture/terminal-proxy.md#terminal-semantics) promised that anything the container emits and the client understands passes through untouched. tmux parses and re-emits, so what survives is what tmux knows. In practice this is invisible to the browser terminal, whose renderer is a narrower target than tmux's output; it is visible to a local terminal with capabilities tmux does not forward, and it is stated where the guarantee used to be.
+
+### Two kinds, because two behaviors
+
+`SHELL` keeps today's meaning and today's command: spawn a shell, and end it with the connection. A new `SHELL_ATTACH` binds the attach-or-create command and takes the shell id, plus an optional working directory used only when the shell is created.
+
+Which one a consumer uses follows what the container is for. Inspecting an **agent** container stays ephemeral — the orchestrator may stop that workload mid-session and nothing there is worth preserving. Working in a **sandbox** is persistent, from the app and from the CLI both.
+
+Attaching a second session to a live shell **displaces the first**. One shell has one attachment, which is what makes a page reload robust: the reloading client does not wait for its predecessor to be reaped, and no size negotiation between clients is needed because there are never two. The displaced client is told why it ended.
+
+### The set of open shells is platform state
+
+The tab list is a **layout document** stored by the Agents service, keyed by `(sandbox, identity)` and carrying a version for concurrent writers. It holds which tabs exist, their order, an optional name override, and each tab's last known working directory.
+
+The container is not asked what shells exist. A tab is opened by attaching to its id, and attach-or-create means a tab whose tmux session is gone — because the sandbox restarted — simply comes back. Reconnecting and restoring are one path, not two.
+
+Keyed by identity rather than by sandbox: a collaborator opening a shared sandbox gets their own tabs rather than joining the owner's. This is a presentation boundary and not a security one — anyone who can open a shell in the container can see every tmux session in it, as they can already read every file and signal every process.
+
+**Working directories are captured before a planned stop.** A browser cannot be relied on at detach — a reload, a closed lid, and a dropped network all end the connection without giving the client a chance to write anything — and the value is only needed once the container is gone. So the [Orchestrator](../architecture/agents-orchestrator.md) snapshots the shells' directories into the layout immediately before it stops a workload, which covers idle timeout and explicit stop. A stop the platform did not initiate leaves the last captured value, and a tab opens where it last was rather than where it last looked.
+
+### Restoring is honest about what it restores
+
+A sandbox that stopped lost its processes. Tabs come back named and in the directory they were left in; they are **fresh shells**, and the app says so rather than presenting them as the ones that were there. This is the feature's own failure mode: persistence invites the belief that a build survives the night, and the idle timeout means it does not.
+
+### Consequences that are not optional
+
+**`PATH` moves into the tmux configuration.** The prefix is established today by the command the proxy binds, because that command *is* the shell. Under `SHELL_ATTACH` the bound command is a tmux client and the shell was spawned by the server, so the prefix has to be set where the server spawns shells. The same construction applies — the login profile runs first and `/agyn/bin` goes in front of what it left — only in a different place.
+
+**Shells inherit `agynd`'s environment, not the exec's.** [agynd-cli](../architecture/agynd-cli.md#native-mode-configuration) reasons that an environment-variable placeholder must be on the container spec because a sandbox shell comes from `Runner.Exec` and inherits the spec rather than anything PID 1 assembled. The conclusion survives — a container-spec variable reaches `agynd` too — but the reason no longer describes what happens, and is corrected.
+
+**The handshake carries `TERM`.** [The wire protocol](../architecture/terminal-proxy.md#wire-protocol) sends only the initial size, which was sufficient when the container's shell inherited whatever the pod spec had. A tmux client uses the attached terminal's `TERM` to decide what it may emit, truecolor included, so the client's value has to reach it. The field is optional and defaults to `xterm-256color`.
+
+### CLI
+
+`agyn sandbox connect` attaches to the caller's most recently attached shell and creates one when there are none, so a terminal and a browser reach the same work. `--new` opens another, `--tab` names one, and `agyn sandbox tabs` lists them. The CLI writes the layout document as the app does; a shell opened from a terminal is a tab in the browser.
+
+## Acceptance Signal
+
+- An engineer runs a build in a browser tab, reloads the page, and finds the same shell with the build still running.
+- The same sandbox opened on a second device shows the same tabs; attaching to one displaces the first device, which says so rather than going silent.
+- A full-screen program — `vim`, `htop` — is correct on reattach without a keystroke, at the new client's size.
+- A shell opened with `agyn sandbox connect --new` appears as a tab in the browser, and a tab opened in the browser is what `agyn sandbox connect` returns to.
+- A sandbox left to idle out and started again presents the same tabs, in the same order, in the directories they were left in, marked as fresh shells.
+- Closing a tab ends its shell; `exit` inside a shell closes its tab.
+- `agyn` and the environment's agent CLI are on `PATH` in a persistent shell, in an image whose `/etc/profile` sets `PATH` unconditionally.
+- A terminal in an agent container behaves exactly as before and leaves nothing behind when it closes.
+- A collaborator opening a shared sandbox starts with their own empty tab list, and the owner's tabs are unaffected by anything they do.
+
+## Notes
+
+- **No splits.** A tab is one shell is one tmux session with one window. Panes are the obvious way to grow into layout later and the model extends to them without breaking, but nothing here exposes them.
+- **Two attachments to one shell** — genuine pairing, both parties watching the same screen — is not introduced. Displacement was chosen precisely to avoid negotiating one PTY size between clients, and reversing that is a deliberate later decision rather than a configuration change.
+- **Shells do not survive the workload.** Nothing checkpoints a process; a stopped sandbox loses everything running in it. The layout is what survives, which is why restoring is described as recreation.
+- **No client-facing shell listing.** The layout answers what tabs exist and the byte stream answers what each is called, so nothing the app draws requires asking the container. The one consumer that must — the Orchestrator, taking the directory snapshot — reaches the container over an internal path.
+- **The Console's sandbox terminal is undecided here.** [Terminal Proxy](../architecture/terminal-proxy.md) names a terminal on the Console's Sandbox Detail page while [Sandboxes App](../product/sandboxes/sandboxes-app.md) states the Console deliberately has none. Pre-existing drift, untouched by this change; whichever way it resolves, persistence follows the sandbox rather than the client.
+- **Idle timeout defaults are unchanged.** Raising them to protect long-running work is an organization policy question and belongs with the people who set the ceiling, not with this change.

--- a/product/sandboxes/sandboxes-app.md
+++ b/product/sandboxes/sandboxes-app.md
@@ -21,6 +21,9 @@ Two facts make it a separate app rather than a Console section. Any organization
 - As an engineer, I want to hand a colleague a shell in the sandbox I am debugging, without giving them anything else.
 - As an engineer, I want a sandbox someone shared with me to appear in my list, so I do not depend on them sending me a link.
 - As a sandbox owner, I want to see exactly what sharing gives away before I share.
+- As an engineer, I want to reload the page without losing the shells I have open, so refreshing is not a decision I have to weigh.
+- As an engineer, I want to open my sandbox on another machine and find the work I left running, so moving between a laptop and a desk costs nothing.
+- As an engineer, I want to know that letting my sandbox go idle ends what is running in my shells, before it happens rather than after.
 - As an engineer, I want to come back to a stopped sandbox and start it again from the same page.
 - As an engineer, I want to open the dev server running in my sandbox in a browser tab, without leaving the page or typing a command in the shell.
 - As an engineer, I want to see which ports this sandbox is serving and at what address, so I do not have to remember what I exposed.
@@ -88,15 +91,23 @@ Status, environment, both clocks, and a terminal filling the rest of the page.
 
 **Terminal** — a real PTY with no platform-imposed limits: colors through truecolor, alternate screen, mouse reporting, full-screen TUIs, resize, working signals, and the shell's exit code reported on exit. It fills the page below the header, because it is what the page is for. See [Sandboxes — Shell Access](sandboxes.md#shell-access).
 
-**Tabs** — several shells in one sandbox, as any terminal emulator gives you: a tab strip above the terminal with a new-shell action, and a close action once more than one is open. Each tab is an independent session, so a background tab keeps running and keeps its scrollback — the [wire protocol](../../architecture/terminal-proxy.md#wire-protocol) has no resume, and a tab that was torn down on leaving it would come back a different shell. Closing a tab ends that session, exactly as closing the page ends them all.
+**Tabs** — several shells in one sandbox, as any terminal emulator gives you: a tab strip above the terminal with a new-shell action, and a close action once more than one is open. Each tab is an independent shell, and a background tab keeps running and keeps its scrollback.
 
-A tab is named by what its shell announces — the title it sets, or failing that the directory it reports — and falls back to the number it opened with. That number is fixed at open and never reused: renumbering by position would rename the shells that were kept when one is closed.
+**Tabs come back.** Reload the page, close the laptop, open the sandbox on another machine — the same tabs are there, in the same order, with the same work still running in them. The shells belong to the sandbox rather than to the page, so nothing on screen was something the browser was holding for you. Closing a tab is what ends a shell, and typing `exit` in one closes its tab.
+
+A tab is named by what its shell announces — the title it sets, or failing that the directory it reports — and falls back to the number it opened with. That number is fixed at open and never reused: renumbering by position would rename the shells that were kept when one is closed. A tab can also be given a name, which then sticks.
 
 Tabs are reordered by dragging, and with `Alt`+`←`/`→` for anyone not using a mouse.
 
-While a session is attached the sandbox cannot idle out. Closing the tab ends that session — like dropping an SSH connection, the foreground process group is signalled and the container keeps running. Work that must outlive a tab belongs under `tmux` or `nohup` from the image.
+**A shell is in one place at a time.** Opening the sandbox on a second device moves each shell there, and the first device says so and offers to take it back. This is what makes reconnecting immediate rather than a wait for the previous connection to be given up on, and it is why a shell always fits the screen actually looking at it.
+
+**Shells in this sandbox are yours.** A [collaborator](#sharing) opening it starts with their own empty strip rather than joining your tabs. Neither of you is hidden from the other — anyone with a shell here can find every shell here from inside the container — but the two of you are not sharing a screen unless you set out to.
+
+While a session is attached the sandbox cannot idle out; the clock runs on time with nothing attached, whether or not shells are still open.
 
 **Stopped, starting, or failed** — the terminal area is replaced by the state and a **Start** action. Starting is a no-op when already running, a restart when stopped, and a fresh attempt when failed; the terminal appears once the workload runs. A `failed` sandbox stays failed until someone acts — nothing retries it in the background, because nothing needs a sandbox to run while nobody is connecting.
+
+**A sandbox that stopped comes back with its tabs and without its work.** Shells live in the container, so an idle timeout takes everything running in them. Starting the sandbox again restores the same tabs, named the same, in the directories they were left in — holding new shells, and saying so rather than letting someone assume otherwise. The **Stops in** countdown sits beside the tab strip for the same reason: once tabs persist, that clock is the thing deciding whether tomorrow's tabs still have anything running in them, and it should not have to be looked for.
 
 **Actions** — Stop, Share, Delete. Stopping a sandbox whose environment declares no persistent volume warns that everything in it is discarded. Deleting warns that the sandbox's disks go with it.
 
@@ -161,6 +172,8 @@ Organization owners are not collaborators by default. They can see and terminate
 - A compact list mode for users who accumulate many sandboxes; cards trade scanning density for a bigger primary action, which is the right trade at a handful and the wrong one at thirty.
 - Organization policy on who may be shared with — confining shares to identities that already hold `can_use` on the environment.
 - Sharing that reaches into live sessions on revocation.
+- Two people attached to one shell at once — a shared screen for pairing, rather than the second attachment taking the first one's place.
+- Splits within a tab, once there is a reason to describe a layout richer than an ordered list of shells.
 - Live updates for the ports strip, once the Expose service publishes change events.
 - Re-exposing the ports a sandbox had before it idled out, so a restart restores what was serving rather than an empty list.
 

--- a/product/sandboxes/sandboxes.md
+++ b/product/sandboxes/sandboxes.md
@@ -9,7 +9,7 @@ The primary use case is running agents in "manual mode": an engineer gets the sa
 ```bash
 agyn sandbox start                 # start a sandbox, drop into a shell
 # ... laptop sleeps, wifi drops ...
-agyn sandbox connect brave-otter   # reattach to the same sandbox
+agyn sandbox connect brave-otter   # back in the same shell, build still running
 
 agyn sandbox sync                  # keep the working directory and /workspace in step
 ```
@@ -33,7 +33,8 @@ agyn sandbox sync                  # keep the working directory and /workspace i
 | Term | Definition |
 |---|---|
 | **Sandbox** | An org-scoped resource owned by the user who created it: one workload running an [environment](../environments/environments.md), started on demand rather than by inbox traffic. Its storage is whatever the environment declares. |
-| **Shell session** | An interactive terminal attached to the sandbox's main container. A sandbox can have zero or more concurrent sessions; the workload keeps running between sessions. |
+| **Shell** | A command line living in the sandbox's main container, with whatever is running in it. It outlives the connections that reach it: closing a laptop, reloading a page, or connecting from somewhere else does not end it. A sandbox can have several. |
+| **Session** | One connection to one shell, from a terminal or a browser tab. Sessions come and go; the shell stays until it is closed or the sandbox stops. |
 | **Sync session** | A continuous two-way reconciliation between a directory on the engineer's machine and a directory in the sandbox. Runs in the background on the engineer's machine, independent of any shell session. |
 
 ## CLI
@@ -43,7 +44,8 @@ Sandboxes are managed through a new `agyn sandbox` command group:
 | Command | Description |
 |---|---|
 | `agyn sandbox start [--env NAME] [--name NAME] [--sync PATH] [--idle-timeout DURATION]` | Create a sandbox, wait for the workload to run, attach a shell. `--env` selects the environment; defaults to the organization's sole environment when exactly one exists, otherwise required. `--name` sets the sandbox name; auto-generated (`adjective-noun`) when omitted. `--idle-timeout` overrides how long the sandbox survives unattended — see [Choosing an idle timeout](#choosing-an-idle-timeout) |
-| `agyn sandbox connect [NAME]` | Attach a shell to an existing sandbox. Calls `EnsureSandboxRunning` first: a no-op when `running`, a restart when `stopped`, a fresh start attempt when `failed` — the shell attaches only once the workload is running. With no argument: connects when the caller owns exactly one non-terminated sandbox, otherwise lists candidates |
+| `agyn sandbox connect [NAME] [--new] [--tab ID]` | Return to a shell in an existing sandbox — the one you were last in, or a new one with `--new`. Calls `EnsureSandboxRunning` first: a no-op when `running`, a restart when `stopped`, a fresh start attempt when `failed` — the shell attaches only once the workload is running. With no argument: connects when the caller owns exactly one non-terminated sandbox, otherwise lists candidates |
+| `agyn sandbox tabs [NAME]` | List your shells in a sandbox — what they are called, where they are, and whether something is attached. The same list the browser shows as tabs |
 | `agyn sandbox list [--all] [--terminated]` | List the caller's sandboxes: name, environment, status, age, last session, idle timeout, remaining TTL. Terminated sandboxes are hidden unless `--terminated` is passed; `failed` ones are shown (they are actionable). `--all` lists every sandbox in the organization (owners) |
 | `agyn sandbox stop [NAME]` | Stop the workload; keep the sandbox record and its persistent volumes. Warns first when the environment declares none — stopping discards everything |
 | `agyn sandbox delete [NAME]` | Terminate the sandbox and delete the volumes provisioned for it |
@@ -121,13 +123,21 @@ Two sandboxes in the same environment never share storage — same layout, separ
 
 The experience is SSH-parity — a real PTY with no platform-imposed limitations:
 
-- Raw, 8-bit-clean byte stream: no line buffering, no filtering. Colors (through truecolor), alternate screen, mouse reporting, and full-screen TUIs (`vim`, `htop`, `tmux`) work.
+- Colors (through truecolor), alternate screen, mouse reporting, and full-screen TUIs (`vim`, `htop`, `tmux`) work. What holds the shell open between connections sits in the byte path and forwards what it understands, so a local terminal with capabilities beyond that — inline images, say — loses them where a plain `Exec` would not. This is the price of a screen that comes back correct after a disconnect.
 - Terminal resize propagates (SIGWINCH), signals behave normally (`Ctrl-C`, job control), `isatty()` is true.
 - No session wall timeout, idle timeout, or output cap. An attached session keeps the sandbox alive indefinitely; the sandbox `idle_timeout` counts only detached time.
-- Multiple concurrent sessions per sandbox are allowed, each with its own PTY — several from the owner, or the owner and a [collaborator](#sharing) working side by side.
+- Multiple shells per sandbox, each with its own PTY — several from the owner, or the owner and a [collaborator](#sharing) working side by side.
 - The shell's exit code becomes the CLI's exit code.
 
-A dropped connection ends the session but not the sandbox — like a dropped SSH connection, the foreground process group gets SIGHUP while the container keeps running. Anything that must survive a session drop should run under `nohup`/`tmux` (from the image); `agyn sandbox connect` opens a fresh shell. See [Terminal Proxy — Terminal Semantics](../../architecture/terminal-proxy.md#terminal-semantics).
+### Shells survive disconnection
+
+**A dropped connection does not end your work.** The shell and everything running in it belong to the sandbox, not to the connection: a closed laptop, a dropped network, a reloaded browser page, or a switch to another machine leaves it running, and reconnecting returns to it — same processes, same scrollback, redrawn at whatever size the new terminal is. `nohup` is no longer the price of leaving.
+
+**One connection at a time.** Attaching from somewhere else takes the shell over, and the connection that had it says so rather than going quiet. This is deliberate: it is what makes reconnecting immediate instead of waiting for the last connection to be given up on, and it means a shell always fits the screen actually looking at it.
+
+**The sandbox stopping still ends everything.** Shells live in the container, so an [idle timeout](#lifecycle) or an explicit stop takes them and their processes with them — nothing is frozen and thawed. What comes back when the sandbox starts again is the same set of shells, with the same names, in the same directories, empty of what was running. A four-hour build survives a train journey; it does not survive a night, unless the idle timeout says it should.
+
+See [Terminal Proxy — Persistent Shells](../../architecture/terminal-proxy.md#persistent-shells).
 
 ## Workspace Sync
 


### PR DESCRIPTION
Documents agynio/authorization#40: can_manage_members is now owner or admin from cluster, so member listing, removal and role updates are available to cluster admins on every organization.