### PR TITLE
A conversation can be deleted

### DIFF
--- a/architecture/authz.md
+++ b/architecture/authz.md
@@ -526,6 +526,8 @@ Chat wraps Threads. Thread-level authorization checks apply, including the per-a
 |-----------|-------|
 | `CreateChat` | `can_create_thread` on `organization:<org_id>` AND for each agent participant: `can_initiate` on `agent:<participant_id>` |
 | `GetChats` | No OpenFGA check — returns chats where caller is a participant (DB filter) |
+| `UpdateChat` | Caller must be a thread participant |
+| `DeleteChat` | `participant` on `thread:<id>` or `owner` on `organization:<thread.org_id>` — delegated to Threads `ArchiveThread` |
 | `GetMessages` | `can_read` on `thread:<id>` |
 | `SendMessage` | `can_write` on `thread:<id>` |
 | `MarkAsRead` | Self only — caller must be a participant |

--- a/architecture/chat.md
+++ b/architecture/chat.md
@@ -11,7 +11,9 @@ Threads is a generic messaging service. Chat adds the application-level logic sp
 | Method | Description |
 |--------|-------------|
 | **CreateChat** | Create a new chat thread between users (and optionally agents) |
-| **GetChats** | List chats for a user with pagination. Each chat carries an [`activity_status`](#activity-status), an [`unread_count`](#unread-counts), and the chat's [`active_workload_ids`](#active-workload-ids) for the caller |
+| **GetChats** | List chats for a user with pagination. Each chat carries an [`activity_status`](#activity-status), an [`unread_count`](#unread-counts), and the chat's [`active_workload_ids`](#active-workload-ids) for the caller. Excludes [deleted chats](#deleting-a-chat) |
+| **UpdateChat** | Update a chat's status (`open` / `closed`) or summary |
+| **DeleteChat** | Delete a chat. See [Deleting a Chat](#deleting-a-chat) |
 | **GetMessages** | List messages in a chat with pagination. Response includes the chat's [`unread_count`](#unread-counts) for the caller |
 | **SendMessage** | Send a message in a chat |
 | **MarkAsRead** | Mark all messages up to the latest in a chat as read for the caller (calls Threads `AckMessages`). See [Marking Messages as Read](#marking-messages-as-read) for trigger semantics |
@@ -53,6 +55,29 @@ The chat-app calls `MarkAsRead` on these triggers:
 | User leaves the conversation view | No further calls — incoming messages on other threads accumulate normally and bump their unread counts |
 
 `SendMessage` does not auto-ack the sender's own messages — Threads excludes the sender from the recipient list when creating `MessageRecipient` rows, so the sender has nothing to ack on their own outgoing message.
+
+## Deleting a Chat
+
+`DeleteChat` removes a chat from the app for every participant. It is a soft delete: the messages stay in [Threads](threads.md) so runs, traces, and metering records that reference them remain resolvable.
+
+Two things happen, in this order:
+
+1. `Threads.ArchiveThread(thread_id)` — the thread moves to [`archived`](threads.md#thread-status) and stops accepting new messages.
+2. Chat marks its own chat record deleted.
+
+The order is load-bearing. If the second step fails, the chat is still listed but frozen, and a retry closes the gap. The reverse order would leave a chat that is hidden from its participants while agents keep writing into it.
+
+`DeleteChat` is idempotent — deleting an already-deleted chat archives an already-archived thread and reports success, so a client retrying after a timeout does not see a failure for work that landed.
+
+A deleted chat is excluded from `GetChats`, and `UpdateChat` and `GetMessages` resolve it as `NOT_FOUND`. `SendMessage` is refused by Threads because the thread is archived.
+
+`GetMessages` is what tells a client holding a stale link that the conversation is gone — the chat-app opens a conversation by asking Chat for the unread count and Threads for the transcript, and the `NOT_FOUND` on the first call is the signal to drop the selection.
+
+That signal is not an access boundary. The messages stay in Threads, and a participant that asks `Threads.GetMessages` directly still gets them — which is the path the chat-app itself uses to page a transcript. The Console likewise still finds the thread through `Threads.ListOrganizationThreads` with `status_in = [archived]`. Deletion removes the conversation from the app; it does not revoke read access to what was said.
+
+Deletion does not stop agent workloads. A workload that is running when the chat is deleted keeps running until it idles out, and any message it tries to send fails with the thread-archived error — the reply is dropped, which is the intended outcome for a conversation the user removed.
+
+Chat publishes no notification on deletion. Other participants' clients drop the chat on their next `GetChats` refresh.
 
 ## Activity Status
 
@@ -133,6 +158,8 @@ Chat delegates authorization to [Threads](threads.md) for all messaging operatio
 |-----------|-------|
 | `CreateChat` | `can_create_thread` on `organization:<org_id>` AND for each agent participant: `can_initiate` on `agent:<participant_id>` (enforced by [Threads](threads.md#agent-availability-check)) |
 | `GetChats` | No OpenFGA check — returns chats where caller is a participant (DB filter) |
+| `UpdateChat` | Caller must be a thread participant |
+| `DeleteChat` | `participant` on `thread:<id>` or `owner` on `organization:<org_id>` (enforced by [Threads](threads.md) `ArchiveThread`) |
 | `GetMessages` | `can_read` on `thread:<id>` |
 | `SendMessage` | `can_write` on `thread:<id>` |
 | `MarkAsRead` | Self only — caller must be a thread participant |

--- a/changes/2026-08-13-chat-deletion.md
+++ b/changes/2026-08-13-chat-deletion.md
@@ -1,0 +1,46 @@
+# Deleting a Conversation
+
+## Target
+
+- [Chat — Deleting a Conversation](../product/chat/chat.md#deleting-a-conversation)
+- [Chat — Header](../product/chat/chat.md#header)
+- [Chat — Deleting a Chat](../architecture/chat.md#deleting-a-chat)
+- [Chat — Interface](../architecture/chat.md#interface)
+- [Chat — Authorization](../architecture/chat.md#authorization)
+- [Authorization — Chat Service](../architecture/authz.md#chat-service)
+
+## Delta
+
+**A conversation, once created, is permanent.** Every mistaken `+`, every one-line question to an agent, every abandoned draft that got a message sent into it stays in the list forever. The only lever is Resolved, which is a lifecycle state, not a disposal — the conversation reappears the moment the filter is set to All. The list only grows.
+
+The conversation actions menu gains **Delete conversation**, and Chat gains the `DeleteChat` RPC behind it.
+
+The pieces to build:
+
+- `DeleteChat` on Chat and on `ChatGateway`. It archives the thread, then marks the chat record deleted — in that order, so a half-failure leaves a visible-but-frozen chat rather than a hidden one agents can still write to.
+- A deleted marker on the chat record, and `GetChats`, `UpdateChat`, and `GetMessages` resolving against it. Filtering deleted chats out client-side or by dropping them after the thread fetch would return short pages and break the cursor.
+- The menu item, its confirmation dialog, and the navigation back to the empty state.
+
+**Nothing in Threads changes.** `ArchiveThread` already exists, already means soft-delete, already refuses new messages on an archived thread, and already authorizes exactly the identities the product calls for — any participant, or an organization owner. No new RPC, no new relation, no new tuple. What is missing is a caller.
+
+**Deletion is shared, not personal.** Chats are org-scoped objects whose status and summary are the same for everyone on them; deletion follows. Per-user hiding would be a different feature — a per-participant list state Chat does not have and this change does not add.
+
+## Acceptance Signal
+
+- A user opens a conversation, picks **Delete conversation** from the actions menu, confirms, and lands on the empty conversation state with the conversation gone from the list.
+- Cancelling the dialog leaves the conversation and its messages untouched.
+- The conversation is gone from every other participant's list on their next refresh, in every status filter including All.
+- Navigating directly to a deleted conversation's URL resolves to the empty state rather than an error or an empty transcript.
+- Sending into a deleted conversation is refused, from the app and from an agent.
+- Deleting an already-deleted conversation succeeds and changes nothing, so a retried request never reports a failure for work that landed.
+- A member of the organization who is not a participant cannot delete the conversation; an organization owner can.
+- Deleting a conversation while its agent is working leaves the workload to idle out, and the reply the agent was writing never lands anywhere.
+- The Console still finds the thread through `ListOrganizationThreads` with `status_in = [archived]`, with its messages intact.
+
+## Notes
+
+- **Deletion hides the conversation, it does not revoke reading it.** Chat's `GetMessages` refuses a deleted chat so a stale link knows to give up, but the messages stay in Threads and a participant holding the ID can still page them through `ThreadsGateway` — which is the path the app itself uses for a transcript. Redacting a conversation is a different feature.
+- **No notification event.** Threads publishes nothing on archive, so a participant with the conversation open in another tab keeps rendering it until their next `GetChats` refresh. Sending from that stale view fails closed. A `thread.archived` event on `thread_participant:{id}` is the fix and is deliberately not specified here — the window is short and the failure is safe.
+- **No undo.** The rows survive (this is a soft delete), so a restore path is possible later; nothing in the app offers one, and the confirmation dialog says so.
+- **No bulk delete and no list-row action.** Deletion lives in the detail header only. Sweeping the list is a different interaction with a different confirmation story.
+- **`UpdateChat` and the chat record's status and summary were never in the architecture doc.** They are now, alongside the new rows, so the interface and authorization tables describe the whole service.

--- a/product/chat/chat.md
+++ b/product/chat/chat.md
@@ -17,6 +17,7 @@ Chat is the platform's communication interface. Users create conversations by se
 - As a user, I want messages to be marked as read automatically when I open a conversation so I do not have to manage read state by hand.
 - As a user, I want to see whether the agent is currently working on a conversation, waiting to start, or finished so I know whether to expect more output.
 - As a user, I want to mark a conversation as resolved or reopen it.
+- As a user, I want to delete a conversation I no longer need so it stops taking up room in my list.
 - As a user, I want to delete messages I no longer need.
 - As a user, I want to see reminders created by agents so I can track follow-ups.
 - As a user, I want to cancel reminders if they are no longer needed.
@@ -80,6 +81,18 @@ Infinite scroll loads older conversations.
 
 User-controlled lifecycle state — **Open** or **Resolved**. Toggled via dropdown in the detail header. Optimistic — the UI updates immediately and rolls back on failure.
 
+## Deleting a Conversation
+
+**Delete conversation** in the [conversation actions menu](#header) removes a conversation for everyone in it. It is not a personal hide — a conversation is shared, the same way its status and summary are.
+
+Deleting asks for confirmation first. The dialog names the conversation, states that it disappears for every participant and cannot be reopened from Chat, and offers Delete and Cancel. Delete is styled as the destructive action; Cancel leaves everything untouched.
+
+After deletion the conversation leaves the list, the detail panel clears, and the app returns to the empty conversation state. Other participants lose it from their list on their next refresh. A link to a deleted conversation resolves to the empty state.
+
+Any participant can delete a conversation, as can an organization owner. A conversation can be deleted in any status, including while an agent is working in it — the agent's in-flight reply is dropped.
+
+Deletion is not undoable from the app.
+
 ## Activity Status
 
 System-derived indicator that reflects whether agent participants are currently processing the conversation. Distinct from [Conversation Status](#conversation-status) (which is user-controlled). Shown only on conversations that have at least one non-passive agent participant; for user-only conversations, no indicator is shown.
@@ -104,6 +117,7 @@ Degraded conversations (see [Chat — Degraded Threads](../../architecture/chat.
 - Summary (editable — click to edit inline, save on blur or Enter, cancel on Escape).
 - Status toggle (Open / Resolved).
 - Reminder count — with popover listing agent-created reminders, each cancellable.
+- Conversation actions menu — edit the summary, copy a link to the conversation, copy its ID, open the agent's settings when an agent participates, and [delete the conversation](#deleting-a-conversation).
 
 ### Conversation Area
 


### PR DESCRIPTION
Resolved is a lifecycle state, not a disposal — nothing in Chat removes a conversation, so the list only grows.

Specifies **Delete conversation** in the conversation actions menu and `DeleteChat` on the Chat service: archive the thread, then mark the chat record deleted (that order, so a half-failure leaves a visible-but-frozen chat rather than a hidden one agents keep writing into). Deletion is shared, not a personal hide.

Nothing in Threads changes — `ArchiveThread` already means soft-delete and already authorizes any participant or an organization owner. It just had no caller.

Also documents `UpdateChat`, which was missing from both tables.